### PR TITLE
Tapping 'ESC' on any window should close the window 

### DIFF
--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren } from 'react'
+import { PropsWithChildren, useEffect } from 'react'
 import styled, { css, keyframes } from 'styled-components'
 import { Flex } from '~/components/common/Flex'
 import { AvailableModals, useModal } from '~/stores/useModalStore'
@@ -108,6 +108,22 @@ export const BaseModal = ({
 }: Props) => {
   const { visible, close } = useModal(id)
 
+  useEffect(() => {
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.keyCode === 27) {
+        close()
+      }
+    }
+
+    if (visible) {
+      document.addEventListener('keydown', handleEsc)
+    }
+
+    return () => {
+      document.removeEventListener('keydown', handleEsc) // Cleanup
+    }
+  }, [visible, close])
+
   if (!visible) {
     return null
   }
@@ -121,7 +137,6 @@ export const BaseModal = ({
         onClick={(e) => {
           if (!preventOutsideClose) {
             e.stopPropagation()
-
             close()
           }
         }}


### PR DESCRIPTION
### Ticket №:  #960

### Problem:

Tapping ESC on any window/modal should close the window.

### Solution:

Listen for ESC key-down and call onClose each time a modal is visible and ESC has been pressed

https://www.loom.com/share/04c709e239ee4f5ca277d7e68a9155cf?sid=3affb15c-acc7-4604-8c5c-a7998e60a504