### PR TITLE
Fix/set budget after payment

### DIFF
--- a/src/components/AddContentModal/index.tsx
+++ b/src/components/AddContentModal/index.tsx
@@ -127,7 +127,7 @@ const handleSubmitForm = async (
     // eslint-disable-next-line  @typescript-eslint/no-explicit-any
   } catch (err: any) {
     if (err.status === 402) {
-      await payLsat()
+      await payLsat(setBudget)
 
       await updateBudget(setBudget)
 

--- a/src/components/App/Helper/AskQuestion/index.tsx
+++ b/src/components/App/Helper/AskQuestion/index.tsx
@@ -100,12 +100,15 @@ export const AskQuestion = () => {
         // @ts-ignore
         await sphinx.enable()
 
-        await postAskQuestion({
-          expertise_level: selectedValue,
-          question_text: question,
-          search_term: searchTerm,
-          transcripts,
-        })
+        await postAskQuestion(
+          {
+            expertise_level: selectedValue,
+            question_text: question,
+            search_term: searchTerm,
+            transcripts,
+          },
+          setBudget,
+        )
 
         await updateBudget(setBudget)
 

--- a/src/components/App/Helper/SentimentAnalysis/index.tsx
+++ b/src/components/App/Helper/SentimentAnalysis/index.tsx
@@ -50,7 +50,7 @@ export const SentimentAnalysis = memo(() => {
       sphinx.enable(),
     )
 
-    getSentimentData({ topic: search, cutoff_date: String(value.unix()) })
+    getSentimentData(setBudget, { topic: search, cutoff_date: String(value.unix()) })
       .then(async (r) => {
         setSentimentData(
           r?.data

--- a/src/components/App/Helper/TeachMe/index.tsx
+++ b/src/components/App/Helper/TeachMe/index.tsx
@@ -102,10 +102,13 @@ export const TeachMe = () => {
         // @ts-ignore
         await sphinx.enable()
 
-        await postTeachMe({
-          term: searchTerm,
-          transcripts,
-        })
+        await postTeachMe(
+          {
+            term: searchTerm,
+            transcripts,
+          },
+          setBudget,
+        )
 
         await updateBudget(setBudget)
 
@@ -113,10 +116,13 @@ export const TeachMe = () => {
           type: 'success',
         })
 
-        await postInstagraph({
-          term: searchTerm,
-          transcripts,
-        })
+        await postInstagraph(
+          {
+            term: searchTerm,
+            transcripts,
+          },
+          setBudget,
+        )
 
         await updateBudget(setBudget)
 

--- a/src/components/App/SecondarySidebar/Sentiment/index.tsx
+++ b/src/components/App/SecondarySidebar/Sentiment/index.tsx
@@ -36,7 +36,7 @@ export const Sentiment = () => {
       sphinx.enable(),
     )
 
-    getSentimentData()
+    getSentimentData(setBudget)
       .then(async (r) => {
         setSentimentData(
           r?.data

--- a/src/components/App/SideBar/Latest/index.tsx
+++ b/src/components/App/SideBar/Latest/index.tsx
@@ -15,7 +15,7 @@ type Props = {
 
 // eslint-disable-next-line no-underscore-dangle
 const _View = ({ isSearchResult }: Props) => {
-  const [nodeCount, setNodeCount] = useUserStore((s) => [s.nodeCount, s.setNodeCount])
+  const [nodeCount, setNodeCount, setBudget] = useUserStore((s) => [s.nodeCount, s.setNodeCount, s.setBudget])
   const [fetchData] = [useDataStore((s) => s.fetchData)]
 
   const getLatest = async () => {
@@ -23,7 +23,7 @@ const _View = ({ isSearchResult }: Props) => {
       return
     }
 
-    await fetchData()
+    await fetchData(setBudget)
     setNodeCount('CLEAR')
   }
 

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -112,7 +112,7 @@ export const App = () => {
       setSphinxModalOpen(false)
     }
 
-    await fetchData(searchTerm)
+    await fetchData(setBudget, searchTerm)
     setSidebarOpen(true)
   }, [fetchData, searchTerm, setSphinxModalOpen, setSidebarOpen, setBudget])
 

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -105,8 +105,6 @@ export const App = () => {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         await sphinx.enable()
-
-        await updateBudget(setBudget)
       }
 
       setSphinxModalOpen(false)
@@ -114,6 +112,10 @@ export const App = () => {
 
     await fetchData(setBudget, searchTerm)
     setSidebarOpen(true)
+
+    if (searchTerm) {
+      await updateBudget(setBudget)
+    }
   }, [fetchData, searchTerm, setSphinxModalOpen, setSidebarOpen, setBudget])
 
   useEffect(() => {

--- a/src/components/DataRetriever/index.tsx
+++ b/src/components/DataRetriever/index.tsx
@@ -2,6 +2,7 @@ import invariant from 'invariant'
 import { PropsWithChildren, useCallback, useEffect, useState } from 'react'
 import { Vector3 } from 'three'
 import { useDataStore, useSelectedNode } from '~/stores/useDataStore'
+import { useUserStore } from '~/stores/useUserStore'
 import { NodeExtended } from '~/types'
 import { Splash } from '../App/Splash'
 import { PATHWAY_RANGE } from './constants'
@@ -10,13 +11,14 @@ type Props = PropsWithChildren
 
 export const DataRetriever = ({ children }: Props) => {
   const fetchData = useDataStore((s) => s.fetchData)
+  const [setBudget] = useUserStore((s) => [s.setBudget])
   const [loading, setLoading] = useState(false)
 
   useEffect(() => {
     setLoading(true)
 
-    fetchData()
-  }, [fetchData])
+    fetchData(setBudget)
+  }, [fetchData, setBudget])
 
   if (loading) {
     return <Splash handleLoading={setLoading} />

--- a/src/network/fetchGraphData/index.ts
+++ b/src/network/fetchGraphData/index.ts
@@ -59,15 +59,19 @@ type TopicMap = Record<string, TopicMapItem>
 const shouldIncludeTopics = true
 const maxScale = 26
 
-export const fetchGraphData = async (search: string, graphStyle: 'split' | 'force' | 'sphere' | 'earth') => {
+export const fetchGraphData = async (
+  search: string,
+  graphStyle: 'split' | 'force' | 'sphere' | 'earth',
+  setBudget: (value: number | null) => void,
+) => {
   try {
-    return getGraphData(search, graphStyle)
+    return getGraphData(search, graphStyle, setBudget)
   } catch (e) {
     return defaultData
   }
 }
 
-const fetchNodes = async (search: string): Promise<FetchDataResponse> => {
+const fetchNodes = async (search: string, setBudget: (value: number | null) => void): Promise<FetchDataResponse> => {
   if (!search) {
     try {
       const response = await api.get<FetchDataResponse>(`/prediction/content/latest`)
@@ -97,9 +101,9 @@ const fetchNodes = async (search: string): Promise<FetchDataResponse> => {
     // eslint-disable-next-line  @typescript-eslint/no-explicit-any
   } catch (error: any) {
     if (error.status === 402) {
-      await payLsat()
+      await payLsat(setBudget)
 
-      return fetchNodes(search)
+      return fetchNodes(search, setBudget)
     }
 
     throw error
@@ -122,10 +126,13 @@ export const getTrends = async () => {
  *  }
  */
 
-export const getSentimentData = async (args?: {
-  topic: string
-  cutoff_date: string
-}): Promise<FetchSentimentResponse> => {
+export const getSentimentData = async (
+  setBudget: (value: number | null) => void,
+  args?: {
+    topic: string
+    cutoff_date: string
+  },
+): Promise<FetchSentimentResponse> => {
   const search = args && new URLSearchParams(args)
 
   const endpoint = search ? `/sentiments?${search.toString()}` : '/sentiments'
@@ -149,16 +156,16 @@ export const getSentimentData = async (args?: {
     // eslint-disable-next-line  @typescript-eslint/no-explicit-any
   } catch (error: any) {
     if (error.status === 402) {
-      await payLsat()
+      await payLsat(setBudget)
 
-      return getSentimentData(args)
+      return getSentimentData(setBudget, args)
     }
 
     throw error
   }
 }
 
-export const postInstagraph = async (data: TeachData): Promise<void> => {
+export const postInstagraph = async (data: TeachData, setBudget: (value: number | null) => void): Promise<void> => {
   const lsatToken = await getLSat()
 
   try {
@@ -167,9 +174,9 @@ export const postInstagraph = async (data: TeachData): Promise<void> => {
     // eslint-disable-next-line  @typescript-eslint/no-explicit-any
   } catch (error: any) {
     if (error.status === 402) {
-      await payLsat()
+      await payLsat(setBudget)
 
-      await postInstagraph(data)
+      await postInstagraph(data, setBudget)
 
       return
     }
@@ -178,7 +185,7 @@ export const postInstagraph = async (data: TeachData): Promise<void> => {
   }
 }
 
-export const postTeachMe = async (data: TeachData): Promise<void> => {
+export const postTeachMe = async (data: TeachData, setBudget: (value: number | null) => void): Promise<void> => {
   const lsatToken = await getLSat()
 
   try {
@@ -187,9 +194,9 @@ export const postTeachMe = async (data: TeachData): Promise<void> => {
     // eslint-disable-next-line  @typescript-eslint/no-explicit-any
   } catch (error: any) {
     if (error.status === 402) {
-      await payLsat()
+      await payLsat(setBudget)
 
-      await postTeachMe(data)
+      await postTeachMe(data, setBudget)
 
       return
     }
@@ -198,7 +205,7 @@ export const postTeachMe = async (data: TeachData): Promise<void> => {
   }
 }
 
-export const postAskQuestion = async (data: QuestionData): Promise<void> => {
+export const postAskQuestion = async (data: QuestionData, setBudget: (value: number | null) => void): Promise<void> => {
   const lsatToken = await getLSat()
 
   try {
@@ -207,9 +214,9 @@ export const postAskQuestion = async (data: QuestionData): Promise<void> => {
     // eslint-disable-next-line  @typescript-eslint/no-explicit-any
   } catch (error: any) {
     if (error.status === 402) {
-      await payLsat()
+      await payLsat(setBudget)
 
-      await postAskQuestion(data)
+      await postAskQuestion(data, setBudget)
 
       return
     }
@@ -326,9 +333,13 @@ const generateGuestsMap = (
   return updatedGuestMap // Return the new variable
 }
 
-export const getGraphData = async (searchterm: string, graphStyle: 'split' | 'force' | 'sphere' | 'earth') => {
+export const getGraphData = async (
+  searchterm: string,
+  graphStyle: 'split' | 'force' | 'sphere' | 'earth',
+  setBudget: (value: number | null) => void,
+) => {
   try {
-    const dataInit = await fetchNodes(searchterm)
+    const dataInit = await fetchNodes(searchterm, setBudget)
 
     return formatFetchNodes(dataInit, searchterm, graphStyle)
   } catch (e) {

--- a/src/stores/useDataStore/index.ts
+++ b/src/stores/useDataStore/index.ts
@@ -39,7 +39,7 @@ type DataStore = {
   setScrollEventsDisabled: (scrollEventsDisabled: boolean) => void
   setCategoryFilter: (categoryFilter: NodeType | null) => void
   setDisableCameraRotation: (rotation: boolean) => void
-  fetchData: (search?: string | null) => void
+  fetchData: (setBudget: (value: number | null) => void, search?: string | null) => void
   setData: (data: GraphData) => void
   setGraphStyle: (graphStyle: GraphStyle) => void
   setGraphRadius: (graphRadius?: number | null) => void
@@ -111,14 +111,14 @@ const defaultData: Omit<
 
 export const useDataStore = create<DataStore>((set, get) => ({
   ...defaultData,
-  fetchData: async (search) => {
+  fetchData: async (setBudget, search) => {
     if (get().isFetching) {
       return
     }
 
     set({ isFetching: true, sphinxModalIsOpen: true })
 
-    const data = await fetchGraphData(search || '', get().graphStyle)
+    const data = await fetchGraphData(search || '', get().graphStyle, setBudget)
 
     if (search) {
       await saveSearchTerm()

--- a/src/utils/payLsat/index.ts
+++ b/src/utils/payLsat/index.ts
@@ -2,9 +2,10 @@ import { Lsat } from 'lsat-js'
 import * as sphinx from 'sphinx-bridge'
 import { requestProvider } from 'webln'
 import { buyLsat } from '~/network/buyLsat'
+import { updateBudget } from '../setBudget'
 
 // eslint-disable-next-line  @typescript-eslint/no-explicit-any
-export async function payLsat(): Promise<void> {
+export async function payLsat(setBudget: (value: number | null) => void): Promise<void> {
   let lsat: Lsat
 
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -62,6 +63,8 @@ export async function payLsat(): Promise<void> {
         )
       }
 
+      await updateBudget(setBudget)
+
       return
     }
   }
@@ -90,4 +93,6 @@ export async function payLsat(): Promise<void> {
       }),
     )
   }
+
+  await updateBudget(setBudget)
 }


### PR DESCRIPTION
### Problem:
When we buy lsat, we don't see the budget updated immediately until after the search

### Solution:
Set a Budget after you are done buying lsat

### Changes:
In the `payLsat` function I always update the budget immediately after we buy `lsat`

### Testing:
None

### Notes:
None

