### PR TITLE
fix(add-node-type): add type column in topic curation table

### DIFF
--- a/src/components/SourcesTableModal/SourcesView/Topics/Table/TableRow.tsx
+++ b/src/components/SourcesTableModal/SourcesView/Topics/Table/TableRow.tsx
@@ -65,6 +65,7 @@ const TableRowComponent: FC<TTableRaw> = ({ topic, onClick, onSearch }) => {
       <StyledTableCell onClick={() => handleClickTopic(topic)}>
         <ClickableText>{topic.topic}</ClickableText>
       </StyledTableCell>
+      <StyledTableCell>{topic.node_type}</StyledTableCell>
       <StyledTableCell>{topic.edgeCount}</StyledTableCell>
       <StyledTableCell>
         <Popover

--- a/src/components/SourcesTableModal/SourcesView/Topics/Table/index.tsx
+++ b/src/components/SourcesTableModal/SourcesView/Topics/Table/index.tsx
@@ -84,6 +84,7 @@ export const Table: React.FC<TopicTableProps> = ({ setShowMuteUnmute, showMuted,
                     Name <SortFilterIcon />
                   </SortedIcon>
                 </StyledTableCell>
+                <StyledTableCell>Type</StyledTableCell>
                 <StyledTableCell>
                   <SortedIcon onClick={() => handleChange(EDGE_COUNT)}>
                     Count <SortFilterIcon />

--- a/src/components/SourcesTableModal/SourcesView/common/index.tsx
+++ b/src/components/SourcesTableModal/SourcesView/common/index.tsx
@@ -8,7 +8,7 @@ export const StyledTableCell = styled(TableCell)`
   && {
     color: ${colors.white};
     border: none;
-    padding: 6px 27px 6px 0;
+    padding: 6px 2px 6px 0;
     color: ${colors.GRAY3};
     font-family: Barlow;
     font-size: 14px;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -182,6 +182,7 @@ export type Sources = {
 
 export type Topic = {
   topic: string
+  node_type: string
   ref_id: string
   muted_topic: string
   edgeList: Array<string>


### PR DESCRIPTION
### Problem:
Add `type` column in topic curation table

closes: #1134

### Expected Behavior:
New type column that uses `node_type` in the response

## Issue ticket number and link:
- **Ticket Number:** [ 1134 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1134 ]


### Evidence:
 - Please see the attached image as evidence.
 
![image](https://github.com/stakwork/sphinx-nav-fiber/assets/160427254/767be360-9294-4fd2-b1eb-e298a6156acb)

### Testing:
- Manual testing was conducted to verify that the new integration works as expected.
