### PR TITLE
fix: added setCustomSchemaFlag on page mount

### DIFF
--- a/src/components/Auth/index.tsx
+++ b/src/components/Auth/index.tsx
@@ -19,9 +19,10 @@ export const Auth = ({ setAuthenticated }: setAuthenticated) => {
   const [unAuthorized, setUnauthorized] = useState(false)
   const [setBudget, setIsAdmin, setPubKey] = useUserStore((s) => [s.setBudget, s.setIsAdmin, s.setPubKey])
 
-  const [setTrendingTopicsFlag, setQueuedSourcesFlag] = useFeatureFlagStore((s) => [
+  const [setTrendingTopicsFlag, setQueuedSourcesFlag, setCustomSchemaFlag] = useFeatureFlagStore((s) => [
     s.setTrendingTopicsFlag,
     s.setQueuedSourcesFlag,
+    s.setCustomSchemaFlag,
   ])
 
   const handleAuth = useCallback(async () => {
@@ -68,6 +69,7 @@ export const Auth = ({ setAuthenticated }: setAuthenticated) => {
 
         setTrendingTopicsFlag(res.data.trendingTopics)
         setQueuedSourcesFlag(res.data.queuedSources)
+        setCustomSchemaFlag(res.data.customSchema)
       }
 
       setAuthenticated(true)
@@ -81,7 +83,15 @@ export const Auth = ({ setAuthenticated }: setAuthenticated) => {
     if (isE2E || isDevelopment) {
       setAuthenticated(true)
     }
-  }, [setIsAdmin, setPubKey, setBudget, setAuthenticated, setTrendingTopicsFlag, setQueuedSourcesFlag])
+  }, [
+    setIsAdmin,
+    setPubKey,
+    setBudget,
+    setAuthenticated,
+    setTrendingTopicsFlag,
+    setQueuedSourcesFlag,
+    setCustomSchemaFlag,
+  ])
 
   // auth checker
   useEffect(() => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -216,6 +216,7 @@ export type IsAdminResponse = {
     isMember: boolean
     trendingTopics: boolean
     queuedSources: boolean
+    customSchema: boolean
   }
   success: boolean
   message: string


### PR DESCRIPTION
### Ticket №:

closes #ticket_number

### Problem:
Custom Schema was not showing

### Solution:
Set `customSchema` on page mount

