### PR TITLE
fix(utils): fixed Support for youtube /live/ in regex

### DIFF
--- a/src/components/AddContentModal/utils/__tests__/index.ts
+++ b/src/components/AddContentModal/utils/__tests__/index.ts
@@ -6,6 +6,10 @@ describe('youtubeRegex', () => {
     expect(getInputType('https://www.youtube.com/watch?v=83eQ9flwVS0&ab_channel=EthanChlebowski')).toBe(LINK)
   })
 
+  it('should assert we can check for youtube live clip regex', async () => {
+    expect(getInputType('https://youtube.com/live/tkdMgjEFNWs')).toBe(LINK)
+  })
+
   it('should assert we can check for twitter spaces regex', async () => {
     expect(getInputType('https://twitter.com/i/spaces/1zqKVqwrVzlxB?s=20')).toBe(LINK)
   })
@@ -28,6 +32,10 @@ describe('youtubeRegex', () => {
 
   it('should assert we can check for twitter handle regex', async () => {
     expect(getInputType('https://twitter.com/@KevKevPal')).toBe(TWITTER_HANDLE)
+  })
+
+  it('should assert we can check for youtube live clip regex', async () => {
+    expect(getInputType('https://www.youtube.com/@MrBeast')).toBe(YOUTUBE_CHANNEL)
   })
 })
 

--- a/src/components/AddContentModal/utils/index.ts
+++ b/src/components/AddContentModal/utils/index.ts
@@ -3,6 +3,7 @@ import { DOCUMENT, LINK, TWITTER_HANDLE, TWITTER_SOURCE, WEB_PAGE, YOUTUBE_CHANN
 export const twitterHandlePattern = /\btwitter\.com\/(?:@)?([\w_]+)(?:$|\?[^/]*$)/
 
 const youtubeRegex = /(https?:\/\/)?(www\.)?youtube\.com\/watch\?v=([A-Za-z0-9_-]+)/
+const youtubeLiveRegex = /(https?:\/\/)?(www\.)?youtube\.com\/live\/([A-Za-z0-9_-]+)/
 const twitterSpaceRegex = /https:\/\/twitter\.com\/i\/spaces\/([A-Za-z0-9_-]+)/
 const tweetUrlRegex = /https:\/\/twitter\.com\/[^/]+\/status\/(\d+)/
 const mp3Regex = /(https?:\/\/)?([A-Za-z0-9_-]+)\.mp3/
@@ -10,21 +11,23 @@ const youtubeChannelPattern = /https?:\/\/(www\.)?youtube\.com\/(@)?([\w-]+)/i
 const genericUrlRegex = /^(https?|ftp):\/\/[^\s/$.?#].[^\s]*$/
 
 export function getInputType(source: string) {
-  let inputType = DOCUMENT
+  let inputType = DOCUMENT;
 
-  if (youtubeRegex.test(source) || twitterSpaceRegex.test(source) || mp3Regex.test(source)) {
-    inputType = LINK
+  if (youtubeLiveRegex.test(source)) {
+    inputType = LINK;
+  } else if (youtubeRegex.test(source) || twitterSpaceRegex.test(source) || mp3Regex.test(source)) {
+    inputType = LINK;
   } else if (youtubeChannelPattern.test(source)) {
-    inputType = YOUTUBE_CHANNEL
+    inputType = YOUTUBE_CHANNEL;
   } else if (twitterHandlePattern.test(source)) {
-    inputType = TWITTER_HANDLE
+    inputType = TWITTER_HANDLE;
   } else if (tweetUrlRegex.test(source)) {
-    inputType = TWITTER_SOURCE
+    inputType = TWITTER_SOURCE;
   } else if (genericUrlRegex.test(source)) {
-    inputType = WEB_PAGE
+    inputType = WEB_PAGE;
   }
 
-  return inputType
+  return inputType;
 }
 
 export const extractNameFromLink = (inputString: string, type = ''): string | null => {


### PR DESCRIPTION
### Problem:
The utility functions responsible for parsing URLs were not correctly identifying YouTube Live links. They were being categorized as YouTube Channel links due to an oversight in the regex pattern.

### Solution:
I've updated the regex patterns in the utilities to correctly distinguish YouTube Live links. The `youtubeLiveRegex` now accurately identifies URLs that contain `/live/` and ensures that they are recognized as individual YouTube video links rather than as YouTube channels.

### Changes:
- Modified `youtubeLiveRegex` to match YouTube Live URLs.
- Updated `getInputType` function to return `LINK` for YouTube Live URLs.
- Added tests to confirm that YouTube Live URLs are handled correctly.

### Testing:
New test cases were added to verify the correct categorization of YouTube Live links. All tests pass with the updated regex, confirming that the utility functions are now functioning as intended.
![image](https://github.com/stakwork/sphinx-nav-fiber/assets/87068339/288778ec-45f3-4940-8463-3fbd0fff78b2)

This fix ensures that our application correctly processes YouTube Live links, improving the accuracy of our link categorization logic.

### Notes:
Please review the changes and merge this PR if everything is in order. This fix is essential for the upcoming release, and I look forward to any feedback you might have.
