### PR TITLE
fix(filter-options): only display filter options if there is a result

### DIFF
--- a/src/components/App/SideBar/Dropdown/index.tsx
+++ b/src/components/App/SideBar/Dropdown/index.tsx
@@ -12,7 +12,17 @@ import { colors } from '~/utils/colors'
 
 export const SelectWithPopover = () => {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
-  const { sidebarFilter, sidebarFilters, setSidebarFilter } = useDataStore((s) => s)
+  const { sidebarFilter, setSidebarFilter, sidebarFilterCounts } = useDataStore((s) => s)
+  const currentFilter = sidebarFilter === 'undefined' ? 'Other' : sidebarFilter
+  const currentFilterCount = sidebarFilterCounts.find((f) => f.name === currentFilter)?.count || 0
+
+  const capitalizeFirstLetter = (text: string): string => {
+    if (!text) {
+      return ''
+    }
+
+    return text.charAt(0).toUpperCase() + text.slice(1)
+  }
 
   const handleOpenPopover = (event: React.MouseEvent<HTMLDivElement>) => {
     setAnchorEl(event.currentTarget as HTMLElement)
@@ -32,7 +42,7 @@ export const SelectWithPopover = () => {
       <Action onClick={handleOpenPopover}>
         <div className="text">Show</div>
         <div className="value" data-testid="value">
-          {sidebarFilter}
+          {`${capitalizeFirstLetter(currentFilter)} (${currentFilterCount})`}
         </div>
         <div className="icon">{!anchorEl ? <ChevronDownIcon /> : <ChevronUpIcon />}</div>
       </Action>
@@ -54,14 +64,14 @@ export const SelectWithPopover = () => {
         }}
       >
         <FormControl>
-          {sidebarFilters.map((option) => (
+          {sidebarFilterCounts.map(({ name, count }) => (
             <MenuItem
-              key={option}
-              className={clsx({ active: option === sidebarFilter })}
-              onClick={() => handleSelectChange(option)}
+              key={name}
+              className={clsx({ active: name === sidebarFilter })}
+              onClick={() => handleSelectChange(name)}
             >
-              <span className="icon">{option === sidebarFilter ? <CheckIcon /> : null}</span>
-              <span>{option}</span>
+              <span className="icon">{name === sidebarFilter ? <CheckIcon /> : null}</span>
+              <span>{`${capitalizeFirstLetter(name)} (${count})`}</span>
             </MenuItem>
           ))}
         </FormControl>


### PR DESCRIPTION
### Problem:
Our filter system displayed all options, regardless of actual results, confusing users by allowing selections with no outcomes.

### Expected Behavior:
This update ensures only filters with results are shown, each with a count of items (e.g., "Tweet (24)"). It dynamically adjusts based on the dataset, improving user experience by guiding choices with visible data availability.

closes: #1099

## Issue ticket number and link:
- **Ticket Number:** [ 1099 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1099 ]

### Testing:
- Manual tests confirmed functionality, including dynamic display and count accuracy. Compatibility and error handling were rigorously evaluated to ensure a smooth integration.

### Evidence:
 - Please see the attached video as evidence.
https://www.loom.com/share/fa81e08c338e403083481f4bf31a491a