### PR TITLE
fix: filter out deleted nodes

### DIFF
--- a/src/components/AddItemModal/SourceTypeStep/__tests__/index.tsx
+++ b/src/components/AddItemModal/SourceTypeStep/__tests__/index.tsx
@@ -1,7 +1,18 @@
 import '@testing-library/jest-dom'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import React from 'react'
 import { SourceTypeStep } from '..'
+jest.mock('~/network/fetchSourcesData', () => ({
+  getNodeSchemaTypes: jest.fn(() =>
+    Promise.resolve({
+      schemas: [
+        { type: 'node1', is_deleted: false },
+        { type: 'node2', is_deleted: true },
+        { type: 'node3', is_deleted: false },
+      ],
+    }),
+  ),
+}))
 
 describe('SourceTypeStep', () => {
   it('renders with initial selected type', () => {
@@ -28,5 +39,17 @@ describe('SourceTypeStep', () => {
     const inputField = screen.getByRole('combobox')
 
     expect(inputField).toHaveFocus()
+  })
+
+  it('filters out deleted node types from the dropdown', async () => {
+    render(<SourceTypeStep allowNextStep onSelectType={jest.fn()} selectedType="" skipToStep={jest.fn()} />)
+
+    const input = await screen.findByRole('combobox')
+    fireEvent.change(input, { target: { value: 'node2' } })
+
+    const options = await screen.findAllByRole('option')
+    expect(options).toHaveLength(2)
+    expect(options[0]).toHaveTextContent('node1')
+    expect(options[1]).toHaveTextContent('node3')
   })
 })

--- a/src/components/AddItemModal/SourceTypeStep/__tests__/index.tsx
+++ b/src/components/AddItemModal/SourceTypeStep/__tests__/index.tsx
@@ -11,19 +11,15 @@ jest.mock('~/stores/useFeatureFlagStore', () => ({
 describe('SourceTypeStep', () => {
   it('renders with initial selected type', () => {
     const selectedType = ''
-
     render(<SourceTypeStep allowNextStep onSelectType={jest.fn()} selectedType={selectedType} skipToStep={jest.fn()} />)
 
     const nextBtn = screen.getByRole('button', { name: 'Next' })
-
     expect(nextBtn).toBeInTheDocument()
 
     const selectTypeText = screen.getByText('Select Type')
-
     expect(selectTypeText).toBeInTheDocument()
 
     const inputField = screen.getByRole('combobox')
-
     expect(inputField).toHaveValue(selectedType)
   })
 
@@ -31,7 +27,6 @@ describe('SourceTypeStep', () => {
     render(<SourceTypeStep allowNextStep onSelectType={jest.fn()} selectedType="" skipToStep={jest.fn()} />)
 
     const inputField = screen.getByRole('combobox')
-
     expect(inputField).toHaveFocus()
   })
 
@@ -45,7 +40,7 @@ describe('SourceTypeStep', () => {
 
     jest.spyOn(fetchSourcesData, 'getNodeSchemaTypes').mockResolvedValue({ schemas: mockedSchemaTypes })
 
-    render(<SourceTypeStep skipToStep={jest.fn()} allowNextStep={true} onSelectType={jest.fn()} selectedType="" />)
+    render(<SourceTypeStep allowNextStep onSelectType={jest.fn()} selectedType="" skipToStep={jest.fn()} />)
 
     await waitFor(() => {
       const autocompleteOptions = screen.getAllByRole('option')

--- a/src/components/AddItemModal/SourceTypeStep/__tests__/index.tsx
+++ b/src/components/AddItemModal/SourceTypeStep/__tests__/index.tsx
@@ -11,15 +11,19 @@ jest.mock('~/stores/useFeatureFlagStore', () => ({
 describe('SourceTypeStep', () => {
   it('renders with initial selected type', () => {
     const selectedType = ''
+
     render(<SourceTypeStep allowNextStep onSelectType={jest.fn()} selectedType={selectedType} skipToStep={jest.fn()} />)
 
     const nextBtn = screen.getByRole('button', { name: 'Next' })
+
     expect(nextBtn).toBeInTheDocument()
 
     const selectTypeText = screen.getByText('Select Type')
+
     expect(selectTypeText).toBeInTheDocument()
 
     const inputField = screen.getByRole('combobox')
+
     expect(inputField).toHaveValue(selectedType)
   })
 
@@ -27,6 +31,7 @@ describe('SourceTypeStep', () => {
     render(<SourceTypeStep allowNextStep onSelectType={jest.fn()} selectedType="" skipToStep={jest.fn()} />)
 
     const inputField = screen.getByRole('combobox')
+
     expect(inputField).toHaveFocus()
   })
 
@@ -44,10 +49,12 @@ describe('SourceTypeStep', () => {
 
     await waitFor(() => {
       const autocompleteOptions = screen.getAllByRole('option')
+
       expect(autocompleteOptions).toHaveLength(1)
       expect(autocompleteOptions[0]).toHaveTextContent('Node1')
 
       const deletedNodeType = screen.queryByText('Node2')
+
       expect(deletedNodeType).toBeNull()
     })
   })

--- a/src/components/AddItemModal/SourceTypeStep/index.tsx
+++ b/src/components/AddItemModal/SourceTypeStep/index.tsx
@@ -26,7 +26,7 @@ export const SourceTypeStep: FC<Props> = ({ skipToStep, allowNextStep, onSelectT
           const nodeTypesToHide = ['about', 'schema']
 
           const schemaOptions = data.schemas
-            .filter((schema) => !nodeTypesToHide.includes(schema.type))
+            .filter((schema) => !nodeTypesToHide.includes(schema.type) && !schema.is_deleted)
             .map((schema) => ({
               label: capitalizeString(schema.type),
               value: schema.type,


### PR DESCRIPTION
### Ticket №: #1179

closes #1179

### Problem:

Add check for deleted node types

### Solution:

To add a check for deleted nodes while fetching schemas 

### Testing:

Added a test to check check that the dropdown filters out deleted node_types