### PR TITLE
feat: add skip_cache param when tapping `See Latest` button

### DIFF
--- a/src/components/App/SideBar/Latest/index.tsx
+++ b/src/components/App/SideBar/Latest/index.tsx
@@ -1,9 +1,9 @@
 import { Button } from '@mui/material'
 import { memo } from 'react'
 import styled from 'styled-components'
-import { Flex } from '~/components/common/Flex'
 import BrowseGalleryIcon from '~/components/Icons/BrowseGalleryIcon'
 import DownloadIcon from '~/components/Icons/DownloadIcon'
+import { Flex } from '~/components/common/Flex'
 import { useDataStore } from '~/stores/useDataStore'
 import { useUserStore } from '~/stores/useUserStore'
 import { colors } from '~/utils/colors'
@@ -16,14 +16,14 @@ type Props = {
 // eslint-disable-next-line no-underscore-dangle
 const _View = ({ isSearchResult }: Props) => {
   const [nodeCount, setNodeCount, setBudget] = useUserStore((s) => [s.nodeCount, s.setNodeCount, s.setBudget])
-  const [fetchData] = [useDataStore((s) => s.fetchData)]
+  const [fetchData] = useDataStore((s) => [s.fetchData])
 
   const getLatest = async () => {
     if (nodeCount < 1) {
       return
     }
 
-    await fetchData(setBudget)
+    await fetchData(setBudget, { skip_cache: 'true' })
     setNodeCount('CLEAR')
   }
 

--- a/src/components/App/SideBar/Relevance/index.tsx
+++ b/src/components/App/SideBar/Relevance/index.tsx
@@ -22,8 +22,7 @@ export const Relevance = ({ isSearchResult }: Props) => {
 
   const [setSelectedNode, setSelectedTimestamp] = useDataStore((s) => [s.setSelectedNode, s.setSelectedTimestamp])
 
-  const [setSidebarOpen] = useAppStore((s) => [s.setSidebarOpen])
-  const setRelevanceSelected = useAppStore((s) => s.setRelevanceSelected)
+  const [setSidebarOpen, setRelevanceSelected] = useAppStore((s) => [s.setSidebarOpen, s.setRelevanceSelected])
 
   const [currentPage, setCurrentPage] = useState(0)
 
@@ -32,12 +31,12 @@ export const Relevance = ({ isSearchResult }: Props) => {
   const startSlice = currentPage * pageSize
   const endSlice = startSlice + pageSize
 
-  const hasNext = filteredNodes.length - 1 > endSlice
+  const hasNext = filteredNodes && filteredNodes.length > 0 ? filteredNodes.length - 1 > endSlice : false
 
   const isMobile = useIsMatchBreakpoint('sm', 'down')
 
   const currentNodes = useMemo(
-    () => [...filteredNodes].sort((a, b) => (b.date || 0) - (a.date || 0)).slice(0, endSlice),
+    () => filteredNodes && [...filteredNodes].sort((a, b) => (b.date || 0) - (a.date || 0)).slice(0, endSlice),
     [filteredNodes, endSlice],
   )
 
@@ -55,7 +54,7 @@ export const Relevance = ({ isSearchResult }: Props) => {
   return (
     <>
       <ScrollView ref={scrollViewRef} id="search-result-list" shrink={1}>
-        {currentNodes.map((n, index) => {
+        {(currentNodes ?? []).map((n, index) => {
           const {
             image_url: imageUrl,
             date,

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -93,7 +93,7 @@ export const App = () => {
   })
 
   const runSearch = useCallback(async () => {
-    await fetchData(setBudget, searchTerm)
+    await fetchData(setBudget, { word: searchTerm ?? '' })
     setSidebarOpen(true)
 
     if (searchTerm) {

--- a/src/stores/useDataStore/index.ts
+++ b/src/stores/useDataStore/index.ts
@@ -9,7 +9,13 @@ export type GraphStyle = 'sphere' | 'force' | 'split' | 'earth'
 
 export const graphStyles: GraphStyle[] = ['sphere', 'force', 'split', 'earth']
 
-type DataStore = {
+export type FetchNodeParams = {
+  word?: string
+  skip_cache?: string
+  free?: string
+}
+
+export type DataStore = {
   scrollEventsDisabled: boolean
   categoryFilter: NodeType | null
   disableCameraRotation: boolean
@@ -41,7 +47,7 @@ type DataStore = {
   setScrollEventsDisabled: (scrollEventsDisabled: boolean) => void
   setCategoryFilter: (categoryFilter: NodeType | null) => void
   setDisableCameraRotation: (rotation: boolean) => void
-  fetchData: (setBudget: (value: number | null) => void, search?: string | null) => void
+  fetchData: (setBudget: (value: number | null) => void, params?: FetchNodeParams) => void
   setData: (data: GraphData) => void
   setGraphStyle: (graphStyle: GraphStyle) => void
   setGraphRadius: (graphRadius?: number | null) => void
@@ -115,16 +121,16 @@ const defaultData: Omit<
 
 export const useDataStore = create<DataStore>((set, get) => ({
   ...defaultData,
-  fetchData: async (setBudget, search) => {
+  fetchData: async (setBudget, params) => {
     if (get().isFetching) {
       return
     }
 
     set({ isFetching: true, sphinxModalIsOpen: true })
 
-    const data = await fetchGraphData(search || '', get().graphStyle, setBudget)
+    const data = await fetchGraphData(get().graphStyle, setBudget, params ?? {})
 
-    if (search) {
+    if (params?.word) {
       await saveSearchTerm()
     }
 


### PR DESCRIPTION
### Ticket №:

closes #809 

### Testing:

- [x] Add param to latest endpoint call when pressing See Latest button called skip_cache = true
- [x] Add test for the this button to render correctly when new data added
- [x] Add test that does not show the latest button when there are no nodes
- [x] Add tests for this button that on click it calls latest endpoint with param