### PR TITLE
Replace Error Toast message with on modal error

### DIFF
--- a/src/components/AddContentModal/BudgetStep/index.tsx
+++ b/src/components/AddContentModal/BudgetStep/index.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@mui/material'
 import { FC, useEffect, useState } from 'react'
+import { MdError } from 'react-icons/md'
 import { ClipLoader } from 'react-spinners'
 import styled from 'styled-components'
 import CheckIcon from '~/components/Icons/CheckIcon'
@@ -14,9 +15,10 @@ type Props = {
   onClick: () => void
   loading: boolean
   type: string
+  error?: string
 }
 
-export const BudgetStep: FC<Props> = ({ onClick, loading, type }) => {
+export const BudgetStep: FC<Props> = ({ onClick, loading, type, error }) => {
   const budget = useUserStore((s) => s.budget)
   const [price, setPrice] = useState<number>(10)
   const endPoint = isSource(type) ? 'radar' : 'add_node'
@@ -42,7 +44,6 @@ export const BudgetStep: FC<Props> = ({ onClick, loading, type }) => {
           <StyledText>Approve Cost</StyledText>
         </Flex>
       </Flex>
-
       <Flex align="center" direction="row" justify="space-between" mb={20}>
         <Cost>
           <div className="title">COST</div>
@@ -59,7 +60,7 @@ export const BudgetStep: FC<Props> = ({ onClick, loading, type }) => {
         <Button
           color="secondary"
           data-testid="check-icon"
-          disabled={loading}
+          disabled={loading || !!error}
           onClick={onClick}
           size="large"
           startIcon={loading ? <ClipLoader size={24} /> : <CheckIcon />}
@@ -69,6 +70,15 @@ export const BudgetStep: FC<Props> = ({ onClick, loading, type }) => {
           Approve
         </Button>
       </Flex>
+      {error ? (
+        <StyledError role="tooltip">
+          <StyledErrorText>
+            <MdError fontSize={13} />
+            <span>{error}</span>
+          </StyledErrorText>
+          <div className="tooltip">{error}</div>
+        </StyledError>
+      ) : null}
     </Flex>
   )
 }
@@ -125,4 +135,55 @@ const StyledText = styled(Text)`
   font-size: 22px;
   font-weight: 600;
   font-family: 'Barlow';
+`
+
+const StyledErrorText = styled(Flex)`
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  white-space: normal;
+  letter-spacing: 0.2px;
+  cursor: pointer;
+  padding-left: 4px;
+  font-size: 13px;
+  font-family: Barlow;
+  line-height: 18px;
+  justify-content: center;
+
+  span {
+    margin-left: 4px;
+  }
+`
+
+const StyledError = styled(Flex)`
+  display: flex;
+  align-items: center;
+  color: ${colors.primaryRed};
+  position: relative;
+  margin-top: 20px;
+
+  .tooltip {
+    position: absolute;
+    background-color: ${colors.black};
+    opacity: 0.8;
+    border-radius: 4px;
+    color: ${colors.white};
+    top: -10px;
+    left: 335px;
+    padding: 4px 8px;
+    font-size: 13px;
+    font-family: Barlow;
+    visibility: hidden;
+    width: 175px;
+    z-index: 1;
+  }
+
+  &:hover .tooltip {
+    visibility: visible;
+  }
+
+  &:focus .tooltip {
+    visibility: visible;
+  }
 `

--- a/src/components/AddContentModal/index.tsx
+++ b/src/components/AddContentModal/index.tsx
@@ -130,13 +130,11 @@ const handleSubmitForm = async (
     if (err.status === 400) {
       const error = await err.json()
 
-      notify(error?.status || NODE_ADD_ERROR)
-      close()
+      throw new Error(error?.status || NODE_ADD_ERROR)
     }
 
     if (err instanceof Error) {
-      notify(err.message || NODE_ADD_ERROR)
-      close()
+      throw new Error(err.message || NODE_ADD_ERROR)
     }
   }
 }
@@ -148,9 +146,11 @@ export const AddContentModal = () => {
   const form = useForm<FormData>({ mode: 'onChange' })
   const { watch, setValue, reset } = form
   const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string>('')
 
   useEffect(
     () => () => {
+      setError('')
       setCurrentStep(0)
       reset()
     },
@@ -188,8 +188,12 @@ export const AddContentModal = () => {
 
     try {
       await handleSubmitForm(data, handleClose, type, setBudget)
-    } catch {
-      notify(NODE_ADD_ERROR)
+    } catch (e: unknown) {
+      if (e instanceof Error) {
+        setError(e.message)
+      }
+
+      setError(String(e))
     } finally {
       setLoading(false)
     }
@@ -209,7 +213,7 @@ export const AddContentModal = () => {
               )}
             </>
           )}
-          {currentStep === 2 && <BudgetStep loading={loading} onClick={() => null} type={type} />}
+          {currentStep === 2 && <BudgetStep error={error} loading={loading} onClick={() => null} type={type} />}
         </form>
       </FormProvider>
     </BaseModal>

--- a/src/components/AddItemModal/BudgetStep/index.tsx
+++ b/src/components/AddItemModal/BudgetStep/index.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@mui/material'
 import { FC, useEffect, useState } from 'react'
+import { MdError } from 'react-icons/md'
 import { ClipLoader } from 'react-spinners'
 import styled from 'styled-components'
 import CheckIcon from '~/components/Icons/CheckIcon'
@@ -12,9 +13,10 @@ import { colors, formatBudget } from '~/utils'
 type Props = {
   onClick: () => void
   loading: boolean
+  error?: string
 }
 
-export const BudgetStep: FC<Props> = ({ onClick, loading }) => {
+export const BudgetStep: FC<Props> = ({ onClick, loading, error }) => {
   const budget = useUserStore((s) => s.budget)
   const [price, setPrice] = useState<number>(10)
   const endPoint = 'node'
@@ -57,7 +59,7 @@ export const BudgetStep: FC<Props> = ({ onClick, loading }) => {
         <Button
           color="secondary"
           data-testid="check-icon"
-          disabled={loading}
+          disabled={loading || !!error}
           onClick={onClick}
           size="large"
           startIcon={loading ? <ClipLoader size={24} /> : <CheckIcon />}
@@ -67,6 +69,15 @@ export const BudgetStep: FC<Props> = ({ onClick, loading }) => {
           Approve
         </Button>
       </Flex>
+      {error ? (
+        <StyledError role="tooltip">
+          <StyledErrorText>
+            <MdError fontSize={13} />
+            <span>{error}</span>
+          </StyledErrorText>
+          <div className="tooltip">{error}</div>
+        </StyledError>
+      ) : null}
     </Flex>
   )
 }
@@ -123,4 +134,55 @@ const StyledText = styled(Text)`
   font-size: 22px;
   font-weight: 600;
   font-family: 'Barlow';
+`
+
+const StyledErrorText = styled(Flex)`
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  white-space: normal;
+  letter-spacing: 0.2px;
+  cursor: pointer;
+  padding-left: 4px;
+  font-size: 13px;
+  font-family: Barlow;
+  line-height: 18px;
+  justify-content: center;
+
+  span {
+    margin-left: 4px;
+  }
+`
+
+const StyledError = styled(Flex)`
+  display: flex;
+  align-items: center;
+  color: ${colors.primaryRed};
+  position: relative;
+  margin-top: 20px;
+
+  .tooltip {
+    position: absolute;
+    background-color: ${colors.black};
+    opacity: 0.8;
+    border-radius: 4px;
+    color: ${colors.white};
+    top: -10px;
+    left: 335px;
+    padding: 4px 8px;
+    font-size: 13px;
+    font-family: Barlow;
+    visibility: hidden;
+    width: 175px;
+    z-index: 1;
+  }
+
+  &:hover .tooltip {
+    visibility: visible;
+  }
+
+  &:focus .tooltip {
+    visibility: visible;
+  }
 `

--- a/src/components/AddItemModal/index.tsx
+++ b/src/components/AddItemModal/index.tsx
@@ -80,8 +80,7 @@ const handleSubmitForm = async (
       errorMessage = err.message
     }
 
-    notify(errorMessage)
-    close()
+    throw new Error(errorMessage)
   }
 }
 
@@ -92,11 +91,13 @@ export const AddItemModal = () => {
   const form = useForm<FormData>({ mode: 'onChange' })
   const { watch, setValue, reset } = form
   const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string>('')
 
   const [addNewNode, setSelectedNode] = useDataStore((s) => [s.addNewNode, s.setSelectedNode])
 
   useEffect(
     () => () => {
+      setError('')
       setCurrentStep(0)
       reset()
     },
@@ -148,8 +149,12 @@ export const AddItemModal = () => {
 
     try {
       await handleSubmitForm(data, handleClose, setBudget, onAddNewNode)
-    } catch {
-      notify(NODE_ADD_ERROR)
+    } catch (e: unknown) {
+      if (e instanceof Error) {
+        setError(e.message)
+      }
+
+      setError(String(e))
     } finally {
       setLoading(false)
     }
@@ -178,7 +183,7 @@ export const AddItemModal = () => {
               type={nodeType}
             />
           )}
-          {currentStep === 2 && <BudgetStep loading={loading} onClick={() => null} />}
+          {currentStep === 2 && <BudgetStep error={error} loading={loading} onClick={() => null} />}
         </form>
       </FormProvider>
     </BaseModal>


### PR DESCRIPTION
### Ticket №:

closes #1067

Replaced the Error Toast with a modal Error

 - [x]  This is for errors only
 - [x]  Used a tooltip for longer errors
 - [x] Display the current error messages we have on the frontend or backend
 - [x] Allow the user to close the modal in their own time
 - [x] Greyed out the submit button when there is an error

### Evidence:

https://www.loom.com/share/6e5917aa487b4a3facbe200dcd8c8e93?sid=b5f242ab-88d6-41a9-88a2-85a2b624dd5c