### PR TITLE
Make Location Step of the Add Content Responsive

### DIFF
--- a/src/components/AddContentModal/LocationStep/index.tsx
+++ b/src/components/AddContentModal/LocationStep/index.tsx
@@ -43,7 +43,7 @@ export const LocationStep: FC<Props> = ({ latitude, longitude, onNextStep, form 
       </Flex>
 
       <Flex direction="row" mb={20}>
-        <Flex grow={1}>
+        <Flex basis="100px" grow={1}>
           <TextInput
             id="add-node-latitude"
             label="Latitude"
@@ -62,7 +62,7 @@ export const LocationStep: FC<Props> = ({ latitude, longitude, onNextStep, form 
           />
         </Flex>
 
-        <Flex grow={1} ml={20}>
+        <Flex basis="100px" grow={1} ml={20}>
           <TextInput
             id="add-node-location-longitude"
             label="Longitude"

--- a/src/components/AppNew/ModalsContainer/AddContentModal/LocationStep/index.tsx
+++ b/src/components/AppNew/ModalsContainer/AddContentModal/LocationStep/index.tsx
@@ -43,7 +43,7 @@ export const LocationStep: FC<Props> = ({ latitude, longitude, onNextStep, form 
       </Flex>
 
       <Flex direction="row" mb={20}>
-        <Flex grow={1}>
+        <Flex basis="100px" grow={1}>
           <TextInput
             id="add-node-latitude"
             label="Latitude"
@@ -62,7 +62,7 @@ export const LocationStep: FC<Props> = ({ latitude, longitude, onNextStep, form 
           />
         </Flex>
 
-        <Flex grow={1} ml={20}>
+        <Flex basis="100px" grow={1} ml={20}>
           <TextInput
             id="add-node-location-longitude"
             label="Longitude"


### PR DESCRIPTION
### Ticket №:

closes #1060

### Problem:

 Location step for the Add content flow was not responsive for smaller screens sizes

### Solution: 

- [x]  Location step is Reponsive for all screen sizes

### Evidence:

![fixed-location-steop](https://github.com/stakwork/sphinx-nav-fiber/assets/117433403/c6a765d9-ccbb-4d61-b823-baba706a81cb)