### PR TITLE
Remove is_deleted options for the parent selector dropdown

### DIFF
--- a/src/components/AddTypeModal/Body/__tests__/index.spec.tsx
+++ b/src/components/AddTypeModal/Body/__tests__/index.spec.tsx
@@ -1,0 +1,48 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { Body } from '../index'
+import * as fetchSourcesData from '~/network/fetchSourcesData'
+
+describe('Body Component', () => {
+  it('filters out deleted types from the dropdown', async () => {
+    const mockData = [
+      {
+        age: 'string',
+        is_deleted: true,
+        name: 'string',
+        namez: 'string',
+        newattribute: 'string',
+        parent: 'Person',
+        ref_id: 'string',
+        surname: '?string',
+        type: 'Persontest',
+        uuid: 'ed6e3319-5c50-4504-8aa8-bb15db7bd668',
+      },
+      {
+        name: 'string',
+        parent: 'thing',
+        ref_id: '58e36ad9-54cb-4e1b-9442-6a3801ee2977',
+        type: 'place',
+      },
+    ]
+
+    jest.mock('~/network/fetchSourcesData', () => ({
+      getNodeSchemaTypes: jest.fn().mockResolvedValue({ schemas: mockData }),
+    }))
+
+    const onSchemaCreateMock = jest.fn()
+    const onDeleteMock = jest.fn()
+
+    const getNodeSchemaTypesSpy = jest.spyOn(fetchSourcesData, 'getNodeSchemaTypes')
+
+    getNodeSchemaTypesSpy.mockResolvedValue({ schemas: mockData })
+
+    render(<Body onDelete={onDeleteMock} onSchemaCreate={onSchemaCreateMock} selectedSchema={null} />)
+
+    await screen.findByText('Loading…')
+
+    expect(screen.queryByText('Persontest')).not.toBeInTheDocument()
+
+    expect(screen.getByText('place')).toBeInTheDocument()
+  })
+})

--- a/src/components/AddTypeModal/Body/index.tsx
+++ b/src/components/AddTypeModal/Body/index.tsx
@@ -108,14 +108,16 @@ export const Body = ({ onSchemaCreate, selectedSchema, onDelete }: Props) => {
       try {
         const data = await getNodeSchemaTypes()
 
-        const schemaOptions = data.schemas.map((schema) =>
-          schema?.type === 'thing'
-            ? { label: 'No Parent', value: schema.type }
-            : {
-                label: schema.type,
-                value: schema.type,
-              },
-        )
+        const schemaOptions = data.schemas
+          .filter((schema) => !schema.is_deleted)
+          .map((schema) =>
+            schema?.type === 'thing'
+              ? { label: 'No Parent', value: schema.type }
+              : {
+                  label: schema.type,
+                  value: schema.type,
+                },
+          )
 
         setParentOptions(schemaOptions)
       } catch (error) {


### PR DESCRIPTION
### Ticket №: #1180

closes #1180

### Problem:

Remove is_deleted options for the parent selector dropdown

### As a Proof:

https://www.loom.com/share/7699629be9e54d65b192af52d6aa39fd?sid=05aee1a8-6775-45c9-8900-d80218340eb3
