### PR TITLE
Fix/balance

### DIFF
--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -153,6 +153,8 @@ export const App = () => {
 
         setPubKey(sphinxEnable?.pubkey)
 
+        await updateBudget(setBudget)
+
         const sigAndMessage = await getSignedMessageFromRelay()
 
         const isAdmin = await getIsAdmin({
@@ -165,8 +167,6 @@ export const App = () => {
         if (isAdmin.isAdmin) {
           setIsAdmin(true)
         }
-
-        await updateBudget(setBudget)
       })
     } catch (error) {
       /* not an admin */

--- a/src/components/Booster/index.tsx
+++ b/src/components/Booster/index.tsx
@@ -6,7 +6,6 @@ import { Flex } from '~/components/common/Flex'
 import { Pill } from '~/components/common/Pill'
 import BoostIcon from '~/components/Icons/BoostIcon'
 import { BOOST_ERROR_BUDGET, BOOST_SUCCESS } from '~/constants'
-import { useUserStore } from '~/stores/useUserStore'
 import { Node } from '~/types'
 import { boost } from '~/utils/boost'
 import { colors } from '~/utils/colors'
@@ -31,7 +30,6 @@ const notify = (message: string) => {
 export const Booster = ({ count = 0, updateCount, content, readOnly, refId }: Props) => {
   const [submitting, setSubmitting] = useState(false)
   const [isSuccess, setIsSuccess] = useState(false)
-  const [setBudget] = useUserStore((s) => [s.setBudget])
 
   useEffect(() => {
     setIsSuccess(false)
@@ -55,17 +53,13 @@ export const Booster = ({ count = 0, updateCount, content, readOnly, refId }: Pr
 
     // eslint-disable-next-line no-useless-catch
     try {
-      const boostResponse = await boost(refId, defaultBoostAmount)
+      await boost(refId, defaultBoostAmount)
 
       setIsSuccess(true)
       notify(BOOST_SUCCESS)
 
       if (updateCount) {
         updateCount(count + defaultBoostAmount)
-      }
-
-      if (boostResponse.budget) {
-        setBudget(boostResponse.budget)
       }
     } catch (e) {
       notify(BOOST_ERROR_BUDGET)

--- a/src/utils/setBudget/index.ts
+++ b/src/utils/setBudget/index.ts
@@ -5,7 +5,7 @@ export async function updateBudget(setBudget: (value: number | null) => void) {
   const lsat = await getLSat()
 
   if (!lsat) {
-    setBudget(null)
+    setBudget(0)
 
     return
   }
@@ -16,6 +16,6 @@ export async function updateBudget(setBudget: (value: number | null) => void) {
     setBudget(balance.balance)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (error: any) {
-    setBudget(null)
+    setBudget(0)
   }
 }


### PR DESCRIPTION
### Problem:
We get `?` as balance when lsat does not exist
We don't get balance for non-sphinx users

### Solution:
Show `0` if the balance does not exist
Non-sphinx user's balances should always show and not remain at zero

### Changes:
stopped returning null as a parameter for `setBudget` in the `updateBudget` function
Get none Sphinx users' balance before checking if they are admins

### Testing:
No

### Notes:
any additional notes

