### PR TITLE
moving apiFromSwarmHost

### DIFF
--- a/src/components/App/Providers/Socket/index.tsx
+++ b/src/components/App/Providers/Socket/index.tsx
@@ -1,7 +1,7 @@
 // SocketProvider.tsx
 import { FC, ReactNode } from 'react'
 import { io } from 'socket.io-client'
-import { API_URL } from '../../../../utils/apiUrlFromSwarmHost/index'
+import { API_URL } from '~/utils/apiUrlFromSwarmHost'
 import SocketContext from './SocketContext'
 
 interface SocketProviderProps {

--- a/src/components/App/Providers/Socket/index.tsx
+++ b/src/components/App/Providers/Socket/index.tsx
@@ -1,7 +1,7 @@
 // SocketProvider.tsx
 import { FC, ReactNode } from 'react'
 import { io } from 'socket.io-client'
-import { API_URL } from '../../../../../src/utils/apiUrlFromSwarmHost/index'
+import { API_URL } from '../../../../utils/apiUrlFromSwarmHost/index'
 import SocketContext from './SocketContext'
 
 interface SocketProviderProps {

--- a/src/components/App/Providers/Socket/index.tsx
+++ b/src/components/App/Providers/Socket/index.tsx
@@ -1,7 +1,7 @@
 // SocketProvider.tsx
 import { FC, ReactNode } from 'react'
 import { io } from 'socket.io-client'
-import { API_URL } from '~/constants'
+import { API_URL } from '../../../../../src/utils/apiUrlFromSwarmHost/index'
 import SocketContext from './SocketContext'
 
 interface SocketProviderProps {

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,7 +1,8 @@
 /* eslint-disable no-console */
 import moment from 'moment'
+import { API_URL } from '~/utils/apiUrlFromSwarmHost'
 
-const { origin, host } = window.location
+const { origin } = window.location
 
 moment.relativeTimeThreshold('h', 24)
 
@@ -21,35 +22,7 @@ export const isDevelopment = !!(
   origin === 'https://sphinx-jarvis-david.sphinx1.repl.co'
 )
 
-const getUrlFormEnv = () => import.meta.env.VITE_APP_API_URL
-
-export const API_URL = getUrlFormEnv() || apiUrlFromSwarmHost() || 'https://knowledge-graph.sphinx.chat'
-
 export const isChileGraph = API_URL.includes('boltwall')
-
-function apiUrlFromSwarmHost(): string | undefined {
-  // for swarm deployments, always point to "boltwall"
-  // for now, only if the URL contains "swarm"
-  const originUrl = window.location.origin
-
-  let url = originUrl
-
-  if (host.includes('swarm')) {
-    if (host.startsWith('nav')) {
-      const hostArray = host.split('.')
-
-      hostArray[0] = 'boltwall'
-
-      const finalHost = hostArray.join('.')
-
-      url = `https://${finalHost}`
-    }
-  } else if (originUrl === 'https://second-brain.sphinx.chat' || origin.includes('localhost')) {
-    url = 'https://knowledge-graph.sphinx.chat'
-  }
-
-  return `${url}/api`
-}
 
 export const AWS_IMAGE_BUCKET_URL = 'https://stakwork-uploads.s3.amazonaws.com/'
 export const CLOUDFRONT_IMAGE_BUCKET_URL = 'https://d1gd7b7slyku8k.cloudfront.net/'

--- a/src/network/api/index.ts
+++ b/src/network/api/index.ts
@@ -1,5 +1,5 @@
-import { API_URL } from '~/constants'
 import { getSignedMessageFromRelay } from '~/utils'
+import { API_URL } from '~/utils/apiUrlFromSwarmHost'
 
 const request = async <Res>(url: string, config?: RequestInit): Promise<Res> => {
   const admin = localStorage.getItem('admin')

--- a/src/utils/apiUrlFromSwarmHost/__tests__/index.ts
+++ b/src/utils/apiUrlFromSwarmHost/__tests__/index.ts
@@ -1,0 +1,35 @@
+// Import the function to test
+import { apiUrlFromSwarmHost } from '../index.ts';
+
+// Mocking global.window and global.location
+function mockWindowLocation(url) {
+  delete global.window.location;
+  global.window = Object.create(window);
+  global.window.location = new URL(url);
+  global.window.host = global.window.location.host;
+  global.window.origin = global.window.location.origin;
+}
+
+describe('apiUrlFromSwarmHost', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns "https://knowledge-graph.sphinx.chat/api" for the URL "https://second-brain.sphinx.chat"', () => {
+    mockWindowLocation('https://second-brain.sphinx.chat');
+    expect(apiUrlFromSwarmHost()).toBe('https://knowledge-graph.sphinx.chat/api');
+  });
+
+  it('returns "https://knowledge-graph.sphinx.chat/api" for a URL containing "localhost"', () => {
+    mockWindowLocation('http://localhost:3000');
+    expect(apiUrlFromSwarmHost()).toBe('https://knowledge-graph.sphinx.chat/api');
+  });
+
+  it('returns the original URL appended with /api for a URL not containing "swarm" and not hardcoded', () => {
+    const nonSwarmUrl = 'https://example.com';
+    mockWindowLocation(nonSwarmUrl);
+    expect(apiUrlFromSwarmHost()).toBe(`${nonSwarmUrl}/api`);
+  });
+
+});
+

--- a/src/utils/apiUrlFromSwarmHost/__tests__/index.ts
+++ b/src/utils/apiUrlFromSwarmHost/__tests__/index.ts
@@ -1,7 +1,5 @@
-// Import the function to test
 import { apiUrlFromSwarmHost } from '../index.ts'
 
-// Mocking global.window and global.location
 function mockWindowLocation(url) {
   delete global.window.location
   global.window = Object.create(window)

--- a/src/utils/apiUrlFromSwarmHost/__tests__/index.ts
+++ b/src/utils/apiUrlFromSwarmHost/__tests__/index.ts
@@ -24,7 +24,8 @@ describe('apiUrlFromSwarmHost', () => {
   })
 
   it('returns the original URL appended with /api for a URL not containing "swarm" and not hardcoded', () => {
-    const nonSwarmUrl = 'https://example.com'
+    const nonSwarmUrl = 'https://knowledge-graph.sphinx.chat'
+
     mockWindowLocation(nonSwarmUrl)
     expect(apiUrlFromSwarmHost()).toBe(`${nonSwarmUrl}/api`)
   })

--- a/src/utils/apiUrlFromSwarmHost/__tests__/index.ts
+++ b/src/utils/apiUrlFromSwarmHost/__tests__/index.ts
@@ -1,35 +1,33 @@
 // Import the function to test
-import { apiUrlFromSwarmHost } from '../index.ts';
+import { apiUrlFromSwarmHost } from '../index.ts'
 
 // Mocking global.window and global.location
 function mockWindowLocation(url) {
-  delete global.window.location;
-  global.window = Object.create(window);
-  global.window.location = new URL(url);
-  global.window.host = global.window.location.host;
-  global.window.origin = global.window.location.origin;
+  delete global.window.location
+  global.window = Object.create(window)
+  global.window.location = new URL(url)
+  global.window.host = global.window.location.host
+  global.window.origin = global.window.location.origin
 }
 
 describe('apiUrlFromSwarmHost', () => {
   afterEach(() => {
-    jest.restoreAllMocks();
-  });
+    jest.restoreAllMocks()
+  })
 
   it('returns "https://knowledge-graph.sphinx.chat/api" for the URL "https://second-brain.sphinx.chat"', () => {
-    mockWindowLocation('https://second-brain.sphinx.chat');
-    expect(apiUrlFromSwarmHost()).toBe('https://knowledge-graph.sphinx.chat/api');
-  });
+    mockWindowLocation('https://second-brain.sphinx.chat')
+    expect(apiUrlFromSwarmHost()).toBe('https://knowledge-graph.sphinx.chat/api')
+  })
 
   it('returns "https://knowledge-graph.sphinx.chat/api" for a URL containing "localhost"', () => {
-    mockWindowLocation('http://localhost:3000');
-    expect(apiUrlFromSwarmHost()).toBe('https://knowledge-graph.sphinx.chat/api');
-  });
+    mockWindowLocation('http://localhost:3000')
+    expect(apiUrlFromSwarmHost()).toBe('https://knowledge-graph.sphinx.chat/api')
+  })
 
   it('returns the original URL appended with /api for a URL not containing "swarm" and not hardcoded', () => {
-    const nonSwarmUrl = 'https://example.com';
-    mockWindowLocation(nonSwarmUrl);
-    expect(apiUrlFromSwarmHost()).toBe(`${nonSwarmUrl}/api`);
-  });
-
-});
-
+    const nonSwarmUrl = 'https://example.com'
+    mockWindowLocation(nonSwarmUrl)
+    expect(apiUrlFromSwarmHost()).toBe(`${nonSwarmUrl}/api`)
+  })
+})

