### PR TITLE
feat: allow specifying API host name in env var

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+API_URL=https://default.dev.api.com

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
+# Temporary env files
+/public/env-config.js
+env-config.js
+
 # dependencies
 /node_modules
 /.pnp

--- a/env.sh
+++ b/env.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Recreate config file
+rm -rf ./env-config.js
+touch ./env-config.js
+
+# Add assignment
+echo "window._env_ = {" >> ./env-config.js
+
+# Read each line in .env file
+# Each line represents key=value pairs
+while read -r line || [[ -n "$line" ]];
+do
+  # Split env variables by character `=`
+  if printf '%s\n' "$line" | grep -q -e '='; then
+    varname=$(printf '%s\n' "$line" | sed -e 's/=.*//')
+    varvalue=$(printf '%s\n' "$line" | sed -e 's/^[^=]*=//')
+  fi
+
+  # Read value of current variable if exists as Environment variable
+  value=$(printf '%s\n' "${!varname}")
+  # Otherwise use value from .env file
+  [[ -z $value ]] && value=${varvalue}
+
+  # Append configuration property to JS file
+  echo "  $varname: \"$value\"," >> ./env-config.js
+done < .env
+
+echo "}" >> ./env-config.js

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "zustand": "^4.1.1"
   },
   "scripts": {
+    "dev": "chmod +x ./env.sh && ./env.sh && cp env-config.js ./public/ && vite",
     "start": "vite --port 3000",
     "start-e2e": "VITE_APP_IS_E2E=true vite --port 3000",
     "dev-tribe": "vite --port 3004",

--- a/public/index.html
+++ b/public/index.html
@@ -24,6 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
+    <script src="%PUBLIC_URL%/env-config.js"></script>
     <title>Second Brain</title>
   </head>
   <body style="background: #000">


### PR DESCRIPTION
Took a stab towards issue #262 

This PR aims to allow specifying of the API host name in an environment variable.

My initial attempt at this involves:

1. Defining a `.env` with a dummy API host name
2. A bash script, found in `env.sh` which uses the value of the environment variable
