### PR TITLE
[Component Tests] Auth

### DIFF
--- a/src/components/Auth/__tests__/index.tsx
+++ b/src/components/Auth/__tests__/index.tsx
@@ -1,0 +1,166 @@
+import '@testing-library/jest-dom'
+import { render, screen, waitFor } from '@testing-library/react'
+import { afterEach } from 'node:test'
+import React from 'react'
+import * as sphinx from 'sphinx-bridge'
+import { Auth } from '..'
+import * as authNetwork from '../../../network/auth'
+import * as useUserStoreModule from '../../../stores/useUserStore'
+import * as utils from '../../../utils'
+
+jest.mock('sphinx-bridge')
+jest.mock('~/network/auth')
+jest.mock('../../../utils')
+
+jest.mock('../../../stores/useUserStore')
+
+const [mockSetBudget, mockSetIsAdmin, mockSetPubKey] = [jest.fn(), jest.fn(), jest.fn()]
+
+const message = 'This is a private Graph, Contact Admin'
+
+describe('Auth Component', () => {
+  beforeAll(() => {
+    jest.clearAllMocks()
+    localStorage.clear()
+    sessionStorage.clear()
+
+    useUserStoreModule.useUserStore.mockImplementation(() => [mockSetBudget, mockSetIsAdmin, mockSetPubKey])
+
+    jest.spyOn(utils, 'executeIfProd').mockImplementation(async (cb) => {
+      await cb()
+    })
+  })
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  test('should set authenticated state to true upon successful authentication', async () => {
+    const mockSetAuthenticated = jest.fn()
+
+    sphinx.enable.mockResolvedValue({ pubkey: 'testPubKey' })
+    authNetwork.getIsAdmin.mockResolvedValue({ data: { isAdmin: false, isPublic: true } })
+    utils.getSignedMessageFromRelay.mockResolvedValue({ message: 'testMessage', signature: 'testSignature' })
+
+    render(<Auth setAuthenticated={mockSetAuthenticated} />)
+
+    jest.advanceTimersByTime(5000)
+
+    await waitFor(() => expect(mockSetAuthenticated).toHaveBeenCalledWith(true))
+  })
+
+  test('should update appropriate state and local storage if user is an admin', async () => {
+    sphinx.enable.mockResolvedValue({ pubkey: 'testPubKey' })
+    authNetwork.getIsAdmin.mockResolvedValue({ data: { isAdmin: true } })
+    utils.getSignedMessageFromRelay.mockResolvedValue({ message: 'testMessage', signature: 'testSignature' })
+
+    render(<Auth setAuthenticated={jest.fn()} />)
+
+    jest.advanceTimersByTime(5000)
+
+    await waitFor(() => expect(mockSetIsAdmin).toHaveBeenCalledWith(true))
+    await waitFor(() => expect(localStorage.getItem('admin')).not.toBeNull())
+  })
+
+  test('should render the unauthorized access message if user is not authorized', async () => {
+    sphinx.enable.mockResolvedValue({ pubkey: 'testPubKey' })
+    authNetwork.getIsAdmin.mockResolvedValue({ data: { isAdmin: false, isPublic: false, isMember: false } })
+    utils.getSignedMessageFromRelay.mockResolvedValue({ message: 'testMessage', signature: 'testSignature' })
+
+    render(<Auth setAuthenticated={jest.fn()} />)
+
+    jest.advanceTimersByTime(5000)
+
+    await waitFor(() => expect(screen.getByText(message)).toBeInTheDocument())
+  })
+
+  test('the unauthorized state is correctly set when the user lacks proper credentials', async () => {
+    const mockSetAuthenticated = jest.fn()
+
+    sphinx.enable.mockResolvedValue({ pubkey: 'testPubKey' })
+    authNetwork.getIsAdmin.mockResolvedValue({ data: { isAdmin: false, isPublic: true, isMember: false } })
+    utils.getSignedMessageFromRelay.mockResolvedValue({ message: 'testMessage' })
+
+    render(<Auth setAuthenticated={mockSetAuthenticated} />)
+
+    jest.advanceTimersByTime(5000)
+
+    await waitFor(() => expect(mockSetAuthenticated).toHaveBeenCalledWith(true))
+  })
+
+  test('test unsuccessful attempts to enable Sphinx', async () => {
+    const mockSetAuthenticated = jest.fn()
+
+    sphinx.enable.mockResolvedValue(null)
+    authNetwork.getIsAdmin.mockResolvedValue({ data: { isAdmin: false, isPublic: true, isMember: false } })
+    utils.getSignedMessageFromRelay.mockResolvedValue({ message: 'testMessage' })
+
+    render(<Auth setAuthenticated={mockSetAuthenticated} />)
+
+    jest.advanceTimersByTime(5000)
+
+    await waitFor(() => expect(mockSetPubKey).toHaveBeenCalledWith(undefined))
+    await waitFor(() => expect(mockSetAuthenticated).toHaveBeenCalledWith(true))
+  })
+
+  test('test the public key is set correctly on successful Sphinx enablement', async () => {
+    const mockSetAuthenticated = jest.fn()
+
+    sphinx.enable.mockResolvedValue({ pubkey: 'testPubKey' })
+    authNetwork.getIsAdmin.mockResolvedValue({ data: { isAdmin: false, isPublic: true, isMember: false } })
+    utils.getSignedMessageFromRelay.mockResolvedValue({ message: 'testMessage' })
+
+    render(<Auth setAuthenticated={mockSetAuthenticated} />)
+
+    jest.advanceTimersByTime(5000)
+
+    await waitFor(() => expect(mockSetPubKey).toHaveBeenCalledWith('testPubKey'))
+  })
+
+  test('test the public key state is handled correctly on Sphinx enablement failure', async () => {
+    const mockSetAuthenticated = jest.fn()
+
+    sphinx.enable.mockRejectedValue()
+    authNetwork.getIsAdmin.mockResolvedValue({ data: { isAdmin: false, isPublic: true, isMember: false } })
+    utils.getSignedMessageFromRelay.mockResolvedValue({ message: 'testMessage' })
+
+    render(<Auth setAuthenticated={mockSetAuthenticated} />)
+
+    jest.advanceTimersByTime(5000)
+
+    await waitFor(() => expect(mockSetPubKey).toHaveBeenCalledWith(''))
+  })
+
+  test('simulate errors during the authentication process and verify that they are handled gracefully.', async () => {
+    const mockSetAuthenticated = jest.fn()
+
+    sphinx.enable.mockRejectedValue()
+    authNetwork.getIsAdmin.mockResolvedValue({ data: { isAdmin: false, isPublic: true, isMember: false } })
+    utils.getSignedMessageFromRelay.mockRejectedValue()
+
+    render(<Auth setAuthenticated={mockSetAuthenticated} />)
+
+    jest.advanceTimersByTime(5000)
+
+    await waitFor(() => expect(mockSetPubKey).toHaveBeenCalledWith(''))
+    await waitFor(() => expect(mockSetAuthenticated).not.toHaveBeenCalledWith(true))
+  })
+
+  test('displays a loading indicator while the authentication process is ongoing', async () => {
+    sphinx.enable.mockResolvedValue({ pubkey: 'testPubKey' })
+    authNetwork.getIsAdmin.mockResolvedValue({ data: { isAdmin: false, isPublic: false, isMember: false } })
+    utils.getSignedMessageFromRelay.mockResolvedValue({ message: 'testMessage', signature: 'testSignature' })
+
+    render(<Auth setAuthenticated={jest.fn()} />)
+
+    expect(screen.getByTestId('PropagateLoader')).toBeInTheDocument()
+
+    jest.advanceTimersByTime(5000)
+
+    await waitFor(() => expect(screen.queryByTestId('PropagateLoader')).not.toBeInTheDocument())
+  })
+})

