### PR TITLE
Make “Related Episode” List Scrollable

### DIFF
--- a/src/components/App/SideBar/Show/index.tsx
+++ b/src/components/App/SideBar/Show/index.tsx
@@ -54,6 +54,11 @@ const EpisodeHeaderText = styled(Text)`
   -webkit-line-clamp: 2;
 `
 
+const ScrollableList = styled.div`
+  max-height: calc(100vh - 340px);
+  overflow-y: auto;
+`
+
 export const Show = () => {
   const [selectedNode, setSelectedNode] = useDataStore((s) => [s.selectedNode, s.setSelectedNode])
   const data = useGraphData()
@@ -121,9 +126,11 @@ export const Show = () => {
             Related Episodes
           </Text>
         </Flex>
-        {episodes.map((node) => (
-          <EpisodePanel key={node.ref_id} node={node} onClick={() => setSelectedNode(node)} />
-        ))}
+        <ScrollableList>
+          {episodes.map((node) => (
+            <EpisodePanel key={node.ref_id} node={node} onClick={() => setSelectedNode(node)} />
+          ))}
+        </ScrollableList>
       </Flex>
     </Wrapper>
   )


### PR DESCRIPTION
### Ticket №:

closes #1059

### Problem:

The Related Episode List should be scrollable to accommodate more Episode Items for smaller screen sizes

### Preview 

https://www.loom.com/share/a57f273f0715401293d0a6439acc858c?sid=78742981-fa5d-4480-a17a-d3f86f73a00f

### Solution:

- [x] Related Episode List is now Scrollable
- [x] Ensured Reponsiveness for all desktop screen sizes
