### PR TITLE
feat: Auto select input field 

### DIFF
--- a/src/components/AddItemModal/SourceTypeStep/__tests__/index.tsx
+++ b/src/components/AddItemModal/SourceTypeStep/__tests__/index.tsx
@@ -1,0 +1,32 @@
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import { SourceTypeStep } from '..'
+
+describe('SourceTypeStep', () => {
+  it('renders with initial selected type', () => {
+    const selectedType = 'Corporation'
+
+    render(<SourceTypeStep allowNextStep onNextStep={jest.fn()} onSelectType={jest.fn()} selectedType={selectedType} />)
+
+    const nextBtn = screen.getByRole('button', { name: 'Next' })
+
+    expect(nextBtn).toBeInTheDocument()
+
+    const selectTypeText = screen.getByText('Select Type')
+
+    expect(selectTypeText).toBeInTheDocument()
+
+    const inputField = screen.getByRole('combobox')
+
+    expect(inputField).toHaveValue(selectedType)
+  })
+
+  it('auto selects input field when component is rendered', () => {
+    render(<SourceTypeStep allowNextStep onNextStep={jest.fn()} onSelectType={jest.fn()} selectedType="" />)
+
+    const inputField = screen.getByRole('combobox')
+
+    expect(inputField).toHaveFocus()
+  })
+})

--- a/src/components/AddItemModal/SourceTypeStep/constants.ts
+++ b/src/components/AddItemModal/SourceTypeStep/constants.ts
@@ -1,7 +1,7 @@
 import { TOption } from './types'
 
-export const initialValue = {
-  label: 'Not selected',
+export const initialValue: TOption = {
+  label: '',
   value: '',
 }
 

--- a/src/components/AddItemModal/SourceTypeStep/index.tsx
+++ b/src/components/AddItemModal/SourceTypeStep/index.tsx
@@ -29,7 +29,7 @@ export const SourceTypeStep: FC<Props> = ({ onNextStep, allowNextStep, onSelectT
       </Flex>
 
       <Flex direction="row" mb={20}>
-        <AutoComplete onSelect={onSelect} options={OPTIONS} selectedValue={selectedOption} />
+        <AutoComplete autoFocus onSelect={onSelect} options={OPTIONS} selectedValue={selectedOption} />
       </Flex>
 
       <Flex>

--- a/src/components/common/AutoComplete/index.tsx
+++ b/src/components/common/AutoComplete/index.tsx
@@ -2,7 +2,7 @@ import { CircularProgress } from '@mui/material'
 import Autocomplete from '@mui/material/Autocomplete'
 import Stack from '@mui/material/Stack'
 import TextField from '@mui/material/TextField'
-import { ChangeEvent, FC, SyntheticEvent } from 'react'
+import { ChangeEvent, FC, SyntheticEvent, useEffect, useRef, useState } from 'react'
 import styled from 'styled-components'
 import { colors } from '~/utils'
 import { Flex } from '../Flex'
@@ -20,6 +20,7 @@ type Props = {
   selectedValue?: TAutocompleteOption | null
   handleInputChange?: (val: string) => void
   isLoading?: boolean
+  autoFocus?: boolean
 }
 
 const defaultProps = {
@@ -34,7 +35,18 @@ export const AutoComplete: FC<Props> = ({
   selectedValue = null,
   handleInputChange,
   isLoading = false,
+  autoFocus = false,
 }) => {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [open, setOpen] = useState<boolean>(false)
+
+  useEffect(() => {
+    if (autoFocus && inputRef.current) {
+      inputRef.current.focus()
+      setOpen(true)
+    }
+  }, [autoFocus])
+
   const handleChange = (event: ChangeEvent<object>, newValue: TAutocompleteOption | null) => {
     onSelect(newValue)
   }
@@ -51,10 +63,14 @@ export const AutoComplete: FC<Props> = ({
         id="blur-on-select"
         loading={isLoading}
         onChange={handleChange}
+        onClose={() => setOpen(false)}
         onInputChange={(e: SyntheticEvent<Element, Event>, val) => handleInputChange?.(val)}
+        onOpen={() => setOpen(true)}
+        open={open}
         options={options}
         renderInput={(params) => (
           <StyledInput
+            inputRef={inputRef}
             {...params}
             InputProps={{
               ...params.InputProps,
@@ -70,7 +86,7 @@ export const AutoComplete: FC<Props> = ({
         renderOption={(props, option) => (
           <li {...props}>
             <Flex align="center" direction="row" grow={1} justify="space-between" shrink={1}>
-              <div className="option">{option.label}</div>
+              <div className="option">{option.label !== '' ? option.label : 'Not Selected'}</div>
               {option?.type && <TypeBadge type={option.type} />}
             </Flex>
           </li>


### PR DESCRIPTION
### Ticket №:

closes #976

### Solution:

Automatically focused the input field on the SourceTypeStep of the Add Item Modal

### Changes:

 - [x] Added logic to automatically select the input field upon clicking the "Add Item" button.
 - [x] Configured the input field to have an empty value by default.
 - [x] Change maintains the reusability of the AutoComplete

### Preview 

https://www.loom.com/share/0201f8a137be4ea9ac4d97589dd7e565?sid=d74d2caa-3d41-4a28-82fc-3a3cf412eac8

