### PR TITLE
39/simplify sidebar results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 # testing
 /coverage
+.vscode
 
 # production
 /build

--- a/src/components/App/SideBar/Creator/ErrorSection/index.tsx
+++ b/src/components/App/SideBar/Creator/ErrorSection/index.tsx
@@ -1,0 +1,122 @@
+import * as sphinx from "sphinx-bridge-kevkevinpal";
+import styled from "styled-components";
+import { useState, useEffect } from "react";
+import { useSelectedNode } from "~/stores/useDataStore";
+import { api } from "~/network/api";
+import { colors } from "~/utils/colors";
+import { Flex } from "~/components/common/Flex";
+import { Pill } from "~/components/common/Pill";
+import { Text } from "~/components/common/Text";
+import { useAppStore } from "~/stores/useAppStore";
+
+const ErrorWrapper = styled(Flex)`
+  height: 30%;
+  padding: 10px;
+`;
+
+const ErrorMsgWrapper = styled.textarea`
+  resize: none;
+  margin-bottom: 5px;
+`;
+
+type UserErrResponse = {
+  error?: { message?: string };
+};
+
+export const ErrorSection = () => {
+  const selectedNode = useSelectedNode();
+  const [userErrorMsg, setUserErrorMsg] = useState("");
+  const [userNotification, setUserNotification] = useState("");
+  const setFlagErrorOpen = useAppStore((s) => s.setFlagErrorOpen);
+
+  const submitUserError = async () => {
+    const body = {
+      content_node_ref_id: selectedNode?.ref_id,
+      message: userErrorMsg,
+    };
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    const trySphinx = await sphinx.enable(true);
+
+    if (!trySphinx) {
+      console.log("Sphinx enable failed");
+    }
+
+    try {
+      const res: UserErrResponse = await api.post(
+        "/prediction/feedback",
+        JSON.stringify(body)
+      );
+
+      if (res.error) {
+        const { message } = res.error;
+
+        throw new Error(message);
+      }
+
+      setUserErrorMsg("");
+      setUserNotification("Sent successfully");
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        setUserNotification(err.message || "Failed to send");
+      }
+    }
+  };
+
+  useEffect(() => {
+    if (!userErrorMsg) {
+      setUserNotification("");
+    }
+  }, [userErrorMsg]);
+
+  return (
+    <ErrorWrapper>
+      <Flex align="center" justify="center" p={6}>
+        <Text color="white" kind="medium">
+          Report Error
+        </Text>
+      </Flex>
+      <ErrorMsgWrapper
+        cols={1}
+        onChange={(e) => {
+          const { value } = e.target;
+
+          setUserErrorMsg(value);
+        }}
+        placeholder="flag incorrect information (misspelled words, etc)"
+        rows={10}
+        value={userErrorMsg}
+      />
+      <Flex direction="row" justify="flex-end" p={8}>
+        {userNotification && (
+          <Flex
+            justify="center"
+            pb={3}
+            style={{
+              color:
+                userNotification === "Sent successfully"
+                  ? colors.green400
+                  : "#FF8F80",
+              marginRight: "20px",
+            }}
+          >
+            {userNotification}
+          </Flex>
+        )}
+
+        <Pill disabled={!userErrorMsg} onClick={submitUserError}>
+          Send
+        </Pill>
+        <Pill
+          onClick={() => {
+            setFlagErrorOpen(false);
+            setUserErrorMsg("");
+          }}
+        >
+          Cancel
+        </Pill>
+      </Flex>
+    </ErrorWrapper>
+  );
+};

--- a/src/components/App/SideBar/Creator/index.tsx
+++ b/src/components/App/SideBar/Creator/index.tsx
@@ -1,12 +1,7 @@
-import * as sphinx from "sphinx-bridge-kevkevinpal";
-import styled from "styled-components";
-import { api } from "~/network/api";
-import { colors } from "~/utils/colors";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo } from "react";
 import { Divider } from "~/components/common/Divider";
 import { Flex } from "~/components/common/Flex";
 import { Text } from "~/components/common/Text";
-import { Pill } from "~/components/common/Pill";
 import { useGraphData } from "~/components/DataRetriever";
 import { useDataStore, useSelectedNode } from "~/stores/useDataStore";
 import { getSelectedNodeTimestamps } from "~/utils/getSelectedNodeTimestamps";
