### PR TITLE
Fix: Center refresh Icon on Trending Topics

### DIFF
--- a/src/components/App/SideBar/Trending/index.tsx
+++ b/src/components/App/SideBar/Trending/index.tsx
@@ -280,6 +280,9 @@ const StyledButton = styled(Button)`
     height: 28px;
     .MuiButton-startIcon {
       color: ${colors.white};
+      margin: auto;
+      display: flex;
+      align-items: center;
     }
   }
 `


### PR DESCRIPTION
### Expected Behavior:
- Center refresh Icon on Trending Topics

closes #1037

## Issue ticket number and link:
- **Ticket Number:** [ 1037 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1037 ]

### Evidence:
 - Please see the attached image as evidence.
 
![image](https://github.com/stakwork/sphinx-nav-fiber/assets/160427254/3cb6a945-98d9-4e34-8437-f7731d7e6355)

### Testing:
- Manual testing was conducted to verify that the new integration works as expected.