### PR TITLE
fix: docker build was failing this fixes the error

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -1,14 +1,24 @@
-const CracoAlias = require("craco-alias");
+const CracoAlias = require('craco-alias')
 
 module.exports = {
+  webpack: {
+    configure: (webpackConfig) => {
+      webpackConfig.module.rules.push({
+        test: /\.mjs$/,
+        include: /node_modules/,
+        type: 'javascript/auto',
+      })
+      return webpackConfig
+    },
+  },
   plugins: [
     {
       plugin: CracoAlias,
       options: {
         // see in examples section
-        source: "tsconfig",
-        tsConfigPath: "./tsconfig.paths.json",
+        source: 'tsconfig',
+        tsConfigPath: './tsconfig.paths.json',
       },
     },
   ],
-};
+}


### PR DESCRIPTION
I was getting this error when running docker build
```
#15 174.4 ./node_modules/react-hook-form/dist/index.esm.mjs
#15 174.4 Can't import the named export 'Fragment' from non EcmaScript module (only default export is available)
```
and these changes helped fix it, but I'm not too certain what they do tbh