### PR TITLE
Add Schema Table to Admin `Blueprint` Column

### DIFF
--- a/src/components/SettingsModal/SettingsView/GraphBlueprint/Table/TableRow.tsx
+++ b/src/components/SettingsModal/SettingsView/GraphBlueprint/Table/TableRow.tsx
@@ -1,0 +1,35 @@
+import React, { memo } from 'react'
+
+import { StyledTableRow, StyledTableCell } from '~/components/SourcesTableModal/SourcesView/common'
+
+interface Schema {
+  name?: string
+  ref_id?: string
+  type?: string
+  age?: number
+  parent?: string
+  link?: string
+  title?: string
+  app_version?: string
+  description?: string
+  mission_statement?: string
+  namespace?: string
+  search_term?: string
+}
+
+interface TableRowProps {
+  schema: Schema
+}
+
+function capitalizeFirstLetter(string: string) {
+  return string.charAt(0).toUpperCase() + string.slice(1).toLowerCase()
+}
+
+const TableRowComponent: React.FC<TableRowProps> = ({ schema }) => (
+  <StyledTableRow>
+    <StyledTableCell className="empty" />
+    <StyledTableCell>{capitalizeFirstLetter(schema.type ?? '')}</StyledTableCell>
+  </StyledTableRow>
+)
+
+export const TopicRow = memo(TableRowComponent)

--- a/src/components/SettingsModal/SettingsView/GraphBlueprint/Table/index.tsx
+++ b/src/components/SettingsModal/SettingsView/GraphBlueprint/Table/index.tsx
@@ -1,0 +1,57 @@
+import { Button, Table as MaterialTable, TableRow } from '@mui/material'
+import React from 'react'
+import { StyledTableHead, StyledTableCell } from '~/components/SourcesTableModal/SourcesView/common'
+import { TopicRow } from './TableRow'
+import { Flex } from '~/components/common/Flex'
+import { useModal } from '~/stores/useModalStore'
+import PlusIcon from '~/components/Icons/PlusIcon'
+import styled from 'styled-components'
+import { Schema } from '~/network/fetchSourcesData'
+
+interface TableProps {
+  schemas: Schema[]
+}
+
+export const Table: React.FC<TableProps> = ({ schemas }) => {
+  const { open: openContentAddModal } = useModal('addItem')
+
+  const handleAddContent = async () => {
+    openContentAddModal()
+  }
+
+  return (
+    <>
+      <MaterialTable component="table">
+        <StyledTableHead>
+          <TableRow component="tr">
+            <StyledTableCell className="empty" />
+            <StyledTableCell>Type</StyledTableCell>
+          </TableRow>
+        </StyledTableHead>
+        <tbody>
+          {schemas?.map((schema) => (
+            <TopicRow key={schema?.ref_id} schema={schema} />
+          ))}
+        </tbody>
+      </MaterialTable>
+      <AddContentSection>
+        <Button
+          color="secondary"
+          endIcon={<PlusIcon />}
+          onClick={handleAddContent}
+          size="medium"
+          type="submit"
+          variant="contained"
+        >
+          Create New Type
+        </Button>
+      </AddContentSection>
+    </>
+  )
+}
+
+const AddContentSection = styled(Flex)`
+  display: flex;
+  margin: 20px 0px 0px 30px;
+  width: 28%;
+`

--- a/src/components/SettingsModal/SettingsView/GraphBlueprint/index.tsx
+++ b/src/components/SettingsModal/SettingsView/GraphBlueprint/index.tsx
@@ -1,18 +1,49 @@
-import React from 'react'
-import styled from 'styled-components'
+import React, { useEffect, useState } from 'react'
+import { Table } from './Table'
 import { Flex } from '~/components/common/Flex'
-import { Text } from '~/components/common/Text'
+import { getSchemaAll, Schema } from '~/network/fetchSourcesData'
+import { ClipLoader } from 'react-spinners'
+import { colors } from '~/utils'
+import styled from 'styled-components'
 
