### PR TITLE
Feature flag queued sources

### DIFF
--- a/src/components/AppNew/ModalsContainer/SourcesTableModal/SourcesView/index.tsx
+++ b/src/components/AppNew/ModalsContainer/SourcesTableModal/SourcesView/index.tsx
@@ -3,6 +3,7 @@ import Tabs from '@mui/material/Tabs'
 import * as React from 'react'
 import styled from 'styled-components'
 import { Flex } from '~/components/common/Flex'
+import { useFeatureFlagStore } from '~/stores/useFeatureFlagStore'
 import { useUserStore } from '~/stores/useUserStore'
 import { colors } from '~/utils/colors'
 import { QueuedSources } from './QueuedSources'
@@ -41,6 +42,7 @@ function a11yProps(index: number) {
 export const SourcesView = () => {
   const [value, setValue] = React.useState(0)
   const [isAdmin] = useUserStore((s) => [s.isAdmin])
+  const [queuedSourcesFlag] = useFeatureFlagStore((s) => [s.queuedSourcesFlag])
 
   const handleChange = (event: React.SyntheticEvent, newValue: number) => {
     setValue(newValue)
@@ -50,7 +52,9 @@ export const SourcesView = () => {
     <Wrapper direction="column">
       <StyledTabs aria-label="sources tabs" onChange={handleChange} value={value}>
         <StyledTab disableRipple label="Sources table" {...a11yProps(0)} />
-        {isAdmin && <StyledTab color={colors.white} disableRipple label="Queued sources" {...a11yProps(1)} />}
+        {isAdmin && queuedSourcesFlag ? (
+          <StyledTab color={colors.white} disableRipple label="Queued sources" {...a11yProps(1)} />
+        ) : null}
         {isAdmin && <StyledTab color={colors.white} disableRipple label="Topics" {...a11yProps(1)} />}
       </StyledTabs>
       <TabPanel index={0} value={value}>

--- a/src/components/Auth/index.tsx
+++ b/src/components/Auth/index.tsx
@@ -18,7 +18,11 @@ interface setAuthenticated {
 export const Auth = ({ setAuthenticated }: setAuthenticated) => {
   const [unAuthorized, setUnauthorized] = useState(false)
   const [setBudget, setIsAdmin, setPubKey] = useUserStore((s) => [s.setBudget, s.setIsAdmin, s.setPubKey])
-  const [setTrendingTopicsFlag] = useFeatureFlagStore((s) => [s.setTrendingTopicsFlag])
+
+  const [setTrendingTopicsFlag, setQueuedSourcesFlag] = useFeatureFlagStore((s) => [
+    s.setTrendingTopicsFlag,
+    s.setQueuedSourcesFlag,
+  ])
 
   const handleAuth = useCallback(async () => {
     // await executeIfProd(async () => {
@@ -63,6 +67,7 @@ export const Auth = ({ setAuthenticated }: setAuthenticated) => {
         setIsAdmin(!!res.data.isAdmin)
 
         setTrendingTopicsFlag(res.data.trendingTopics)
+        setQueuedSourcesFlag(res.data.queuedSources)
       }
 
       setAuthenticated(true)
@@ -76,7 +81,7 @@ export const Auth = ({ setAuthenticated }: setAuthenticated) => {
     if (isE2E || isDevelopment) {
       setAuthenticated(true)
     }
-  }, [setIsAdmin, setPubKey, setBudget, setAuthenticated, setTrendingTopicsFlag])
+  }, [setIsAdmin, setPubKey, setBudget, setAuthenticated, setTrendingTopicsFlag, setQueuedSourcesFlag])
 
   // auth checker
   useEffect(() => {

--- a/src/components/SourcesTableModal/SourcesView/__tests__/index.tsx
+++ b/src/components/SourcesTableModal/SourcesView/__tests__/index.tsx
@@ -1,0 +1,28 @@
+import '@testing-library/jest-dom'
+import { render } from '@testing-library/react'
+import React from 'react'
+import { SourcesView } from '..'
+import { useFeatureFlagStore } from '../../../../stores/useFeatureFlagStore'
+import { useUserStore } from '../../../../stores/useUserStore'
+
+jest.mock('~/stores/useUserStore', () => ({
+  useUserStore: jest.fn(),
+}))
+
+jest.mock('~/stores/useFeatureFlagStore', () => ({
+  useFeatureFlagStore: jest.fn(),
+}))
+
+const useFeatureFlagStoreMock = useFeatureFlagStore as jest.MockedFunction<typeof useFeatureFlagStore>
+const useUserStoreMock = useUserStore as jest.MockedFunction<typeof useUserStore>
+
+describe('Test SourceView', () => {
+  it('assserts that when queuedSourceFlag is false, queued sources column is hidden', () => {
+    useFeatureFlagStoreMock.mockReturnValue([false])
+    useUserStoreMock.mockReturnValue([false])
+
+    const { queryByText } = render(<SourcesView />)
+
+    expect(queryByText('Queued sources')).not.toBeInTheDocument()
+  })
+})

--- a/src/components/SourcesTableModal/SourcesView/index.tsx
+++ b/src/components/SourcesTableModal/SourcesView/index.tsx
@@ -3,6 +3,7 @@ import Tabs from '@mui/material/Tabs'
 import * as React from 'react'
 import styled from 'styled-components'
 import { Flex } from '~/components/common/Flex'
+import { useFeatureFlagStore } from '~/stores/useFeatureFlagStore'
 import { useUserStore } from '~/stores/useUserStore'
 import { colors } from '~/utils/colors'
 import { QueuedSources } from './QueuedSources'
@@ -41,6 +42,7 @@ function a11yProps(index: number) {
 export const SourcesView = () => {
   const [value, setValue] = React.useState(0)
   const [isAdmin] = useUserStore((s) => [s.isAdmin])
+  const [queuedSourcesFlag] = useFeatureFlagStore((s) => [s.queuedSourcesFlag])
 
   const handleChange = (event: React.SyntheticEvent, newValue: number) => {
     setValue(newValue)
@@ -50,7 +52,9 @@ export const SourcesView = () => {
     <Wrapper direction="column">
       <StyledTabs aria-label="sources tabs" onChange={handleChange} value={value}>
         <StyledTab disableRipple label="Sources table" {...a11yProps(0)} />
-        {isAdmin && <StyledTab color={colors.white} disableRipple label="Queued sources" {...a11yProps(1)} />}
+        {isAdmin && queuedSourcesFlag ? (
+          <StyledTab color={colors.white} disableRipple label="Queued sources" {...a11yProps(1)} />
+        ) : null}
         {isAdmin && <StyledTab color={colors.white} disableRipple label="Topics" {...a11yProps(1)} />}
       </StyledTabs>
       <TabPanel index={0} value={value}>

--- a/src/stores/useFeatureFlagStore/index.ts
+++ b/src/stores/useFeatureFlagStore/index.ts
@@ -2,13 +2,16 @@ import { create } from 'zustand'
 
 export type FeatureFlagStore = {
   trendingTopicsFlag: boolean
+  queuedSourcesFlag: boolean
   v2Flag: boolean
   setTrendingTopicsFlag: (val: boolean) => void
   setV2Flag: (val: boolean) => void
+  setQueuedSourcesFlag: (val: boolean) => void
 }
 
-const defaultData = {
+const defaultData: Omit<FeatureFlagStore, 'setTrendingTopicsFlag' | 'setV2Flag' | 'setQueuedSourcesFlag'> = {
   trendingTopicsFlag: true,
+  queuedSourcesFlag: false,
   v2Flag: false,
 }
 
@@ -16,4 +19,5 @@ export const useFeatureFlagStore = create<FeatureFlagStore>((set) => ({
   ...defaultData,
   setTrendingTopicsFlag: (trendingTopicsFlag) => set({ trendingTopicsFlag }),
   setV2Flag: (v2Flag) => set({ v2Flag }),
+  setQueuedSourcesFlag: (queuedSourcesFlag) => set({ queuedSourcesFlag }),
 }))

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -211,10 +211,11 @@ export type AuthRequest = {
 
 export type IsAdminResponse = {
   data: {
-    trendingTopics: boolean
     isAdmin: boolean
     isPublic: boolean
     isMember: boolean
+    trendingTopics: boolean
+    queuedSources: boolean
   }
   success: boolean
   message: string


### PR DESCRIPTION
### Ticket №:

closes #1030

### Problem:

We want to hide queued sources column when queuedSources is false:

### Solution:

 - [x] Added queuedSourcesFlag state to the store 
- [x] Wrote tests to assert that `Queued Sources` is not visible when queuedSourcesFlag is false