--- a/src/components/Auth/index.tsx
+++ b/src/components/Auth/index.tsx
@@ -81,7 +81,13 @@ export const Auth = ({ setAuthenticated }: setAuthenticated) => {
   const message = 'This is a private Graph, Contact Admin'
 
   return (
-    <StyledFlex>{!unAuthorized ? <PropagateLoader color="#909BAA" /> : <StyledText>{message}</StyledText>}</StyledFlex>
+    <StyledFlex>
+      {!unAuthorized ? (
+        <PropagateLoader color="#909BAA" data-testid="PropagateLoader" />
+      ) : (
+        <StyledText>{message}</StyledText>
+      )}
+    </StyledFlex>
   )
 }
 


### PR DESCRIPTION
### Ticket №:

closes #893 

### Solution

add Test for `src/components/Auth/index.tsx`

![image](https://github.com/stakwork/sphinx-nav-fiber/assets/23151576/3fcfd841-6af8-46f1-b00b-761003a5458c)

### Testing

- [x] Verify that upon successful authentication, the authenticated state is set to true.
- [x] Ensure that if the user is an admin, the appropriate state and local storage are updated accordingly.
- [x] Test that if the user is not authorized, the component renders the unauthorized access message.
- [x] Confirm that the unauthorized state is correctly set when the user lacks proper credentials.
- [x] Mock successful and unsuccessful attempts to enable Sphinx.
- [x] Validate that the public key is set correctly on successful Sphinx enablement.
- [x] Ensure that the public key state is handled correctly on Sphinx enablement failure.
- [x] Simulate errors during the authentication process and verify that they are handled gracefully.
- [x] Ensure that a loading indicator is displayed while the authentication process is ongoing.