### PR TITLE
Feat/form help messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react-audio-player": "^0.17.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.39.5",
+    "react-icons": "^4.7.1",
     "react-is": "^18.2.0",
     "react-scripts": "4.0.3",
     "react-spinners": "^0.13.3",

--- a/src/components/AddNodeModal/TagInput/index.tsx
+++ b/src/components/AddNodeModal/TagInput/index.tsx
@@ -23,6 +23,7 @@ const Wrapper = styled(Flex).attrs({
 
 type Props = Omit<BaseTextInputProps, "name"> & {
   label: string;
+  message?: string;
   rules?: RegisterOptions;
 };
 
@@ -30,7 +31,7 @@ type Fields = { tags: string[] | undefined };
 
 const name = "tags";
 
-export const TagInput = ({ label, rules, ...props }: Props) => {
+export const TagInput = ({ label, message, rules, ...props }: Props) => {
   const {
     setValue,
     getValues,
@@ -94,10 +95,14 @@ export const TagInput = ({ label, rules, ...props }: Props) => {
 
   return (
     <Flex shrink={1}>
-      <Flex pb={4} pl={4}>
+      <Flex align="center" direction="row" pb={4} pl={4}>
         <Text color="lightGray" kind="regularBold">
           {label}
         </Text>
+        <QuestionIcon>
+          <span className="material-icons">question_mark</span>
+          <div className="tooltip">{message}</div>
+        </QuestionIcon>
       </Flex>
       <Flex direction="row">
         <Wrapper>
@@ -187,9 +192,37 @@ const AddTagButton = styled(Flex).attrs({
   borderSize: 1,
   direction: "row",
   px: 8,
-  py: 12,
+  py: 8,
 })`
   border-color: ${colors.gray500};
   cursor: pointer;
   color: ${colors.lightGray};
+`;
+
+const QuestionIcon = styled(Flex).attrs({})`
+  cursor: default;
+  margin-left: 4px;
+  position: relative;
+
+  span {
+    color: ${colors.secondaryText4};
+    font-size: 12px;
+  }
+
+  .tooltip {
+    position: absolute;
+    background-color: ${colors.dashboardHeader};
+    border: 1px solid ${colors.secondaryText4};
+    border-radius: 4px;
+    color: ${colors.white};
+    top: 22px;
+    padding: 4px 8px;
+    font-size: 13px;
+    visibility: hidden;
+    width: 250px;
+  }
+
+  &:hover .tooltip {
+    visibility: visible;
+  }
 `;

--- a/src/components/AddNodeModal/TagInput/index.tsx
+++ b/src/components/AddNodeModal/TagInput/index.tsx
@@ -6,6 +6,7 @@ import {
   Controller,
 } from "react-hook-form";
 import styled from "styled-components";
+import { FaRegQuestionCircle } from "react-icons/fa";
 import { BaseTextInput, BaseTextInputProps } from "~/components/BaseTextInput";
 import { Flex } from "~/components/common/Flex";
 import { Text } from "~/components/common/Text";
@@ -100,7 +101,7 @@ export const TagInput = ({ label, message, rules, ...props }: Props) => {
           {label}
         </Text>
         <QuestionIcon>
-          <span className="material-icons">question_mark</span>
+          <FaRegQuestionCircle color={colors.secondaryText4} />
           <div className="tooltip">{message}</div>
         </QuestionIcon>
       </Flex>
@@ -199,15 +200,10 @@ const AddTagButton = styled(Flex).attrs({
   color: ${colors.lightGray};
 `;
 
-const QuestionIcon = styled(Flex).attrs({})`
+const QuestionIcon = styled(Flex)`
   cursor: default;
-  margin-left: 4px;
+  margin-left: 6px;
   position: relative;
-
-  span {
-    color: ${colors.secondaryText4};
-    font-size: 12px;
-  }
 
   .tooltip {
     position: absolute;

--- a/src/components/AddNodeModal/TextArea/index.tsx
+++ b/src/components/AddNodeModal/TextArea/index.tsx
@@ -5,6 +5,7 @@ import {
   useFormContext,
 } from "react-hook-form";
 import styled from "styled-components";
+import { FaRegQuestionCircle } from "react-icons/fa";
 import { BaseTextArea, BaseTextAreaProps } from "~/components/BaseTextArea";
 import { colors } from "~/utils/colors";
 import { Flex } from "~/components/common/Flex";
@@ -39,7 +40,7 @@ export const TextArea = ({ label, message, name, rules, ...props }: Props) => {
           {label}
         </Text>
         <QuestionIcon>
-          <span className="material-icons">question_mark</span>
+          <FaRegQuestionCircle color={colors.secondaryText4} />
           <div className="tooltip">{message}</div>
         </QuestionIcon>
       </Flex>
@@ -85,15 +86,10 @@ export const TextArea = ({ label, message, name, rules, ...props }: Props) => {
   );
 };
 
-const QuestionIcon = styled(Flex).attrs({})`
+const QuestionIcon = styled(Flex)`
   cursor: default;
-  margin-left: 4px;
+  margin-left: 6px;
   position: relative;
-
-  span {
-    color: ${colors.secondaryText4};
-    font-size: 12px;
-  }
 
   .tooltip {
     position: absolute;

--- a/src/components/AddNodeModal/TextArea/index.tsx
+++ b/src/components/AddNodeModal/TextArea/index.tsx
@@ -6,6 +6,7 @@ import {
 } from "react-hook-form";
 import styled from "styled-components";
 import { BaseTextArea, BaseTextAreaProps } from "~/components/BaseTextArea";
+import { colors } from "~/utils/colors";
 import { Flex } from "~/components/common/Flex";
 import { Text } from "~/components/common/Text";
 
@@ -19,10 +20,11 @@ const Wrapper = styled(Flex).attrs({
 
 type Props = BaseTextAreaProps & {
   label: string;
+  message?: string;
   rules?: RegisterOptions;
 };
 
-export const TextArea = ({ label, name, rules, ...props }: Props) => {
+export const TextArea = ({ label, message, name, rules, ...props }: Props) => {
   const {
     control,
     formState: { errors },
@@ -32,10 +34,14 @@ export const TextArea = ({ label, name, rules, ...props }: Props) => {
 
   return (
     <>
-      <Flex pb={4} pl={4}>
+      <Flex align="center" direction="row" pb={4} pl={4}>
         <Text color="lightGray" kind="regularBold">
           {label}
         </Text>
+        <QuestionIcon>
+          <span className="material-icons">question_mark</span>
+          <div className="tooltip">{message}</div>
+        </QuestionIcon>
       </Flex>
 
       <Wrapper>
@@ -78,3 +84,31 @@ export const TextArea = ({ label, name, rules, ...props }: Props) => {
     </>
   );
 };
+
+const QuestionIcon = styled(Flex).attrs({})`
+  cursor: default;
+  margin-left: 4px;
+  position: relative;
+
+  span {
+    color: ${colors.secondaryText4};
+    font-size: 12px;
+  }
+
+  .tooltip {
+    position: absolute;
+    background-color: ${colors.dashboardHeader};
+    border: 1px solid ${colors.secondaryText4};
+    border-radius: 4px;
+    color: ${colors.white};
+    top: 22px;
+    padding: 4px 8px;
+    font-size: 13px;
+    visibility: hidden;
+    width: 175px;
+  }
+
+  &:hover .tooltip {
+    visibility: visible;
+  }
+`;

--- a/src/components/AddNodeModal/TextInput/index.tsx
+++ b/src/components/AddNodeModal/TextInput/index.tsx
@@ -5,6 +5,7 @@ import {
   useFormContext,
 } from "react-hook-form";
 import styled from "styled-components";
+import { FaRegQuestionCircle } from "react-icons/fa";
 import { BaseTextInput, BaseTextInputProps } from "~/components/BaseTextInput";
 import { colors } from "~/utils/colors";
 import { Flex } from "~/components/common/Flex";
@@ -17,6 +18,10 @@ const Wrapper = styled(Flex).attrs({
 })`
   border-radius: 8px;
 `;
+
+type QuestionIconProps = {
+  name: string;
+};
 
 type Props = BaseTextInputProps & {
   label: string;
@@ -38,8 +43,8 @@ export const TextInput = ({ label, message, name, rules, ...props }: Props) => {
         <Text color="lightGray" kind="regularBold">
           {label}
         </Text>
-        <QuestionIcon>
-          <span className="material-icons">question_mark</span>
+        <QuestionIcon name={name}>
+          <FaRegQuestionCircle color={colors.secondaryText4} />
           <div className="tooltip">{message}</div>
         </QuestionIcon>
       </Flex>
@@ -84,15 +89,10 @@ export const TextInput = ({ label, message, name, rules, ...props }: Props) => {
   );
 };
 
-const QuestionIcon = styled(Flex).attrs({})`
+const QuestionIcon = styled(Flex)<QuestionIconProps>`
   cursor: default;
-  margin-left: 4px;
+  margin-left: 6px;
   position: relative;
-
-  span {
-    color: ${colors.secondaryText4};
-    font-size: 12px;
-  }
 
   .tooltip {
     position: absolute;
@@ -107,6 +107,14 @@ const QuestionIcon = styled(Flex).attrs({})`
     width: 175px;
     z-index: 1;
   }
+
+  ${(props) =>
+    props.name === "endTime" &&
+    `
+    .tooltip {
+      left: -68px;
+    }
+  `}
 
   &:hover .tooltip {
     visibility: visible;

--- a/src/components/AddNodeModal/TextInput/index.tsx
+++ b/src/components/AddNodeModal/TextInput/index.tsx
@@ -6,6 +6,7 @@ import {
 } from "react-hook-form";
 import styled from "styled-components";
 import { BaseTextInput, BaseTextInputProps } from "~/components/BaseTextInput";
+import { colors } from "~/utils/colors";
 import { Flex } from "~/components/common/Flex";
 import { Text } from "~/components/common/Text";
 
@@ -19,10 +20,11 @@ const Wrapper = styled(Flex).attrs({
 
 type Props = BaseTextInputProps & {
   label: string;
+  message?: string;
   rules?: RegisterOptions;
 };
 
-export const TextInput = ({ label, name, rules, ...props }: Props) => {
+export const TextInput = ({ label, message, name, rules, ...props }: Props) => {
   const {
     control,
     formState: { errors },
@@ -32,10 +34,14 @@ export const TextInput = ({ label, name, rules, ...props }: Props) => {
 
   return (
     <Flex shrink={1}>
-      <Flex pb={4} pl={4}>
+      <Flex align="center" direction="row" pb={4} pl={4}>
         <Text color="lightGray" kind="regularBold">
           {label}
         </Text>
+        <QuestionIcon>
+          <span className="material-icons">question_mark</span>
+          <div className="tooltip">{message}</div>
+        </QuestionIcon>
       </Flex>
       <Wrapper>
         <Controller
@@ -77,3 +83,32 @@ export const TextInput = ({ label, name, rules, ...props }: Props) => {
     </Flex>
   );
 };
+
+const QuestionIcon = styled(Flex).attrs({})`
+  cursor: default;
+  margin-left: 4px;
+  position: relative;
+
+  span {
+    color: ${colors.secondaryText4};
+    font-size: 12px;
+  }
+
+  .tooltip {
+    position: absolute;
+    background-color: ${colors.dashboardHeader};
+    border: 1px solid ${colors.secondaryText4};
+    border-radius: 4px;
+    color: ${colors.white};
+    top: 22px;
+    padding: 4px 8px;
+    font-size: 13px;
+    visibility: hidden;
+    width: 175px;
+    z-index: 1;
+  }
+
+  &:hover .tooltip {
+    visibility: visible;
+  }
+`;

--- a/src/components/AddNodeModal/index.tsx
+++ b/src/components/AddNodeModal/index.tsx
@@ -34,6 +34,9 @@ const tagRule = {
 
 const timeRegex = /^\d{2}:\d{2}:\d{2}$/;
 
+const mainInfoMessage =
+  'Come across an interesting or useful part of a video or audio you\'d like to share? You can add it to the knowledge graph here!\n\nEnter a valid link to the YouTube video or Twitter Space you were watching, choose a start and end timestamp to encompass the segment you found interesting or useful, provide a brief description of what the segment is about, and add topic tags that are relevant to the segment. Hit "Add node", and your clip will be added to the graph shortly.\n\nYour pubkey will be submitted with your clip, and any boosts your clip receives will go to you!';
+
 type SubmitErrRes = {
   error?: { message?: string };
 };
@@ -121,7 +124,13 @@ export const AddNodeModal = () => {
       <FormProvider {...form}>
         <form onSubmit={onSubmit}>
           <Flex align="center" direction="row" justify="space-between" pb={32}>
-            <Text kind="bigHeadingBold">Add Node</Text>
+            <Flex align="center" direction="row">
+              <Text kind="bigHeadingBold">Add Node</Text>
+              <InfoIcon>
+                <span className="material-icons-outlined">info</span>
+                <div className="tooltip">{mainInfoMessage}</div>
+              </InfoIcon>
+            </Flex>
 
             <CloseButton onClick={close}>
               <span className="material-icons">close</span>
@@ -131,6 +140,7 @@ export const AddNodeModal = () => {
           <Flex>
             <TextInput
               label="Link"
+              message="Paste a valid YouTube or Twitter Space link here."
               name="link"
               placeholder="Paste your link here..."
               rules={requiredRule}
@@ -141,11 +151,12 @@ export const AddNodeModal = () => {
             <Flex basis="50%" pr={16}>
               <TextInput
                 label="Start Time"
+                message="Enter start and end timestamps which will encompass the segment of video or audio you want to submit."
                 name="startTime"
                 placeholder="00:00:00"
                 rules={{
                   pattern: {
-                    message: "The start time should be a time string",
+                    message: "Timestamp must be in the format hh:mm:ss",
                     value: timeRegex,
                   },
                   ...requiredRule,
@@ -156,11 +167,12 @@ export const AddNodeModal = () => {
             <Flex basis="50%" pl={16}>
               <TextInput
                 label="End Time"
+                message="Enter start and end timestamps which will encompass the segment of video or audio you want to submit."
                 name="endTime"
                 placeholder="00:00:00"
                 rules={{
                   pattern: {
-                    message: "The end time should be a time string",
+                    message: "Timestamp must be in the format hh:mm:ss",
                     value: timeRegex,
                   },
                   validate: {
@@ -177,13 +189,18 @@ export const AddNodeModal = () => {
           <Flex pt={12}>
             <TextArea
               label="Clip Description"
+              message="Enter a short description of your audio/video segment. Think of this as the title of your node."
               name="description"
               rules={requiredRule}
             />
           </Flex>
 
           <Flex pt={12}>
-            <TagInput label="Tags" rules={tagRule} />
+            <TagInput
+              label="Tags"
+              message="Enter some topic tags that capture the main ideas of your segment. Be specific! Generic tags aren't useful for anyone. Think, 'What term(s) would someone search to find my node?"
+              rules={tagRule}
+            />
           </Flex>
 
           <Flex pt={16} px={4}>
@@ -216,6 +233,37 @@ const CloseButton = styled(Flex)`
   span {
     font-size: 24px;
     color: ${colors.white};
+  }
+`;
+
+const InfoIcon = styled(Flex)`
+  cursor: default;
+  padding: 8px;
+  position: relative;
+
+  span {
+    font-size: 22px;
+    color: ${colors.secondaryText4};
+  }
+
+  .tooltip {
+    position: absolute;
+    background-color: ${colors.dashboardHeader};
+    border: 1px solid ${colors.secondaryText4};
+    border-radius: 4px;
+    color: ${colors.white};
+    top: 40px;
+    left: -142px;
+    padding: 4px 8px;
+    font-size: 13px;
+    visibility: hidden;
+    width: 470px;
+    white-space: pre-wrap;
+    z-index: 1;
+  }
+
+  span:hover + .tooltip {
+    visibility: visible;
   }
 `;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2005,12 +2005,12 @@
     suspend-react "^0.0.8"
     zustand "^3.7.1"
 
-"@react-three/postprocessing@^2.6.2":
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/@react-three/postprocessing/-/postprocessing-2.6.2.tgz#fe1484a51ccc0577f67280307a0fc3a9ecb0e070"
-  integrity sha512-YvU3oH5Vb2UT+ekhhzHwMTvEYo50VoW8EYMQxmh9TzWaTohSB0GGDanJw5peUMDUgYS1gNjj9cpsk0w/z/7Qpg==
+"@react-three/postprocessing@^2.7.0":
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/@react-three/postprocessing/-/postprocessing-2.7.0.tgz#bae6be248bdb43cbab3d125b23ba5b0de4d934d2"
+  integrity sha512-lJfV8GYp+L1SlGRcl8QPUg9QMdO+8ojW2kfaEc/MuvoI4rX3TRhVd3qFjjF++0bBmzt8LeQpDHCOHFAaT3MNYA==
   dependencies:
-    postprocessing "^6.28.5"
+    postprocessing "^6.29.0"
     react-merge-refs "^1.1.0"
     screen-space-reflections "2.5.0"
     three-stdlib "^2.8.11"
@@ -2696,6 +2696,14 @@
     "@types/prop-types" "*"
     "@types/scheduler" "*"
     csstype "^3.0.2"
+
+"@types/readable-stream@^2.3.14":
+  version "2.3.15"
+  resolved "https://registry.yarnpkg.com/@types/readable-stream/-/readable-stream-2.3.15.tgz#3d79c9ceb1b6a57d5f6e6976f489b9b5384321ae"
+  integrity sha512-oM5JSKQCcICF1wvGgmecmHldZ48OZamtMxcGGVICOJA8o8cahXC1zEVAif8iwoc5j8etxFaRFnf095+CDsuoFQ==
+  dependencies:
+    "@types/node" "*"
+    safe-buffer "~5.1.1"
 
 "@types/resolve@0.0.8":
   version "0.0.8"
@@ -10676,10 +10684,10 @@ postcss@^8.1.0:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
-postprocessing@^6.28.5:
-  version "6.28.7"
-  resolved "https://registry.yarnpkg.com/postprocessing/-/postprocessing-6.28.7.tgz#ab1104585c3372e576ccf1910a4ea577be379266"
-  integrity sha512-norsBlNIhDoNG2R0nki9C0bNEARIunE/s5W/4qH/Ozlg3m0dOOmBoY8JZhnmPild/+Jvq/UFEeHQRBvTc11WUg==
+postprocessing@^6.29.0:
+  version "6.29.1"
+  resolved "https://registry.yarnpkg.com/postprocessing/-/postprocessing-6.29.1.tgz#169b48cca498a52d3ee4b8960645b089cc7f64b3"
+  integrity sha512-w+XoL2Z7YpVDsHbIeg6sldMMmDqZS4Hul1FDq3TjOeXZ0Wnp0Qy1EvR7QmYJxyWBux1cKQx/k3XO7LxfvPsZyg==
 
 potpack@^1.0.1:
   version "1.0.2"
@@ -11043,6 +11051,11 @@ react-hook-form@^7.39.5:
   version "7.39.5"
   resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.39.5.tgz#a4272b60288ef5e1bb42bbb6ba3b36d243ab2879"
   integrity sha512-OE0HKyz5IPc6svN2wd+e+evidZrw4O4WZWAWYzQVZuHi+hYnHFSLnxOq0ddjbdmaLIsLHut/ab7j72y2QT3+KA==
+
+react-icons@^4.7.1:
+  version "4.7.1"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.7.1.tgz#0f4b25a5694e6972677cb189d2a72eabea7a8345"
+  integrity sha512-yHd3oKGMgm7zxo3EA7H2n7vxSoiGmHk5t6Ou4bXsfcgWyhfDKMpyKfhHR6Bjnn63c+YXBLBPUql9H4wPJM6sXw==
 
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
@@ -12071,11 +12084,12 @@ spdy@^4.0.2:
     select-hose "^2.0.0"
     spdy-transport "^3.0.0"
 
-sphinx-bridge-kevkevinpal@^0.2.51:
-  version "0.2.54"
-  resolved "https://registry.yarnpkg.com/sphinx-bridge-kevkevinpal/-/sphinx-bridge-kevkevinpal-0.2.54.tgz#21937867c5edcc343c199beaf76b1d4117070a9d"
-  integrity sha512-qoHYeSzwse8L8slno7tuCLSqyx6QKSgygWKi0f98Um0hjYMibUMFXMSe6BDI6t8iEd9Lh5O/vJW3HzuailVmCw==
+sphinx-bridge-kevkevinpal@0.2.48:
+  version "0.2.48"
+  resolved "https://registry.yarnpkg.com/sphinx-bridge-kevkevinpal/-/sphinx-bridge-kevkevinpal-0.2.48.tgz#52ba15098151fde2b9ae429fb1bb302b8a96af44"
+  integrity sha512-4RzL8259rx/RVsmAMQBfRwt6lQWxdWA9H9DKuen4guEhUKR4RUPB1zGqBIxpfHRHm5YJmjbomTZExo9lQcvfTw==
   dependencies:
+    "@types/readable-stream" "^2.3.14"
     invoices "^2.1.0"
 
 split-string@^3.0.1, split-string@^3.0.2:


### PR DESCRIPTION
 - references #116 
 - adds help tooltips to labels
 - change to timestamp error message. `hh:mm:ss`
 
![Screenshot 2022-12-14 173454](https://user-images.githubusercontent.com/61718801/207731390-2516a01c-8237-4db5-8814-f86d53d2efcd.png)