-export const GraphBlueprint: React.FC = () => (
-  <Flex direction="column">
-    <StyledText>Graph Blueprint settings will go here.</StyledText>
-  </Flex>
-)
+export const GraphBlueprint: React.FC = () => {
+  const [loading, setLoading] = useState(true)
+  const [schemaAll, setSchemaAll] = useState<Schema[]>([])
 
-const StyledText = styled(Text)`
-  font-family: Barlow;
-  font-size: 16px;
-  font-style: normal;
-  font-weight: 400;
-  margin: 120px;
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const response = await getSchemaAll()
+
+        setSchemaAll(response.schemas)
+
+        setLoading(false)
+      } catch (error) {
+        console.error('Error fetching data:', error)
+
+        setLoading(false)
+      }
+    }
+
+    fetchData()
+  }, [])
+
+  return (
+    <TableWrapper align={loading ? 'center' : 'flex-start'} justify={loading ? 'center' : 'flex-start'}>
+      {loading ? (
+        <ClipLoader color={colors.white} />
+      ) : (
+        <>
+          <Table schemas={schemaAll} />
+        </>
+      )}
+    </TableWrapper>
+  )
+}
+
+const TableWrapper = styled(Flex)`
+  min-height: 0;
+  overflow: auto;
+  flex: 1;
+  width: 100%;
 `

--- a/src/components/SettingsModal/SettingsView/index.tsx
+++ b/src/components/SettingsModal/SettingsView/index.tsx
@@ -110,6 +110,7 @@ const StyledTabs = styled(Tabs)`
     .MuiTabs-indicator {
       background: ${colors.primaryBlue};
     }
+    width: 90%;
   }
 `
 
@@ -122,16 +123,17 @@ const StyledTab = styled(Tab)`
   && {
     padding: 30px 0 24px;
     color: ${colors.GRAY6};
-    margin-left: 36px;
+    margin-left: 10px;
     font-family: Barlow;
     font-size: 16px;
     font-style: normal;
     font-weight: 500;
-    text-align: left;
+    text-align: center;
 
     &.Mui-selected {
       color: ${colors.white};
     }
+    flex-grow: 1;
   }
 `
 

--- a/src/components/SettingsModal/index.tsx
+++ b/src/components/SettingsModal/index.tsx
@@ -4,8 +4,9 @@ import { SettingsView } from './SettingsView'
 
 export const SettingsModal = () => {
   const { close } = useModal('settings')
+  const { visible } = useModal('addItem')
 
-  return (
+  return visible ? null : (
     <BaseModal background="BG1" id="settings" noWrap onClose={close}>
       <SettingsView onClose={close} />
     </BaseModal>

--- a/src/network/fetchSourcesData/index.ts
+++ b/src/network/fetchSourcesData/index.ts
@@ -98,6 +98,32 @@ const defaultViewContentParams = {
   limit: '10',
 }
 
+export interface Schema {
+  name?: string
+  ref_id?: string
+  type?: string
+  age?: number
+  parent?: string
+  link?: string
+  title?: string
+  app_version?: string
+  description?: string
+  mission_statement?: string
+  namespace?: string
+  search_term?: string
+}
+
+interface SchemaAllResponse {
+  schemas: Schema[]
+}
+
+export const getSchemaAll = async () => {
+  const url = '/schema/all'
+  const response = await api.get<SchemaAllResponse>(url)
+
+  return response
+}
+
 export const getNodeContent = async (queryParams: ViewContentParams = defaultViewContentParams) => {
   const queryString = new URLSearchParams({ ...queryParams }).toString()
 


### PR DESCRIPTION
### Problem:
The admin section requires a new feature where administrators can view and add new types via a schema table in the Blueprint column, enhancing the data management and customization capabilities.

closes: #1081

### Expected Behavior:
Admins should be able to view a list of all types retrieved from the `GET schema/all API` and add new types through a user-friendly interface, following the existing design patterns of the platform.

## Issue ticket number and link:
- **Ticket Number:** [ 1081 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1081 ]

### Solution:
 new schema table has been added to the Blueprint column for admins. This includes calling the `GET schema/all` endpoint to list existing types and providing a button to add new types, initiating the custom node type flow as per the existing AddItem workflow.

### Changes:
- Implemented feature flag for new Blueprint column functionality.
- Added new schema table under the Blueprint column, accessible only by admins.
- Integrated GET schema/all to fetch and display types in a list format.
- Added "Create new type" button to initiate custom node type creation.
- Adapted UI to match the existing style of the Sources and Topics tables, including alternative coloring for list items.

### Evidence:
 - Please see the attached video as evidence.
https://www.loom.com/share/2f3386db08344f3b93c3f74e0af4d5c2

### Testing:
- Manual testing was conducted to verify that the new integration works as expected.
