### PR TITLE
 fix:Highlighting name field in Topic Curation table should not execute search

### DIFF
--- a/src/components/SourcesTableModal/SourcesView/Topics/Table/TableRow.tsx
+++ b/src/components/SourcesTableModal/SourcesView/Topics/Table/TableRow.tsx
@@ -54,8 +54,12 @@ const TableRowComponent: FC<TTableRaw> = ({ topic, onClick, onSearch, checkedSta
     }))
   }
 
-  const handleClickTopic = (topicItem: Topic) => {
-    onSearch(topicItem.topic)
+  const handleClickTopic = (event: React.MouseEvent<HTMLTableCellElement, MouseEvent>, topicItem: Topic) => {
+    if (window.getSelection()?.toString()) {
+      event.preventDefault()
+    } else {
+      onSearch(topicItem.topic)
+    }
   }
 
   const lettersToShow = topic.edgeList.slice(0, 1)
@@ -87,7 +91,7 @@ const TableRowComponent: FC<TTableRaw> = ({ topic, onClick, onSearch, checkedSta
           </CheckboxIcon>
         </CheckboxSection>
       </StyledTableCell>
-      <StyledTableCell onClick={() => handleClickTopic(topic)}>
+      <StyledTableCell onClick={(event) => handleClickTopic(event, topic)}>
         <ClickableText>{topic.topic}</ClickableText>
       </StyledTableCell>
       <StyledTableCell>{topic.edgeCount}</StyledTableCell>


### PR DESCRIPTION
### Ticket №: #1169 

closes #1169 

### Solution:

- [x]  Fix issue where highlighting the name, does NOT execute a search
- [x] User should be able to copy the name without the modal closing

### Preview

https://www.loom.com/share/afe290175ef743c0acdccfdb8675ff4f?sid=dec0a57b-b3af-4868-8d6c-e2db18d73d56