--- a/src/utils/apiUrlFromSwarmHost/index.ts
+++ b/src/utils/apiUrlFromSwarmHost/index.ts
@@ -4,7 +4,7 @@ const getUrlFormEnv = () => import.meta.env.VITE_APP_API_URL
 
 export const API_URL = getUrlFormEnv() || apiUrlFromSwarmHost() || 'https://knowledge-graph.sphinx.chat'
 
-function apiUrlFromSwarmHost(): string | undefined {
+export function apiUrlFromSwarmHost(): string | undefined {
   // for swarm deployments, always point to "boltwall"
   // for now, only if the URL contains "swarm"
   const originUrl = window.location.origin

--- a/src/utils/apiUrlFromSwarmHost/index.ts
+++ b/src/utils/apiUrlFromSwarmHost/index.ts
@@ -1,0 +1,29 @@
+const { origin, host } = window.location
+
+const getUrlFormEnv = () => import.meta.env.VITE_APP_API_URL
+
+export const API_URL = getUrlFormEnv() || apiUrlFromSwarmHost() || 'https://knowledge-graph.sphinx.chat'
+
+function apiUrlFromSwarmHost(): string | undefined {
+  // for swarm deployments, always point to "boltwall"
+  // for now, only if the URL contains "swarm"
+  const originUrl = window.location.origin
+
+  let url = originUrl
+
+  if (host.includes('swarm')) {
+    if (host.startsWith('nav')) {
+      const hostArray = host.split('.')
+
+      hostArray[0] = 'boltwall'
+
+      const finalHost = hostArray.join('.')
+
+      url = `https://${finalHost}`
+    }
+  } else if (originUrl === 'https://second-brain.sphinx.chat' || origin.includes('localhost')) {
+    url = 'https://knowledge-graph.sphinx.chat'
+  }
+
+  return `${url}/api`
+}


### PR DESCRIPTION
### Ticket №:
https://github.com/stakwork/sphinx-nav-fiber/issues/828

closes https://github.com/stakwork/sphinx-nav-fiber/issues/828
### Problem:

apiUrlFromSwarmHost to another file 

### Solution:
created new folder  under /utils/apiUrlFromSwarmHost

### Testing:
yet to be added 

### Notes:

any additional notes
