### PR TITLE
fix: changed graphBluePrintFlag to customSchemaFlag

### DIFF
--- a/src/components/SettingsModal/SettingsView/index.tsx
+++ b/src/components/SettingsModal/SettingsView/index.tsx
@@ -50,7 +50,7 @@ type Props = {
 export const SettingsView: React.FC<Props> = ({ onClose }) => {
   const [value, setValue] = useState(0)
   const [isAdmin, pubKey] = useUserStore((s) => [s.isAdmin, s.setPubKey, s.pubKey])
-  const graphBlueprintFlag = useFeatureFlagStore((s) => s.graphBluePrint)
+  const customSchemaFlag = useFeatureFlagStore((s) => s.customSchemaFlag)
   const appMetaData = useAppStore((s) => s.appMetaData)
 
   const getSettingsLabel = () => (isAdmin ? 'Admin Settings' : 'Settings')
@@ -84,7 +84,7 @@ export const SettingsView: React.FC<Props> = ({ onClose }) => {
   const tabs = [
     ...(isAdmin ? [{ label: 'General', component: General }] : []),
     { label: 'Appearance', component: Appearance },
-    ...(isAdmin && graphBlueprintFlag ? [{ label: 'Graph Blueprint', component: GraphBlueprint }] : []),
+    ...(isAdmin && customSchemaFlag ? [{ label: 'Graph Blueprint', component: GraphBlueprint }] : []),
   ]
 
   return (


### PR DESCRIPTION
### Ticket №:
1116

### Problem:
Want to change `graphBluePrintFlag` to `customSchemaFlag`

### Solution:
used `customSchemaFlag` instead of `graphBluePrintFlag`
