### PR TITLE
fix: camera animation safeguards

### DIFF
--- a/src/components/Universe/Controls/CameraAnimations/useAutoNavigate.ts
+++ b/src/components/Universe/Controls/CameraAnimations/useAutoNavigate.ts
@@ -10,6 +10,9 @@ import { getNearbyNodeIds } from '../constants'
 import { arriveDistance, selectionGraphCameraPosition, selectionGraphDistance, topicArriveDistance } from './constants'
 
 let lookAtAnimationTimer: ReturnType<typeof setTimeout>
+let departAnimationTimer: ReturnType<typeof setTimeout>
+const departAnimationTimerLength = 4000
+const lookAtAnimationTimerLength = 2000
 
 export const useAutoNavigate = (cameraControlsRef: RefObject<CameraControls | null>) => {
   const selectedNode = useSelectedNode()
@@ -68,36 +71,44 @@ export const useAutoNavigate = (cameraControlsRef: RefObject<CameraControls | nu
     }
   }, [selectedNode, setMinDistance, showSelectionGraph])
 
-  const arrive = () => {
-    setDistanceReached(true)
-  }
-
-  const depart = () => {
-    if (selectedNode) {
-      const distance = camera.position.distanceTo(destination)
-
-      playInspectSound(distance)
-    }
-
-    setUserMovedCamera(false)
-    setDistanceReached(false)
-    setLookAtReached(false)
-  }
-
   useEffect(() => {
-    setDistanceReached(false)
-    setLookAtReached(false)
-    setUserMovedCamera(false)
-  }, [cameraFocusTrigger, setUserMovedCamera, setLookAtReached, setDistanceReached])
+    startAnimation()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cameraFocusTrigger])
 
   useEffect(() => {
     // stop navigation when user interacts
-    if (isUserDragging && !distanceReached) {
-      arrive()
+    if (isUserDragging) {
+      setDistanceReached(true)
       setLookAtReached(true)
     }
+  }, [isUserDragging, setDistanceReached, setLookAtReached])
+
+  useEffect(() => {
+    if (selectedNode) {
+      if (lookAtAnimationTimer) {
+        clearTimeout(lookAtAnimationTimer)
+      }
+
+      lookAtAnimationTimer = setTimeout(() => {
+        setLookAtReached(true)
+        clearTimeout(lookAtAnimationTimer)
+      }, lookAtAnimationTimerLength)
+
+      depart()
+    }
+
+    return () => {
+      if (lookAtAnimationTimer) {
+        clearTimeout(lookAtAnimationTimer)
+      }
+
+      if (departAnimationTimer) {
+        clearTimeout(departAnimationTimer)
+      }
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isUserDragging])
+  }, [selectedNode])
 
   useFrame((state) => {
     if (cameraControlsRef.current) {
@@ -114,28 +125,37 @@ export const useAutoNavigate = (cameraControlsRef: RefObject<CameraControls | nu
     }
   })
 
-  useEffect(() => {
+  const depart = () => {
     if (selectedNode) {
-      clearTimeout(lookAtAnimationTimer)
+      const distance = camera.position.distanceTo(destination)
 
-      lookAtAnimationTimer = setTimeout(() => {
-        setLookAtReached(true)
-        clearTimeout(lookAtAnimationTimer)
-      }, 2000)
-
-      depart()
+      playInspectSound(distance)
     }
 
-    return () => clearTimeout(lookAtAnimationTimer)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedNode])
+    startAnimation()
+  }
+
+  const startAnimation = () => {
+    setDistanceReached(false)
+    setLookAtReached(false)
+    setUserMovedCamera(false)
+
+    if (departAnimationTimer) {
+      clearTimeout(departAnimationTimer)
+    }
+
+    departAnimationTimer = setTimeout(() => {
+      setDistanceReached(true)
+      setLookAtReached(true)
+    }, departAnimationTimerLength)
+  }
 
   const moveCameraToNode = (dest: Vector3, cam: Camera) => {
     const distance = cam.position.distanceTo(dest)
 
     // stop before colliding with cube
     if (distance < minDistance) {
-      arrive()
+      setDistanceReached(true)
     } else {
       cam.position.lerp(dest, 0.5)
       cam.updateProjectionMatrix()

--- a/src/components/Universe/Graph/Cubes/BlurryInstances/index.tsx
+++ b/src/components/Universe/Graph/Cubes/BlurryInstances/index.tsx
@@ -16,12 +16,13 @@ export const BlurryInstances = ({ hide }: InstanceProps) => {
 
   const instances = useMemo(
     () =>
-      data.nodes.map((node) => {
+      data.nodes.map((node, i) => {
         const visible = !nearbyNodeIds.includes(node.ref_id || '') && !isMainTopic(node)
 
         return (
           <Instance
-            key={node.ref_id || node.id}
+            // eslint-disable-next-line react/no-array-index-key
+            key={`${node.ref_id || node.id}-instanced-node-${i}`}
             color={node.node_type === 'guest' ? 'orange' : 'lightgray'}
             name={node.id}
             position={[node.x, node.y, node.z]}

--- a/src/components/Universe/Graph/Cubes/Highlights/animated.tsx
+++ b/src/components/Universe/Graph/Cubes/Highlights/animated.tsx
@@ -21,7 +21,7 @@ export const AnimatedHighlights = () => {
 
   return (
     <>
-      {nodeData.map((node: NodeExtended) => {
+      {nodeData.map((node: NodeExtended, i) => {
         const { highlight, highlightColor } = getHighlighter({ node, selectedNode, searchTerm })
 
         if (!highlight) {
@@ -36,7 +36,13 @@ export const AnimatedHighlights = () => {
         }
 
         return (
-          <HighlightMesh key={`highlight-${node.ref_id}`} color={highlightColor} node={node} scale={node.scale || 1} />
+          <HighlightMesh
+            // eslint-disable-next-line react/no-array-index-key
+            key={`animated-highlight-${node.ref_id}-${i}`}
+            color={highlightColor}
+            node={node}
+            scale={node.scale || 1}
+          />
         )
       })}
     </>

--- a/src/components/Universe/Graph/Cubes/Highlights/index.tsx
+++ b/src/components/Universe/Graph/Cubes/Highlights/index.tsx
@@ -41,9 +41,10 @@ export const Highlights = () => {
 
   return (
     <>
-      {highlights.map((h) => (
+      {highlights.map((h, i) => (
         <mesh
-          key={`highlight-${h.userData.ref_id}`}
+          // eslint-disable-next-line react/no-array-index-key
+          key={`highlight-${h.userData.ref_id}-${i}`}
           geometry={boxGeometry}
           material={materials[h.color]}
           position={h.position}


### PR DESCRIPTION
I added a timeout for camera animation to prevent an eternal loop bug. also added index to the keys of nodes to prevent duplicate key issues (seems like the backend is providing nodes with identical ref_ids). 

I reorganized code in useAutoNavigate, so it looks like a lot has changed, but things are just moved around. 