### PR TITLE
fix: remove timestamp from tooltip

### DIFF
--- a/src/components/Universe/Graph/Cubes/Cube/components/Tooltip/index.tsx
+++ b/src/components/Universe/Graph/Cubes/Cube/components/Tooltip/index.tsx
@@ -44,7 +44,6 @@ export const Tooltip = ({ node }: Props) => {
     description,
     label,
     text,
-    timestamp,
     type,
     tweet_id: tweetId,
     twitter_handle: twitterHandle,
@@ -130,10 +129,6 @@ export const Tooltip = ({ node }: Props) => {
                   </Text>
                 )}
               </Flex>
-
-              <Text color="primaryText1" kind="tiny">
-                {timestamp}
-              </Text>
 
               <Flex pt={12}>
                 {nodeType === 'clip' && <Text color="primaryText1">Episode</Text>}


### PR DESCRIPTION
PR closes https://github.com/stakwork/sphinx-nav-fiber/issues/513

## Before
<img width="296" alt="Screen Shot 2023-10-31 at 2 36 39 PM" src="https://github.com/stakwork/sphinx-nav-fiber/assets/8108245/675fc485-0944-4906-bd43-9a3071471d37">


## After
<img width="310" alt="Screen Shot 2023-10-31 at 2 36 09 PM" src="https://github.com/stakwork/sphinx-nav-fiber/assets/8108245/6277392c-a87e-4707-bcb9-a5d576ad2d43">
