### PR TITLE
fix: Topic name disappears when selected

### DIFF
--- a/src/components/Universe/Graph/Cubes/RelevanceBadges/index.tsx
+++ b/src/components/Universe/Graph/Cubes/RelevanceBadges/index.tsx
@@ -108,7 +108,9 @@ export const RelevanceBadges = memo(() => {
       .filter((f) => selectedNodeRelativeIds.includes(f?.ref_id || '') || selectedNode?.ref_id === f?.ref_id)
       .slice(0, maxChildrenDisplayed)
 
-    const badgesToRender = childIds.map((n) => {
+    const nodesToRender = selectedNode ? [...childIds, selectedNode] : childIds
+
+    const badgesToRender = nodesToRender.map((n) => {
       const color = getNodeColorByType(n.node_type || '', true) as string
       const position = new Vector3(n?.x || 0, n?.y || 0, n?.z || 0)
 


### PR DESCRIPTION
### Ticket №:

closes #743

### Problem:

large topic name disappers when a node on graph is selected 

### Preview:

https://www.loom.com/share/497580dcf23b42799b0c7594877ccac8?sid=a7668138-6413-4d06-a4db-60e65c8f0678
