### PR TITLE
fix: url validation on add content modal

### DIFF
--- a/src/components/AddContentModal/SourceStep/index.tsx
+++ b/src/components/AddContentModal/SourceStep/index.tsx
@@ -5,7 +5,7 @@ import { Flex } from '~/components/common/Flex'
 import { Text } from '~/components/common/Text'
 import { TextInput } from '~/components/common/TextInput'
 import { LINK, requiredRule } from '~/constants'
-import { twitterOrYoutubeRegexOrMp3 } from './utils'
+import { sourceUrlRegex, validateSourceURL } from './utils'
 
 type Props = {
   type: string
@@ -32,8 +32,11 @@ export const SourceStep: FC<Props> = ({ type, onNextStep, allowNextStep }) => (
           ...(type !== LINK
             ? {
                 pattern: {
-                  message: 'You must enter a valid YouTube, Twitter Space or mp3 link.',
-                  value: twitterOrYoutubeRegexOrMp3,
+                  message: 'Please enter a valid URL',
+                  value: sourceUrlRegex,
+                },
+                validate: {
+                  source: validateSourceURL,
                 },
               }
             : {}),

--- a/src/components/AddContentModal/SourceStep/index.tsx
+++ b/src/components/AddContentModal/SourceStep/index.tsx
@@ -10,10 +10,10 @@ import { twitterOrYoutubeRegexOrMp3 } from './utils'
 type Props = {
   type: string
   onNextStep: () => void
-  value?: string
+  allowNextStep?: boolean
 }
 
-export const SourceStep: FC<Props> = ({ type, onNextStep, value }) => (
+export const SourceStep: FC<Props> = ({ type, onNextStep, allowNextStep }) => (
   <Flex>
     <Flex align="center" direction="row" justify="space-between" mb={18}>
       <Flex align="center" direction="row">
@@ -29,7 +29,7 @@ export const SourceStep: FC<Props> = ({ type, onNextStep, value }) => (
         placeholder="Paste your url here..."
         rules={{
           ...requiredRule,
-          ...(type === LINK
+          ...(type !== LINK
             ? {
                 pattern: {
                   message: 'You must enter a valid YouTube, Twitter Space or mp3 link.',
@@ -41,7 +41,7 @@ export const SourceStep: FC<Props> = ({ type, onNextStep, value }) => (
       />
     </Flex>
     <Flex>
-      <Button color="secondary" disabled={!value} onClick={onNextStep} size="large" variant="contained">
+      <Button color="secondary" disabled={!allowNextStep} onClick={onNextStep} size="large" variant="contained">
         Next
       </Button>
     </Flex>

--- a/src/components/AddContentModal/SourceStep/utils/__tests__/index.ts
+++ b/src/components/AddContentModal/SourceStep/utils/__tests__/index.ts
@@ -1,4 +1,4 @@
-import { twitterOrYoutubeRegexOrMp3 } from '..'
+import { twitterOrYoutubeRegexOrMp3, validateSourceURL } from '..'
 
 describe('twitterOrYoutubeRegexOrMp3', () => {
   const regex = new RegExp(twitterOrYoutubeRegexOrMp3)
@@ -30,5 +30,17 @@ describe('twitterOrYoutubeRegexOrMp3', () => {
     expect(regex.test('www.idkwhat.mp3')).toBe(true)
     expect(regex.test('idkwhat.org')).toBe(false)
     expect(regex.test('facebook.com')).toBe(false)
+  })
+})
+
+describe('validateSourceURL', () => {
+  it('should assert we can check for a valid source', () => {
+    expect(validateSourceURL('https://twitter.com/i/spaces/1zqKVqwrVzlxB?s=20')).toBe(true)
+    expect(validateSourceURL('https://twitter.com/@Ekep-Obasi')).toBe(false)
+    expect(validateSourceURL('youtube.com/watch?v=D900-udw9Dw&ab_channel=SwanBitcoin')).toBe(true)
+    expect(validateSourceURL('https://youtube.com/live/8djflewrio')).toBe(false)
+    expect(validateSourceURL('https://google.com')).toBe(false)
+    expect(validateSourceURL('frontendmasters.com')).toBe(false)
+    expect(validateSourceURL('www/idkwhat.mp3')).toBe(true)
   })
 })

--- a/src/components/AddContentModal/SourceStep/utils/__tests__/index.ts
+++ b/src/components/AddContentModal/SourceStep/utils/__tests__/index.ts
@@ -1,46 +1,36 @@
-import { twitterOrYoutubeRegexOrMp3, validateSourceURL } from '..'
+import { sourceUrlRegex, validateSourceURL } from '..'
 
-describe('twitterOrYoutubeRegexOrMp3', () => {
-  const regex = new RegExp(twitterOrYoutubeRegexOrMp3)
+describe('sourceUrlRegex', () => {
+  const regex = new RegExp(sourceUrlRegex)
 
-  it('should assert we can check for twitter spaces regex', async () => {
+  it('should assert we can check for a valid url', async () => {
     expect(regex.test('https://twitter.com/i/spaces/1zqKVqwrVzlxB?s=20')).toBe(true)
     expect(regex.test('twitter.com/i/spaces/1zqKVqwrVzlxB?s=20')).toBe(true)
-    expect(regex.test('twitter.com')).toBe(false)
-    expect(regex.test('https://twitter.com')).toBe(false)
-    expect(regex.test('www.twitter.com')).toBe(false)
-    expect(regex.test('twitter.org')).toBe(false)
-    expect(regex.test('facebook.com')).toBe(false)
-  })
-
-  it('should assert we can check for youtube regex', async () => {
+    expect(regex.test('twitter.com')).toBe(true)
+    expect(regex.test('https://twitter.com')).toBe(true)
+    expect(regex.test('www.twitter.com')).toBe(true)
+    expect(regex.test('twitter.org')).toBe(true)
+    expect(regex.test('facebook.com')).toBe(true)
     expect(regex.test('https://www.youtube.com/watch?v=D900-udw9Dw&ab_channel=SwanBitcoin')).toBe(true)
     expect(regex.test('www.youtube.com/watch?v=D900-udw9Dw&ab_channel=SwanBitcoin')).toBe(true)
     expect(regex.test('youtube.com/watch?v=D900-udw9Dw&ab_channel=SwanBitcoin')).toBe(true)
-    expect(regex.test('youtube.com')).toBe(false)
-    expect(regex.test('https://youtube.com')).toBe(false)
-    expect(regex.test('www.youtube.com')).toBe(false)
-    expect(regex.test('youtube.org')).toBe(false)
-    expect(regex.test('facebook.com')).toBe(false)
-  })
-
-  it('should assert we can check for mp3 regex', async () => {
-    expect(regex.test('idkwhat.mp3')).toBe(true)
-    expect(regex.test('https://idkwhat.mp3')).toBe(true)
-    expect(regex.test('www.idkwhat.mp3')).toBe(true)
-    expect(regex.test('idkwhat.org')).toBe(false)
-    expect(regex.test('facebook.com')).toBe(false)
+    expect(regex.test('youtube.com')).toBe(true)
+    expect(regex.test('https://youtube.com')).toBe(true)
+    expect(regex.test('www.youtube.com')).toBe(true)
+    expect(regex.test('youtube.org')).toBe(true)
+    expect(regex.test('@tomsmith')).toBe(false)
+    expect(regex.test('389sdfsdfjk')).toBe(false)
   })
 })
 
 describe('validateSourceURL', () => {
   it('should assert we can check for a valid source', () => {
     expect(validateSourceURL('https://twitter.com/i/spaces/1zqKVqwrVzlxB?s=20')).toBe(true)
-    expect(validateSourceURL('https://twitter.com/@Ekep-Obasi')).toBe(false)
+    expect(validateSourceURL('https://twitter.com/@Ekep-Obasi')).toBe(true)
     expect(validateSourceURL('youtube.com/watch?v=D900-udw9Dw&ab_channel=SwanBitcoin')).toBe(true)
-    expect(validateSourceURL('https://youtube.com/live/8djflewrio')).toBe(false)
-    expect(validateSourceURL('https://google.com')).toBe(false)
-    expect(validateSourceURL('frontendmasters.com')).toBe(false)
-    expect(validateSourceURL('www/idkwhat.mp3')).toBe(true)
+    expect(validateSourceURL('https://youtube.com/live/8djflewrio')).toBe(true)
+    expect(validateSourceURL('https://google.com')).toBe(true)
+    expect(validateSourceURL('frontendmasters.com')).toBe(true)
+    expect(validateSourceURL('www/idkwhat.mp3')).toBe(false)
   })
 })

--- a/src/components/AddContentModal/SourceStep/utils/index.ts
+++ b/src/components/AddContentModal/SourceStep/utils/index.ts
@@ -1,11 +1,11 @@
 // This regex is specifically for youtube videos, twitter spaces and mp3 links
-export const twitterOrYoutubeRegexOrMp3 =
-  /^(?:(?:https?:\/\/)?(?:www\.)?(?:youtube\.com\/(?:watch\?v=|embed\/)|youtu\.be\/)[\w-]{11}(?:\S*)?|(?:https?:\/\/)?(?:www\.)?twitter\.com\/i\/spaces\/\d+.*$|.+\.mp3)$/i
+export const sourceUrlRegex =
+  /^(https?:\/\/)?(((?:[a-zA-Z\d](?:[a-zA-Z\d-]*[a-zA-Z\d])*)\.)+[a-zA-Z]{2,}|((\d{1,3}\.){3}\d{1,3}))(:\d+)?(\/[-a-zA-Z\d%_.~+]*)*(\?[;&a-zA-Z\d%_.~+=-]*)?(#[-a-zA-Z\d_]*)?(@[a-zA-Z\d-]+)?$/i
 
 export function validateSourceURL(input: string) {
-  if (twitterOrYoutubeRegexOrMp3.test(input)) {
+  if (sourceUrlRegex.test(input)) {
     return true
   }
-  
+
   return false
 }

--- a/src/components/AddContentModal/SourceStep/utils/index.ts
+++ b/src/components/AddContentModal/SourceStep/utils/index.ts
@@ -1,3 +1,11 @@
 // This regex is specifically for youtube videos, twitter spaces and mp3 links
 export const twitterOrYoutubeRegexOrMp3 =
   /^(?:(?:https?:\/\/)?(?:www\.)?(?:youtube\.com\/(?:watch\?v=|embed\/)|youtu\.be\/)[\w-]{11}(?:\S*)?|(?:https?:\/\/)?(?:www\.)?twitter\.com\/i\/spaces\/\d+.*$|.+\.mp3)$/i
+
+export function validateSourceURL(input: string) {
+  if (twitterOrYoutubeRegexOrMp3.test(input)) {
+    return true
+  }
+  
+  return false
+}

--- a/src/components/AddContentModal/index.tsx
+++ b/src/components/AddContentModal/index.tsx
@@ -24,6 +24,7 @@ import { LocationStep } from './LocationStep'
 import { SourceStep } from './SourceStep'
 import { SourceTypeStep } from './SourceTypeStep'
 import { getInputType, isSource, twitterHandlePattern } from './utils'
+import { validateSourceURL } from './SourceStep/utils'
 
 export type FormData = {
   input: string
@@ -164,6 +165,8 @@ export const AddContentModal = () => {
 
   const source = watch('source')
 
+  const isValidSource = type === LINK && validateSourceURL(sourceValue)
+
   useEffect(() => {
     setValue('inputType', getInputType(source))
   }, [source, setValue])
@@ -196,7 +199,7 @@ export const AddContentModal = () => {
     <BaseModal id="addContent" kind="small" onClose={close} preventOutsideClose>
       <FormProvider {...form}>
         <form id="add-node-form" onSubmit={onSubmit}>
-          {currentStep === 0 && <SourceStep onNextStep={onNextStep} type={type} value={sourceValue} />}
+          {currentStep === 0 && <SourceStep allowNextStep={isValidSource} onNextStep={onNextStep} type={type} />}
           {currentStep === 1 && (
             <>
               {!isSource(type) ? (

--- a/src/components/AddContentModal/index.tsx
+++ b/src/components/AddContentModal/index.tsx
@@ -165,7 +165,7 @@ export const AddContentModal = () => {
 
   const source = watch('source')
 
-  const isValidSource = type === LINK && validateSourceURL(sourceValue)
+  const isValidSource = validateSourceURL(sourceValue)
 
   useEffect(() => {
     setValue('inputType', getInputType(source))


### PR DESCRIPTION
### Ticket №: 
closes #807

### Problem:

The problem was that on the Add Content Modal all urls inputs which are not valid Youtube videos, Twitterspaces or MP3 urls still pass

### Solution:

I have added a check for whether the source passed is valid before you can proceed to the next step
I have added new test in tests file for valid source check

### Changes:
https://www.loom.com/share/567ebb08852c4f5bae313db138a53d3c


