### PR TITLE
docker: moved the yarn install before the copy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,11 @@ FROM node:16 as build
 # Create app directory
 WORKDIR /usr/src/app
 
+COPY package*.json ./
+RUN yarn install
+
 COPY . .
 
-RUN yarn install
 RUN yarn run build
 
 FROM nginx:alpine


### PR DESCRIPTION
We do this because otherwise we copy the .git file which is for the submodule and it doesnt install the nodemodules in the correct spot then fails on the docker build from SecondBrainSwarm