### PR TITLE
Remove Label from Dropdown in Add Item Flow

### DIFF
--- a/src/components/common/AutoComplete/index.tsx
+++ b/src/components/common/AutoComplete/index.tsx
@@ -6,7 +6,6 @@ import { ChangeEvent, FC, SyntheticEvent, useEffect, useRef, useState } from 're
 import styled from 'styled-components'
 import { colors } from '~/utils'
 import { Flex } from '../Flex'
-import { TypeBadge } from '../TypeBadge'
 
 export type TAutocompleteOption = {
   label: string
@@ -104,7 +103,6 @@ export const AutoComplete: FC<Props> = ({
           <li {...props}>
             <Flex align="center" direction="row" grow={1} justify="space-between" onClick={option?.action} shrink={1}>
               <div className="option">{option.label !== '' ? option.label : 'Not Selected'}</div>
-              {option?.type && <TypeBadge type={option.type} />}
             </Flex>
           </li>
         )}


### PR DESCRIPTION
### Problem:
Labels next to dropdown menus in the Add Item flow were cluttering the UI and potentially confusing users.

### Expected Behavior:
Removing the labels will streamline the UI, making the Add Item flow more intuitive and user-friendly.

closes: #1160

## Issue ticket number and link:
- **Ticket Number:** [ 1160 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1160 ]

### Testing:
- Testing should ensure the UI remains intuitive without the labels, checking functionality, user experience, cross-platform consistency, and for any regressions.

### Evidence:
 - Please see the attached video as evidence.
https://www.loom.com/share/46a4d08ef8634ffcb7eefc97057d2385