### PR TITLE
feat: display image_url for document node type if avaliable

### DIFF
--- a/src/network/fetchGraphData/index.ts
+++ b/src/network/fetchGraphData/index.ts
@@ -462,7 +462,7 @@ export const formatFetchNodes = (
       if (['data_series', 'document', 'tweet', 'image'].includes(node.node_type)) {
         const imageUrlsMapper: { [key: string]: string } = {
           data_series: 'node_data.webp',
-          document: 'document.svg',
+          document: node.node_type === "document" && !!node.image_url ? node.image_url : 'document.svg',
           tweet: 'twitter_placeholder.png',
         }
 


### PR DESCRIPTION
### Ticket №:

closes #1133

### Task:

Display the `image_url` if there is one available for node_type document.

### Solution:

Updated the formatFetchNodes topic in `src/network/fetchGraphData/index.ts`

Before, for document type `document.svg` image was the default for `node_type=document`

### Change:

```js 

      const imageUrlsMapper: { [key: string]: string } = {
        data_series: 'node_data.webp',
         document: node.node_type === 'document' && !!node.image_url ? node.image_url : 'document.svg', // <-- change
         tweet: 'twitter_placeholder.png',
      }

```

