### PR TITLE
Feat/free endpoint for admin

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,9 @@
       }
     },
     "testEnvironment": "jsdom",
-    "setupFilesAfterEnv": ["<rootDir>/jest.setup.js"]
+    "setupFilesAfterEnv": [
+      "<rootDir>/jest.setup.js"
+    ]
   },
   "browserslist": {
     "production": [

--- a/src/components/AddContentModal/index.tsx
+++ b/src/components/AddContentModal/index.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from 'react'
 import { FieldValues, FormProvider, useForm } from 'react-hook-form'
 import * as sphinx from 'sphinx-bridge'
-import { BaseModal } from '~/components/Modal'
 import { notify } from '~/components/common/Toast/toastMessage'
+import { BaseModal } from '~/components/Modal'
 import {
   DOCUMENT,
   LINK,
@@ -18,7 +18,7 @@ import { api } from '~/network/api'
 import { useModal } from '~/stores/useModalStore'
 import { useUserStore } from '~/stores/useUserStore'
 import { SubmitErrRes } from '~/types'
-import { executeIfProd, generateAuthQueryParam, getLSat, payLsat, updateBudget } from '~/utils'
+import { executeIfProd, getLSat, payLsat, updateBudget } from '~/utils'
 import { BudgetStep } from './BudgetStep'
 import { LocationStep } from './LocationStep'
 import { SourceStep } from './SourceStep'
@@ -103,15 +103,7 @@ const handleSubmitForm = async (
   })
 
   try {
-    let query = ''
-
-    if (endPoint === 'radar') {
-      const result = await generateAuthQueryParam()
-
-      query = `?${result}`
-    }
-
-    const res: SubmitErrRes = await api.post(`/${endPoint}${query}`, JSON.stringify(body), {
+    const res: SubmitErrRes = await api.post(`/${endPoint}`, JSON.stringify(body), {
       Authorization: lsatToken,
     })
 

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -5,10 +5,10 @@ import 'react-toastify/dist/ReactToastify.css'
 import { Socket } from 'socket.io-client'
 import * as sphinx from 'sphinx-bridge'
 import styled from 'styled-components'
+import { Flex } from '~/components/common/Flex'
 import { DataRetriever } from '~/components/DataRetriever'
 import { GlobalStyle } from '~/components/GlobalStyle'
 import { Universe } from '~/components/Universe'
-import { Flex } from '~/components/common/Flex'
 import { isDevelopment, isE2E } from '~/constants'
 import useSocket from '~/hooks/useSockets'
 import { getIsAdmin } from '~/network/auth'
@@ -18,7 +18,6 @@ import { useDataStore } from '~/stores/useDataStore'
 import { useTeachStore } from '~/stores/useTeachStore'
 import { useUserStore } from '~/stores/useUserStore'
 import { GraphData } from '~/types'
-import { extractUuidAndHost } from '~/utils/auth'
 import { colors } from '~/utils/colors'
 import { getSignedMessageFromRelay } from '~/utils/getSignedMessage'
 import { updateBudget } from '~/utils/setBudget'
@@ -29,12 +28,12 @@ import { SettingsModal } from '../SettingsModal'
 import { SourcesTableModal } from '../SourcesTableModal'
 import { ActionsToolbar } from './ActionsToolbar'
 import { AppBar } from './AppBar'
+import { DeviceCompatibilityNotice } from './DeviceCompatibilityNotification'
 import { Helper } from './Helper'
 import { MainToolbar } from './MainToolbar'
 import { AppProviders } from './Providers'
 import { SecondarySideBar } from './SecondarySidebar'
 import { SideBar } from './SideBar'
-import { DeviceCompatibilityNotice } from './DeviceCompatibilityNotification'
 import { Toasts } from './Toasts'
 
 const Wrapper = styled(Flex)`
@@ -53,11 +52,9 @@ const Version = styled(Flex)`
 `
 
 export const App = () => {
-  const [setBudget, setNodeCount, setTribeHost, setTribeUuid, setIsAdmin, setPubKey] = useUserStore((s) => [
+  const [setBudget, setNodeCount, setIsAdmin, setPubKey] = useUserStore((s) => [
     s.setBudget,
     s.setNodeCount,
-    s.setTribeHost,
-    s.setTribeUuid,
     s.setIsAdmin,
     s.setPubKey,
   ])
@@ -144,11 +141,6 @@ export const App = () => {
 
   const handleAuth = useCallback(async () => {
     try {
-      const { host, uuid } = extractUuidAndHost(window.location.search)
-
-      setTribeHost(host)
-      setTribeUuid(uuid)
-
       await executeIfProd(async () => {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
@@ -161,8 +153,6 @@ export const App = () => {
         const sigAndMessage = await getSignedMessageFromRelay()
 
         const isAdmin = await getIsAdmin({
-          tribeHost: host,
-          tribeUuid: uuid,
           message: sigAndMessage.message,
           signature: sigAndMessage.signature,
         })
@@ -174,7 +164,7 @@ export const App = () => {
     } catch (error) {
       /* not an admin */
     }
-  }, [setIsAdmin, setTribeHost, setTribeUuid, setPubKey, setBudget])
+  }, [setIsAdmin, setPubKey, setBudget])
 
   // setup socket
   useEffect(() => {

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -142,6 +142,8 @@ export const App = () => {
   const handleAuth = useCallback(async () => {
     try {
       await executeIfProd(async () => {
+        localStorage.removeItem('admin')
+
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         const sphinxEnable = await sphinx.enable()
@@ -158,6 +160,7 @@ export const App = () => {
         })
 
         if (isAdmin.isAdmin) {
+          localStorage.setItem('admin', JSON.stringify({ isAdmin: true }))
           setIsAdmin(true)
         }
       })

--- a/src/network/api/index.ts
+++ b/src/network/api/index.ts
@@ -1,7 +1,27 @@
 import { API_URL } from '~/constants'
+import { getSignedMessageFromRelay } from '~/utils'
 
 const request = async <Res>(url: string, config?: RequestInit): Promise<Res> => {
-  const response = await fetch(url, config)
+  const admin = localStorage.getItem('admin')
+
+  let updatedUrl = url
+
+  if (admin) {
+    const newUrl = new URL(url)
+
+    const existingParams = new URLSearchParams(newUrl.search)
+
+    const adminAuth = await getSignedMessageFromRelay()
+
+    existingParams.append('sig', adminAuth.signature)
+    existingParams.append('msg', adminAuth.message)
+
+    newUrl.search = existingParams.toString()
+
+    updatedUrl = newUrl.toString()
+  }
+
+  const response = await fetch(updatedUrl, config)
 
   if (!response.ok) {
     throw response

--- a/src/network/auth/__tests__/index.ts
+++ b/src/network/auth/__tests__/index.ts
@@ -8,12 +8,10 @@ describe('test extracting uuid and tribe host', () => {
 
     const authRequest = {
       message: 'test message',
-      tribeHost: 'test tribe host',
-      tribeUuid: 'test tribe uuid',
       signature: 'test signature',
     }
 
-    const expectedEndpoint = `/isAdmin?msg=${authRequest.message}&sig=${authRequest.signature}&tribe_host=${authRequest.tribeHost}&uuid=${authRequest.tribeUuid}`
+    const expectedEndpoint = `/isAdmin?msg=${authRequest.message}&sig=${authRequest.signature}`
 
     mockApiGet.mockReturnValue(Promise.resolve({ isAdmin: false }))
 

--- a/src/network/auth/index.ts
+++ b/src/network/auth/index.ts
@@ -1,10 +1,8 @@
 import { api } from '~/network/api'
 import { AuthRequest, IsAdminResponse } from '~/types'
 
-export async function getIsAdmin({ message, tribeHost, tribeUuid, signature }: AuthRequest) {
-  const response = api.get<IsAdminResponse>(
-    `/isAdmin?msg=${message}&sig=${signature}&tribe_host=${tribeHost}&uuid=${tribeUuid}`,
-  )
+export async function getIsAdmin({ message, signature }: AuthRequest) {
+  const response = api.get<IsAdminResponse>(`/isAdmin?msg=${message}&sig=${signature}`)
 
   return response
 }

--- a/src/network/fetchSourcesData/index.ts
+++ b/src/network/fetchSourcesData/index.ts
@@ -6,7 +6,6 @@ import {
   RadarRequest,
   SubmitErrRes,
 } from '~/types'
-import { generateAuthQueryParam } from '~/utils'
 import { api } from '../api'
 
 type TradarParams = {
@@ -69,10 +68,8 @@ export const getRadarData = async (queryParams: TradarParams = defaultParams) =>
 }
 
 export const getTopicsData = async (queryParams: TtopicsParams = defaultParams) => {
-  const query = await generateAuthQueryParam()
-
   const response = await api.get<FetchTopicResponse>(
-    `/topics?${new URLSearchParams({ ...defaultParams, ...queryParams }).toString()}${query}`,
+    `/topics?${new URLSearchParams({ ...defaultParams, ...queryParams }).toString()}`,
   )
 
   return response
@@ -91,33 +88,25 @@ export const getStats = async () => {
 }
 
 export const getEdgeTypes = async () => {
-  const query = await generateAuthQueryParam()
-
-  const response = await api.get<FetchEdgesResponse>(`curation/edge/type?${query}`)
+  const response = await api.get<FetchEdgesResponse>(`curation/edge/type`)
 
   return response
 }
 
 export const postEdgeType = async (data: TAddEdgeParams) => {
-  const query = await generateAuthQueryParam()
-
-  const response = await api.post(`/curation/edge?${query}`, JSON.stringify(data))
+  const response = await api.post(`/curation/edge`, JSON.stringify(data))
 
   return response
 }
 
 export const postAboutData = async (data: TAboutParams) => {
-  const query = await generateAuthQueryParam()
-
-  const response = await api.post(`/about?${query}`, JSON.stringify(data))
+  const response = await api.post(`/about`, JSON.stringify(data))
 
   return response
 }
 
 export const postMergeTopics = async (data: TMergeTopicsParams) => {
-  const query = await generateAuthQueryParam()
-
-  const response = await api.post(`/curation/merge?${query}`, JSON.stringify(data))
+  const response = await api.post(`/curation/merge`, JSON.stringify(data))
 
   return response
 }
@@ -125,33 +114,25 @@ export const postMergeTopics = async (data: TMergeTopicsParams) => {
 export const triggerRadarJob = async () => api.get<SubmitErrRes>(`/radar/trigger-job`)
 
 export const putRadarData = async (id: string, data: RadarRequest) => {
-  const query = await generateAuthQueryParam()
-
-  const response = await api.put(`/radar/${id}?${query}`, JSON.stringify(data))
+  const response = await api.put(`/radar/${id}`, JSON.stringify(data))
 
   return response
 }
 
 export const putNodeData = async (data: NodeRequest) => {
-  const query = await generateAuthQueryParam()
-
-  const response = await api.put(`/node?${query}`, JSON.stringify(data))
+  const response = await api.put(`/node`, JSON.stringify(data))
 
   return response
 }
 
 export const approveRadarData = async (id: string, pubkey: string) => {
-  const query = await generateAuthQueryParam()
-
-  const response = await api.put(`/radar/${id}/approve?${query}`, JSON.stringify({ approve: 'True', pubkey }))
+  const response = await api.put(`/radar/${id}/approve`, JSON.stringify({ approve: 'True', pubkey }))
 
   return response
 }
 
 export const deleteRadarData = async (id: string) => {
-  const query = await generateAuthQueryParam()
-
-  const response = await api.delete(`/radar/${id}?${query}`)
+  const response = await api.delete(`/radar/${id}`)
 
   return response
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -187,8 +187,6 @@ export type SubmitErrRes = {
 
 export type AuthRequest = {
   message: string
-  tribeHost: string
-  tribeUuid: string
   signature: string
 }
 

--- a/src/utils/logger/logger.ts
+++ b/src/utils/logger/logger.ts
@@ -1,6 +1,6 @@
 /* eslint-disable func-names */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import './styles.css'
+// import './styles.css'
 
 const getElementsMemoized = () => {
   const cache = {} as { inner: HTMLElement; body: HTMLElement }


### PR DESCRIPTION
### Ticket №:
closes #753

### Problem:
We want all paid endpoint to be free for all admins

### Solution:
If the user is an admin, add `msg` and `sig` to all their request

### Changes:
the request function is check if the currrent user is an admin or not

### Testing:
None

### Notes:
any additional notes

