### PR TITLE
Added Regex to identify `youtu.be` as audio_video content type

### DIFF
--- a/src/components/AddContentModal/utils/__tests__/index.ts
+++ b/src/components/AddContentModal/utils/__tests__/index.ts
@@ -14,6 +14,14 @@ describe('youtubeRegex', () => {
     expect(getInputType('https://twitter.com/i/spaces/1zqKVqwrVzlxB?s=20')).toBe(LINK)
   })
 
+  it('should assert we can check for youtu.be link regex', async () => {
+    expect(getInputType('https://youtu.be/HfMYOeg79dM')).toBe(LINK)
+  })
+
+  it('should assert we can check for youtu.be link with parameters regex', async () => {
+    expect(getInputType('https://youtu.be/HfMYOeg79dM?t=120')).toBe(LINK)
+  })
+
   it('should assert we can check for twitter tweet regex', async () => {
     expect(getInputType('https://twitter.com/LarryRuane/status/1720496960489095668')).toBe(TWITTER_SOURCE)
   })

--- a/src/components/AddContentModal/utils/index.ts
+++ b/src/components/AddContentModal/utils/index.ts
@@ -4,6 +4,7 @@ export const twitterHandlePattern = /\btwitter\.com\/(?:@)?([\w_]+)(?:$|\?[^/]*$
 
 const youtubeRegex = /(https?:\/\/)?(www\.)?youtube\.com\/watch\?v=([A-Za-z0-9_-]+)/
 const youtubeLiveRegex = /(https?:\/\/)?(www\.)?youtube\.com\/live\/([A-Za-z0-9_-]+)/
+const youtubeShortRegex = /(https?:\/\/)?(www\.)?youtu\.be\/([A-Za-z0-9_-]+)/
 const twitterSpaceRegex = /https:\/\/twitter\.com\/i\/spaces\/([A-Za-z0-9_-]+)/
 const tweetUrlRegex = /https:\/\/twitter\.com\/[^/]+\/status\/(\d+)/
 const mp3Regex = /(https?:\/\/)?([A-Za-z0-9_-]+)\.mp3/
@@ -15,7 +16,14 @@ const genericUrlRegex = /^(https?|ftp):\/\/[^\s/$.?#].[^\s]*$/
 const twitterBroadcastRegex = /https:\/\/twitter\.com\/i\/broadcasts\/([A-Za-z0-9_-]+)/
 
 export function getInputType(source: string) {
-  const linkPatterns = [youtubeLiveRegex, twitterBroadcastRegex, youtubeRegex, twitterSpaceRegex, mp3Regex]
+  const linkPatterns = [
+    youtubeLiveRegex,
+    twitterBroadcastRegex,
+    youtubeRegex,
+    youtubeShortRegex,
+    twitterSpaceRegex,
+    mp3Regex,
+  ]
 
   if (linkPatterns.some((pattern) => pattern.test(source))) {
     return LINK


### PR DESCRIPTION
### Problem:
The current Regex checker for YouTube videos in the `AddContentModal` component does not include support for `youtu.be` URLs. The task is to enhance the Regex checker to recognize youtu.be URLs and treat them as `audio_video` content type.

### Expected Behavior:
- The Regex checker should be updated to include youtu.be URLs.
- The `youtu.be` URLs should be treated as `audio_video`, similar to other YouTube video formats.

## Issue ticket number and link:
- **Ticket Number:** [ 1001 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1001 ]

### Solution:
- Updated the Regex checker in `src/components/AddContentModal/utils/index.ts` to include support for `youtu.be` URLs.
- Modified the handling of youtu.be URLs in `src/components/AddContentModal/index.tsx` to push them as `audio_video` content type.

### Testing:
- Manual testing was conducted to verify that the new integration works as expected.

### Evidence:
 - Please see the attached image as evidence.
 
![image](https://github.com/stakwork/sphinx-nav-fiber/assets/160427254/48813584-dedd-400b-a0e0-b0fccf579889)
