### PR TITLE
Add CustomSchema Feature Flag to useFeatureFlagStore

### DIFF
--- a/src/stores/useFeatureFlagStore/index.ts
+++ b/src/stores/useFeatureFlagStore/index.ts
@@ -3,22 +3,22 @@ import { create } from 'zustand'
 export type FeatureFlagStore = {
   trendingTopicsFlag: boolean
   queuedSourcesFlag: boolean
-  FeatureFlag: boolean
+  customSchema: boolean
   v2Flag: boolean
   setTrendingTopicsFlag: (val: boolean) => void
   setV2Flag: (val: boolean) => void
   setQueuedSourcesFlag: (val: boolean) => void
-  setFeatureFlag: (val: boolean) => void
+  setCustomSchema: (val: boolean) => void
 }
 
 const defaultData: Omit<
   FeatureFlagStore,
-  'setTrendingTopicsFlag' | 'setV2Flag' | 'setQueuedSourcesFlag' | 'setFeatureFlag'
+  'setTrendingTopicsFlag' | 'setV2Flag' | 'setQueuedSourcesFlag' | 'setCustomSchema'
 > = {
   trendingTopicsFlag: true,
   queuedSourcesFlag: false,
   v2Flag: false,
-  FeatureFlag: false,
+  customSchema: false,
 }
 
 export const useFeatureFlagStore = create<FeatureFlagStore>((set) => ({
@@ -26,5 +26,5 @@ export const useFeatureFlagStore = create<FeatureFlagStore>((set) => ({
   setTrendingTopicsFlag: (trendingTopicsFlag) => set({ trendingTopicsFlag }),
   setV2Flag: (v2Flag) => set({ v2Flag }),
   setQueuedSourcesFlag: (queuedSourcesFlag) => set({ queuedSourcesFlag }),
-  setFeatureFlag: (FeatureFlag) => set({ FeatureFlag }),
+  setCustomSchema: (customSchema) => set({ customSchema }),
 }))

--- a/src/stores/useFeatureFlagStore/index.ts
+++ b/src/stores/useFeatureFlagStore/index.ts
@@ -3,16 +3,22 @@ import { create } from 'zustand'
 export type FeatureFlagStore = {
   trendingTopicsFlag: boolean
   queuedSourcesFlag: boolean
+  FeatureFlag: boolean
   v2Flag: boolean
   setTrendingTopicsFlag: (val: boolean) => void
   setV2Flag: (val: boolean) => void
   setQueuedSourcesFlag: (val: boolean) => void
+  setFeatureFlag: (val: boolean) => void
 }
 
-const defaultData: Omit<FeatureFlagStore, 'setTrendingTopicsFlag' | 'setV2Flag' | 'setQueuedSourcesFlag'> = {
+const defaultData: Omit<
+  FeatureFlagStore,
+  'setTrendingTopicsFlag' | 'setV2Flag' | 'setQueuedSourcesFlag' | 'setFeatureFlag'
+> = {
   trendingTopicsFlag: true,
   queuedSourcesFlag: false,
   v2Flag: false,
+  FeatureFlag: false,
 }
 
 export const useFeatureFlagStore = create<FeatureFlagStore>((set) => ({
@@ -20,4 +26,5 @@ export const useFeatureFlagStore = create<FeatureFlagStore>((set) => ({
   setTrendingTopicsFlag: (trendingTopicsFlag) => set({ trendingTopicsFlag }),
   setV2Flag: (v2Flag) => set({ v2Flag }),
   setQueuedSourcesFlag: (queuedSourcesFlag) => set({ queuedSourcesFlag }),
+  setFeatureFlag: (FeatureFlag) => set({ FeatureFlag }),
 }))


### PR DESCRIPTION
#### Problem:
The frontend cannot dynamically toggle new schema implementations, which is necessary for phased rollouts and testing.

### Expected Behavior:
A new feature flag for CustomSchema should be integrated within the useFeatureFlagStore, allowing for the conditional rendering and utilization of new schema features based on the flag's state.

 Closes: #1048

## Issue ticket number and link:
- **Ticket Number:** [ 1048 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1048 ]

### Solution:
Implemented a new feature flag CustomSchemaFlag within the useFeatureFlagStore, defaulting to false, and provided a setter function setCustomSchemaFlag for dynamic adjustments.

### Changes:
- Added `FeatureFlag` and `setFeatureFlag` to the `FeatureFlagStore` type.
- Initialized `FeatureFlag` to false in defaultData.
- Implemented `setFeatureFlag` within the store creation logic.

### Testing:
**Browser Compatibility:**
- Tested the feature extensively on Chrome to ensure consistent behavior.