### PR TITLE
Implement Hover Effect and Ellipsis for Multiple Edges in Topics Table

### DIFF
--- a/src/components/SourcesTableModal/SourcesView/Topics/Table/TableRow.tsx
+++ b/src/components/SourcesTableModal/SourcesView/Topics/Table/TableRow.tsx
@@ -80,7 +80,7 @@ const TableRowComponent: FC<TTableRaw> = ({ topic, onClick, onSearch }) => {
             '& .MuiPaper-root': {
               backgroundColor: 'rgba(0, 0, 0, 0.9)',
               borderRadius: '4px',
-              width: '140px',
+              width: '160px',
             },
           }}
           transformOrigin={{
@@ -88,7 +88,7 @@ const TableRowComponent: FC<TTableRaw> = ({ topic, onClick, onSearch }) => {
             horizontal: 'center',
           }}
         >
-          <Typography sx={{ p: 1.5, fontSize: '13px', fontWeight: 400, lineHeight: '1.8' }}>
+          <Typography sx={{ p: 1.5, fontSize: '13px', fontWeight: 400, lineHeight: '1.8', wordWrap: 'break-word' }}>
             {topic.edgeList.join(', ')}
           </Typography>
         </Popover>


### PR DESCRIPTION
### Problem:
The Topics Table currently lacks a mechanism to handle multiple edges efficiently, leading to UI inconsistency and potential information overload for the users.

### Expected Behavior:
The table should provide a clear, concise view of the edges, even when multiple edges are associated with a single topic. This includes displaying an ellipsis ("...") when the edge list exceeds the display limit and revealing additional edges through a hover effect, without affecting the row height.

## Issue ticket number and link:
- **Ticket Number:** [ 1012 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1012 ]

### Address Issue:
https://github.com/stakwork/sphinx-nav-fiber/issues/1012#issuecomment-2004474761

### Evidence:
 - Please see the attached Image as evidence.
![image](https://github.com/stakwork/sphinx-nav-fiber/assets/156602406/53df5383-669e-4b71-a266-9c98fc6496e8)

 ### Test Evidence:
 - Please see the attached Image as evidence.
![image](https://github.com/stakwork/sphinx-nav-fiber/assets/156602406/5a25c9f1-9bb9-45f6-847c-47d1f1bdd208)

### Testing:
- Manual testing was conducted to verify that the new integration works as expected.