@@ -14,20 +9,7 @@ import { useAppStore } from "~/stores/useAppStore";
 import { Relevance } from "../Relevance";
 import { Heading } from "./Heading";
 import { Timestamp } from "./Timestamp";
-
-const ErrorWrapper = styled(Flex)`
-  height: 30%;
-  padding: 10px;
-`;
-
-const ErrorMsgWrapper = styled.textarea`
-  resize: none;
-  margin-bottom: 5px;
-`;
-
-type UserErrResponse = {
-  error?: { message?: string };
-};
+import { ErrorSection } from "./ErrorSection";
 
 export const Creator = () => {
   const data = useGraphData();
@@ -39,55 +21,7 @@ export const Creator = () => {
   );
 
   const setSelectedTimestamp = useDataStore((s) => s.setSelectedTimestamp);
-
-  const [flagErrorIsOpen, setFlagErrorOpen] = useAppStore((s) => [
-    s.flagErrorIsOpen,
-    s.setFlagErrorOpen,
-  ]);
-
-  const [userErrorMsg, setUserErrorMsg] = useState("");
-  const [userNotification, setUserNotification] = useState("");
-
-  const submitUserError = async () => {
-    const body = {
-      content_node_ref_id: selectedNode?.ref_id,
-      message: userErrorMsg,
-    };
-
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    const trySphinx = await sphinx.enable(true);
-
-    if (!trySphinx) {
-      console.log("Sphinx enable failed");
-    }
-
-    try {
-      const res: UserErrResponse = await api.post(
-        "/prediction/feedback",
-        JSON.stringify(body)
-      );
-
-      if (res.error) {
-        const { message } = res.error;
-
-        throw new Error(message);
-      }
-
-      setUserErrorMsg("");
-      setUserNotification("Sent successfully");
-    } catch (err: unknown) {
-      if (err instanceof Error) {
-        setUserNotification(err.message || "Failed to send");
-      }
-    }
-  };
-
-  useEffect(() => {
-    if (!userErrorMsg) {
-      setUserNotification("");
-    }
-  }, [userErrorMsg]);
+  const flagErrorIsOpen = useAppStore((s) => s.flagErrorIsOpen);
 
   useEffect(() => {
     if (selectedNodeTimestamps?.length) {
@@ -103,55 +37,7 @@ export const Creator = () => {
     <>
       <Heading />
 
-      {flagErrorIsOpen && (
-        <ErrorWrapper>
-          <Flex align="center" justify="center" p={6}>
-            <Text color="white" kind="medium">
-              Report Error
-            </Text>
-          </Flex>
-          <ErrorMsgWrapper
-            cols={1}
-            onChange={(e) => {
-              const { value } = e.target;
-
-              setUserErrorMsg(value);
-            }}
-            placeholder="flag incorrect information (misspelled words, etc)"
-            rows={10}
-            value={userErrorMsg}
-          />
-          <Flex direction="row" justify="flex-end" p={8}>
-            {userNotification && (
-              <Flex
-                justify="center"
-                pb={3}
-                style={{
-                  color:
-                    userNotification === "Sent successfully"
-                      ? colors.green400
-                      : "#FF8F80",
-                  marginRight: "20px",
-                }}
-              >
-                {userNotification}
-              </Flex>
-            )}
-
-            <Pill disabled={!userErrorMsg} onClick={submitUserError}>
-              Send
-            </Pill>
-            <Pill
-              onClick={() => {
-                setFlagErrorOpen(false);
-                setUserErrorMsg("");
-              }}
-            >
-              Cancel
-            </Pill>
-          </Flex>
-        </ErrorWrapper>
-      )}
+      {flagErrorIsOpen && <ErrorSection />}
 
       {!!selectedNodeTimestamps?.length && (
         <>

--- a/src/components/App/SideBar/Relevance/index.tsx
+++ b/src/components/App/SideBar/Relevance/index.tsx
@@ -3,6 +3,8 @@ import { Flex } from "~/components/common/Flex";
 import { Pill } from "~/components/common/Pill";
 import { Text } from "~/components/common/Text";
 import { useGraphData } from "~/components/DataRetriever";
+import { useAppStore } from "~/stores/useAppStore";
+import { Heading } from "../Creator/Heading";
 import { ScrollView } from "~/components/ScrollView";
 import { useDataStore } from "~/stores/useDataStore";
 import { NodeExtended } from "~/types";
@@ -21,6 +23,12 @@ export const Relevance = ({ header = null }: Props) => {
   const scrollViewRef = useRef<HTMLDivElement | null>(null);
 
   const setSelectedNode = useDataStore((s) => s.setSelectedNode);
+  const setSelectedTimestamp = useDataStore((s) => s.setSelectedTimestamp);
+
+  const [relevanceIsSelected, setRelevanceSelected] = useAppStore((s) => [
+    s.relevanceIsSelected,
+    s.setRelevanceSelected,
+  ]);
 
   const [currentPage, setCurrentPage] = useState(0);
 
@@ -41,69 +49,73 @@ export const Relevance = ({ header = null }: Props) => {
   const handleNodeClick = useCallback(
     (node: NodeExtended) => {
       saveConsumedContent(node);
-
+      setSelectedTimestamp(node);
+      setRelevanceSelected(true);
       setSelectedNode(node);
     },
-    [setSelectedNode]
+    [setSelectedNode, setRelevanceSelected, setSelectedTimestamp]
   );
 
   return (
-    <ScrollView ref={scrollViewRef} shrink={1}>
-      {header}
+    <>
+      {relevanceIsSelected && <Heading />}
+      <ScrollView ref={scrollViewRef} shrink={1}>
+        {header}
 
-      <Flex pb={10} px={20}>
-        <Text color="textSecondary">
-          Page {currentPage + 1} of {Math.ceil(data.nodes.length / pageSize)}
-        </Text>
-      </Flex>
+        <Flex pb={10} px={20}>
+          <Text color="textSecondary">
+            Page {currentPage + 1} of {Math.ceil(data.nodes.length / pageSize)}
+          </Text>
+        </Flex>
 
-      {currentNodes.map((n, index) => {
-        const {
-          image_url: imageUrl,
-          episode_title: episodeTitle,
-          description,
-          date,
-          boost,
-        } = n || {};
+        {currentNodes.map((n, index) => {
+          const {
+            image_url: imageUrl,
+            episode_title: episodeTitle,
+            description,
+            date,
+            boost,
+          } = n || {};
 
-        return (
-          <Episode
-            // eslint-disable-next-line react/no-array-index-key
-            key={index.toString()}
-            boostCount={boost || 0}
-            date={date || 0}
-            description={description || ""}
-            imageUrl={imageUrl || "audio_default.svg"}
-            onClick={() => handleNodeClick(n)}
-            title={episodeTitle || ""}
-          />
-        );
-      })}
+          return (
+            <Episode
+              // eslint-disable-next-line react/no-array-index-key
+              key={index.toString()}
+              boostCount={boost || 0}
+              date={date || 0}
+              description={description || ""}
+              imageUrl={imageUrl || "audio_default.svg"}
+              onClick={() => handleNodeClick(n)}
+              title={episodeTitle || ""}
+            />
+          );
+        })}
 
-      <Flex direction="row" justify="space-between" p={20}>
-        <Pill
-          disabled={!hasPrevious}
-          onClick={() => {
-            if (hasPrevious) {
-              setCurrentPage(currentPage - 1);
-              scrollViewRef.current?.scrollTo(0, 0);
-            }
-          }}
-        >
-          Previous
-        </Pill>
-        <Pill
-          disabled={!hasNext}
-          onClick={() => {
-            if (hasNext) {
-              setCurrentPage(currentPage + 1);
-              scrollViewRef.current?.scrollTo(0, 0);
-            }
-          }}
-        >
-          Next
-        </Pill>
-      </Flex>
-    </ScrollView>
+        <Flex direction="row" justify="space-between" p={20}>
+          <Pill
+            disabled={!hasPrevious}
+            onClick={() => {
+              if (hasPrevious) {
+                setCurrentPage(currentPage - 1);
+                scrollViewRef.current?.scrollTo(0, 0);
+              }
+            }}
+          >
+            Previous
+          </Pill>
+          <Pill
+            disabled={!hasNext}
+            onClick={() => {
+              if (hasNext) {
+                setCurrentPage(currentPage + 1);
+                scrollViewRef.current?.scrollTo(0, 0);
+              }
+            }}
+          >
+            Next
+          </Pill>
+        </Flex>
+      </ScrollView>
+    </>
   );
 };

--- a/src/components/App/SideBar/Relevance/index.tsx
+++ b/src/components/App/SideBar/Relevance/index.tsx
@@ -10,6 +10,7 @@ import { useDataStore } from "~/stores/useDataStore";
 import { NodeExtended } from "~/types";
 import { saveConsumedContent } from "~/utils/relayHelper";
 import { Episode } from "./Episode";
+import { ErrorSection } from "../Creator/ErrorSection";
 
 const pageSize = 80;
 
@@ -24,7 +25,8 @@ export const Relevance = ({ header = null }: Props) => {
 
   const setSelectedNode = useDataStore((s) => s.setSelectedNode);
   const setSelectedTimestamp = useDataStore((s) => s.setSelectedTimestamp);
-
+  const flagErrorIsOpen = useAppStore((s) => s.flagErrorIsOpen);
+  
   const [relevanceIsSelected, setRelevanceSelected] = useAppStore((s) => [
     s.relevanceIsSelected,
     s.setRelevanceSelected,
@@ -59,6 +61,8 @@ export const Relevance = ({ header = null }: Props) => {
   return (
     <>
       {relevanceIsSelected && <Heading />}
+      {flagErrorIsOpen && <ErrorSection />}
+
       <ScrollView ref={scrollViewRef} shrink={1}>
         {header}
 

--- a/src/components/App/SideBar/View/index.tsx
+++ b/src/components/App/SideBar/View/index.tsx
@@ -12,11 +12,10 @@ export const View = () => {
   const selectedNode = useDataStore((s) => s.selectedNode);
   const relevanceIsSelected = useAppStore((s) => s.relevanceIsSelected);
 
-  if (!selectedNode && data?.nodes?.length) {
-    return <Relevance />;
-  }
+  const isBaseSearchView = !selectedNode && data?.nodes?.length;
+  const isRelevanceView = relevanceIsSelected;
 
-  if (relevanceIsSelected) {
+  if (isBaseSearchView || isRelevanceView) {
     return <Relevance />;
   }
 

--- a/src/components/App/SideBar/View/index.tsx
+++ b/src/components/App/SideBar/View/index.tsx
@@ -1,4 +1,5 @@
 import { useGraphData } from "~/components/DataRetriever";
+import { useAppStore } from "~/stores/useAppStore";
 import { useDataStore } from "~/stores/useDataStore";
 import { Creator } from "../Creator";
 import { Person } from "../Person";
@@ -9,8 +10,13 @@ import { YouTube } from "../YouTube";
 export const View = () => {
   const data = useGraphData();
   const selectedNode = useDataStore((s) => s.selectedNode);
+  const relevanceIsSelected = useAppStore((s) => s.relevanceIsSelected);
 
   if (!selectedNode && data?.nodes?.length) {
+    return <Relevance />;
+  }
+
+  if (relevanceIsSelected) {
     return <Relevance />;
   }
 

--- a/src/components/App/SideBar/index.tsx
+++ b/src/components/App/SideBar/index.tsx
@@ -36,6 +36,7 @@ const CloseButton = styled(Flex).attrs({
 const Content = () => {
   const clearSearch = useAppStore((s) => s.clearSearch);
   const setFlagErrorOpen = useAppStore((s) => s.setFlagErrorOpen);
+  const setRelevanceSelected = useAppStore((s) => s.setRelevanceSelected);
   const setSelectedNode = useDataStore((s) => s.setSelectedNode);
   const isLoading = useDataStore((s) => s.isFetching);
 
@@ -49,6 +50,7 @@ const Content = () => {
             setFlagErrorOpen(false);
             setSelectedNode(null);
             clearSearch();
+            setRelevanceSelected(false);
           }}
         >
           <span className="material-icons" style={{ fontSize: 20 }}>

--- a/src/components/SearchBar/index.tsx
+++ b/src/components/SearchBar/index.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import styled, { css } from "styled-components";
 import { useAppStore } from "~/stores/useAppStore";
+import { useDataStore } from "~/stores/useDataStore";
 import { colors } from "~/utils/colors";
 
 type Props = {
@@ -48,6 +49,8 @@ export const SearchBar = ({ loading }: Props) => {
     s.setCurrentSearch,
   ]);
 
+  const setSelectedNode = useDataStore((s) => s.setSelectedNode);
+
   const [tempSearch, setTempSearch] = useState(() => search);
 
   return (
@@ -61,6 +64,7 @@ export const SearchBar = ({ loading }: Props) => {
       }}
       onKeyPress={(event) => {
         if (event.key === "Enter" && !!tempSearch) {
+          setSelectedNode(null);
           setSearch(tempSearch);
         }
       }}

--- a/src/components/SearchBar/index.tsx
+++ b/src/components/SearchBar/index.tsx
@@ -44,9 +44,10 @@ const Input = styled.input<{ loading?: boolean }>`
 `;
 
 export const SearchBar = ({ loading }: Props) => {
-  const [search, setSearch] = useAppStore((s) => [
+  const [search, setSearch, setRelevanceSelected] = useAppStore((s) => [
     s.currentSearch,
     s.setCurrentSearch,
+    s.setRelevanceSelected,
   ]);
 
   const setSelectedNode = useDataStore((s) => s.setSelectedNode);
@@ -65,6 +66,7 @@ export const SearchBar = ({ loading }: Props) => {
       onKeyPress={(event) => {
         if (event.key === "Enter" && !!tempSearch) {
           setSelectedNode(null);
+          setRelevanceSelected(false);
           setSearch(tempSearch);
         }
       }}

--- a/src/components/Universe/Graph/index.tsx
+++ b/src/components/Universe/Graph/index.tsx
@@ -5,6 +5,7 @@ import { Vector3 } from "three";
 import ThreeForceGraph from "three-forcegraph";
 import { useGraphData } from "~/components/DataRetriever";
 import { useDataStore } from "~/stores/useDataStore";
+import { useAppStore } from "~/stores/useAppStore";
 import { NodeExtended } from "~/types";
 import { renderLink } from "./renderLink";
 import { renderNode } from "./renderNode";
@@ -15,11 +16,15 @@ export const Graph = () => {
 
   const data = useGraphData();
 
-  const [selectedNode, setSelectedNode, setHoveredNode] = useDataStore((s) => [
-    s.selectedNode,
-    s.setSelectedNode,
-    s.setHoveredNode,
-  ]);
+  const [selectedNode, setSelectedNode, setHoveredNode, setSelectedTimestamp] =
+    useDataStore((s) => [
+      s.selectedNode,
+      s.setSelectedNode,
+      s.setHoveredNode,
+      s.setSelectedTimestamp,
+    ]);
+
+  const relevanceIsSelected = useAppStore((s) => s.relevanceIsSelected);
 
   const graph = useMemo(
     () =>
@@ -76,8 +81,14 @@ export const Graph = () => {
   }, []);
 
   const onClick = useCallback(
-    (node: NodeExtended | null) => setSelectedNode(node),
-    [setSelectedNode]
+    (node: NodeExtended | null) => {
+      setSelectedNode(node);
+
+      if (relevanceIsSelected) {
+        setSelectedTimestamp(node);
+      }
+    },
+    [setSelectedNode, setSelectedTimestamp, relevanceIsSelected]
   );
 
   const onHover = useCallback(

--- a/src/stores/useAppStore/index.ts
+++ b/src/stores/useAppStore/index.ts
@@ -5,8 +5,10 @@ type AppStore = {
   sidebarIsOpen: boolean;
   transcriptIsOpen: boolean;
   flagErrorIsOpen: boolean;
+  relevanceIsSelected: boolean;
   clearSearch: () => void;
   setCurrentSearch: (_: string) => void;
+  setRelevanceSelected: (_: boolean) => void;
   setSidebarOpen: (_: boolean) => void;
   setTranscriptOpen: (_: boolean) => void;
   setFlagErrorOpen: (_: boolean) => void;
@@ -15,6 +17,7 @@ type AppStore = {
 const defaultData = {
   currentSearch: null,
   flagErrorIsOpen: false,
+  relevanceIsSelected: false,
   sidebarIsOpen: false,
   transcriptIsOpen: false,
 };
@@ -24,6 +27,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
   clearSearch: () => set({ currentSearch: null }),
   setCurrentSearch: (currentSearch) => set({ currentSearch }),
   setFlagErrorOpen: (flagErrorIsOpen) => set({ flagErrorIsOpen }),
+  setRelevanceSelected: (relevanceIsSelected) => set({ relevanceIsSelected }),
   setSidebarOpen: (sidebarIsOpen) =>
     set({
       sidebarIsOpen,


### PR DESCRIPTION
### New Flow
- clicking on a search result should now load that specific timestamp but maintain the results underneath the heading
- accomplished by persisting within the `Relevance / Search` view
- When in the Relevance view, universe node clicks will load their respective timestamps as well.
- When in regular view / no-search, selecting a node from the universe will give the normal sidebar view with all timestamps for that ep

### Old Flow
- clicking on a search result would fully expand it, getting all timestamps and setting the first one, losing the search results and disregarding the chosen clip