### PR TITLE
Fix(source-link): Enhance Linking Functionality for All Source Types in Sources Table

### DIFF
--- a/src/components/SourcesTableModal/SourcesView/Sources/Table/index.tsx
+++ b/src/components/SourcesTableModal/SourcesView/Sources/Table/index.tsx
@@ -102,7 +102,7 @@ const Table: React.FC<Props> = ({ data, canEdit = false }) => {
                       </StyledLink>
                     )}
                     {i.source_type === YOUTUBE_CHANNEL && (
-                      <StyledLink href={i.source} target="_blank">
+                      <StyledLink href={`${i.source}${i.source.includes('?') ? '&' : '?'}open=system`} target="_blank">
                         {i.source}
                       </StyledLink>
                     )}

--- a/src/components/SourcesTableModal/SourcesView/Sources/Table/index.tsx
+++ b/src/components/SourcesTableModal/SourcesView/Sources/Table/index.tsx
@@ -94,19 +94,19 @@ const Table: React.FC<Props> = ({ data, canEdit = false }) => {
                   </EditableCell>
                 )}
               >
-                {i.source_type === TWITTER_HANDLE || i.source_type === RSS || i.source_type === YOUTUBE_CHANNEL ? (
+                {i.source_type === TWITTER_HANDLE || i.source_type === YOUTUBE_CHANNEL || i.source_type === RSS ? (
                   <>
                     {i.source_type === TWITTER_HANDLE && (
                       <StyledLink href={`${TWITTER_LINK}/${i.source}`} target="_blank">
                         @{i.source}
                       </StyledLink>
                     )}
-                    {i.source_type === RSS && (
+                    {i.source_type === YOUTUBE_CHANNEL && (
                       <StyledLink href={i.source} target="_blank">
                         {i.source}
                       </StyledLink>
                     )}
-                    {i.source_type === YOUTUBE_CHANNEL && (
+                    {i.source_type === RSS && (
                       <StyledLink href={i.source} target="_blank">
                         {i.source}
                       </StyledLink>

--- a/src/components/SourcesTableModal/SourcesView/Sources/Table/index.tsx
+++ b/src/components/SourcesTableModal/SourcesView/Sources/Table/index.tsx
@@ -8,7 +8,7 @@ import FilterOffIcon from '~/components/Icons/FilterOffIcon'
 import ConfirmPopover from '~/components/common/ConfirmPopover'
 import { Flex } from '~/components/common/Flex'
 import { Text } from '~/components/common/Text'
-import { RSS, TWITTER_HANDLE } from '~/constants'
+import { RSS, TWITTER_HANDLE, YOUTUBE_CHANNEL } from '~/constants'
 import { deleteRadarData, putRadarData } from '~/network/fetchSourcesData'
 import { useDataStore } from '~/stores/useDataStore'
 import { RadarRequest, Sources } from '~/types'
@@ -94,7 +94,7 @@ const Table: React.FC<Props> = ({ data, canEdit = false }) => {
                   </EditableCell>
                 )}
               >
-                {i.source_type === TWITTER_HANDLE || i.source_type === RSS ? (
+                {i.source_type === TWITTER_HANDLE || i.source_type === RSS || i.source_type === YOUTUBE_CHANNEL ? (
                   <>
                     {i.source_type === TWITTER_HANDLE && (
                       <StyledLink href={`${TWITTER_LINK}/${i.source}`} target="_blank">
@@ -102,6 +102,11 @@ const Table: React.FC<Props> = ({ data, canEdit = false }) => {
                       </StyledLink>
                     )}
                     {i.source_type === RSS && (
+                      <StyledLink href={i.source} target="_blank">
+                        {i.source}
+                      </StyledLink>
+                    )}
+                    {i.source_type === YOUTUBE_CHANNEL && (
                       <StyledLink href={i.source} target="_blank">
                         {i.source}
                       </StyledLink>

--- a/src/components/SourcesTableModal/SourcesView/Sources/Table/tests/test.tsx
+++ b/src/components/SourcesTableModal/SourcesView/Sources/Table/tests/test.tsx
@@ -39,15 +39,15 @@ describe('Table Component Tests', () => {
     render(<Table canEdit={false} data={mockData} />)
 
     const rows = screen.getAllByRole('row')
-    const firstRow = rows[1] as HTMLTableRowElement // Type assertion here
+    const firstRow = rows[1] as HTMLTableRowElement
 
     const expectedSourceTypeText = sourcesMapper[mockData[0].source_type]
     const sourceTypeCell = within(firstRow.cells[1]).getByText(expectedSourceTypeText)
 
     let sourceCellText = mockData[0].source
-
     if (mockData[0].source_type === TWITTER_HANDLE) {
-      sourceCellText = '@' + sourceCellText // Adjust for Twitter handles
+      // Use template literal here
+      sourceCellText = `@${sourceCellText}`
     }
 
     const sourceCell = within(firstRow.cells[2]).getByText(sourceCellText)

--- a/src/components/SourcesTableModal/SourcesView/Sources/Table/tests/test.tsx
+++ b/src/components/SourcesTableModal/SourcesView/Sources/Table/tests/test.tsx
@@ -45,6 +45,7 @@ describe('Table Component Tests', () => {
     const sourceTypeCell = within(firstRow.cells[1]).getByText(expectedSourceTypeText)
 
     let sourceCellText = mockData[0].source
+
     if (mockData[0].source_type === TWITTER_HANDLE) {
       // Use template literal here
       sourceCellText = `@${sourceCellText}`

--- a/src/components/SourcesTableModal/SourcesView/Sources/Table/tests/test.tsx
+++ b/src/components/SourcesTableModal/SourcesView/Sources/Table/tests/test.tsx
@@ -26,7 +26,7 @@ describe('Table Component Tests', () => {
     const youtubeLink = screen.getByText(mockData[1].source).closest('a')
 
     expect(youtubeLink).toBeInTheDocument()
-    expect(youtubeLink).toHaveAttribute('href', mockData[1].source)
+    expect(youtubeLink).toHaveAttribute('href', `${mockData[1].source}?open=system`)
 
     // RSS link
     const rssLink = screen.getByText(mockData[2].source).closest('a')

--- a/src/components/SourcesTableModal/SourcesView/Sources/Table/tests/test.tsx
+++ b/src/components/SourcesTableModal/SourcesView/Sources/Table/tests/test.tsx
@@ -1,0 +1,58 @@
+import '@testing-library/jest-dom/extend-expect'
+import React from 'react'
+import { render, screen, within } from '@testing-library/react'
+import Table from '../index' // Adjust path as needed
+import { RSS, TWITTER_HANDLE, YOUTUBE_CHANNEL } from '~/constants'
+import { sourcesMapper, TWITTER_LINK } from '~/components/SourcesTableModal/SourcesView/constants'
+
+describe('Table Component Tests', () => {
+  // Mock data based on your Sources type
+  const mockData = [
+    { ref_id: '1', source: '@snyke', source_type: TWITTER_HANDLE },
+    { ref_id: '2', source: '@danielprince1038', source_type: YOUTUBE_CHANNEL },
+    { ref_id: '3', source: 'https://anchor.fm/s/71a8cc78/podcast/rss', source_type: RSS },
+  ]
+
+  it('should correctly render links for each source type', () => {
+    render(<Table canEdit={false} data={mockData} />)
+
+    // Twitter link
+    const twitterLink = screen.getByText(`@${mockData[0].source}`).closest('a')
+
+    expect(twitterLink).toBeInTheDocument()
+    expect(twitterLink).toHaveAttribute('href', `${TWITTER_LINK}/${mockData[0].source}`)
+
+    // YouTube link
+    const youtubeLink = screen.getByText(mockData[1].source).closest('a')
+
+    expect(youtubeLink).toBeInTheDocument()
+    expect(youtubeLink).toHaveAttribute('href', mockData[1].source)
+
+    // RSS link
+    const rssLink = screen.getByText(mockData[2].source).closest('a')
+
+    expect(rssLink).toBeInTheDocument()
+    expect(rssLink).toHaveAttribute('href', mockData[2].source)
+  })
+
+  it('should display the most recently added source at the top', () => {
+    render(<Table canEdit={false} data={mockData} />)
+
+    const rows = screen.getAllByRole('row')
+    const firstRow = rows[1] as HTMLTableRowElement // Type assertion here
+
+    const expectedSourceTypeText = sourcesMapper[mockData[0].source_type]
+    const sourceTypeCell = within(firstRow.cells[1]).getByText(expectedSourceTypeText)
+
+    let sourceCellText = mockData[0].source
+
+    if (mockData[0].source_type === TWITTER_HANDLE) {
+      sourceCellText = '@' + sourceCellText // Adjust for Twitter handles
+    }
+
+    const sourceCell = within(firstRow.cells[2]).getByText(sourceCellText)
+
+    expect(sourceTypeCell).toBeInTheDocument()
+    expect(sourceCell).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
### Problem:
Currently, our application allows linking out to `Twitter handles` and `RSS feeds` directly from the source table. However, `YouTube channel` links are not yet implemented, causing inconsistency in user experience and limiting the accessibility of `YouTube channel` sources directly from the application.

### Expected Behavior:
All source types, including `Twitter handles`, `YouTube channels`, and `RSS feeds`, should have a clickable link style. Clicking on these links should take the user directly to the respective external pages in a new browser tab. This feature enhances user engagement and simplifies navigation to these external sources.

## Issue ticket number and link:
- **Ticket Number:** [ 759 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/759 ]

### Solution:
Implemented the functionality to allow `YouTube channels` to be linked out to the `browser`. This was achieved by extending the existing logic that renders `Twitter` and `RSS` links to also include `YouTube channels`.

### Changes:
- Modified the rendering logic in the Table component to include `YOUTUBE_CHANNEL` as a condition. Now, if the source type is a YouTube channel, it gets rendered as a clickable link.
- Updated the `StyledLink` component usage to handle YouTube channel links appropriately, ensuring they open in a new browser tab.

### Evidence:
 Please see the attached video as evidence.
- Demo: [Link](https://www.loom.com/share/8b0e7d6fa59b44f0bb30e9b5ee6e7bd0)

### Testing:
- **Component Tests:** Added new tests in `SourcesTableModal/SourcesView/Sources/Table/__test__` to verify that all source types (Twitter, RSS, YouTube) are correctly rendered as clickable links.
- **Order Test:** Included a test to ensure that the most recently added source appears at the top of the list.
- **Link Out Test**: Added tests to confirm that each source type link correctly redirects to the respective external page.
