### PR TITLE
Ensure Required Fields Are Filled Before Enabling `Next` Button and Correct `Scrollbar` Positioning

### DIFF
--- a/src/components/AddItemModal/SetAttributesStep/index.tsx
+++ b/src/components/AddItemModal/SetAttributesStep/index.tsx
@@ -20,7 +20,11 @@ type Props = {
 export const SetAttributesStep: FC<Props> = ({ skipToStep, nodeType }) => {
   const [loading, setLoading] = useState(false)
   const [attributes, setAttributes] = useState<parsedObjProps[]>()
-  const { watch } = useFormContext()
+
+  const {
+    watch,
+    formState: { isValid },
+  } = useFormContext()
 
   useEffect(() => {
     const init = async () => {
@@ -37,6 +41,8 @@ export const SetAttributesStep: FC<Props> = ({ skipToStep, nodeType }) => {
 
     init()
   }, [nodeType, watch])
+
+  const capitalizeFirstLetter = (string: string) => string.charAt(0).toUpperCase() + string.slice(1).replace(/_/g, ' ')
 
   return (
     <Flex>
@@ -56,7 +62,7 @@ export const SetAttributesStep: FC<Props> = ({ skipToStep, nodeType }) => {
             {attributes?.map(({ key, required }: parsedObjProps) => (
               <>
                 <TextFeildWrapper>
-                  <Text>{key.replace('_', ' ')}</Text>
+                  <Text>{capitalizeFirstLetter(key)}</Text>
                   <TextInput
                     id="item-name"
                     name={key}
@@ -79,7 +85,13 @@ export const SetAttributesStep: FC<Props> = ({ skipToStep, nodeType }) => {
           </Button>
         </Flex>
         <Flex grow={1} ml={20}>
-          <Button color="secondary" onClick={() => skipToStep('setBudget')} size="large" variant="contained">
+          <Button
+            color="secondary"
+            disabled={!isValid || loading || attributes?.some((attr) => attr.required && !watch(attr.key))}
+            onClick={() => skipToStep('setBudget')}
+            size="large"
+            variant="contained"
+          >
             Next
           </Button>
         </Flex>
@@ -106,6 +118,8 @@ const StyledWrapper = styled(Flex)`
     gap: 15px;
     max-height: 225px;
     overflow-y: auto;
+    padding-right: 20px;
+    width: calc(100% + 20px);
   }
 `
 


### PR DESCRIPTION
### Problem:
The current implementation allows the addition of an item without filling in the required fields. This results in the 'Next' button being enabled prematurely during the Add item flow. Additionally, the positioning of the scrollbar on the "Add Item" modal is incorrect. Also, capitalize the first letters for each: Age, Name, Namez.

### Expected Behavior:
The system should prevent the addition of an item until all required fields are filled. Consequently, the 'Next' button should remain disabled until all necessary attributes are set during the Add item flow. Furthermore, the scrollbar positioning within the "Add Item" modal should be corrected to ensure a proper user experience.

closes: #1196

## Issue ticket number and link:
- **Ticket Number:** [ 1196 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1196 ]

### Testing:
- Verify that the 'Next' button remains disabled until all required fields are filled during the Add item flow.
- Confirm that the scrollbar positioning within the "Add Item" modal is adjusted correctly to provide a smooth user experience.

### Evidence:
 - Please see the attached video as evidence.
https://www.loom.com/share/18cbf0e9967f4378b763972bad77b98e

### Evidence Images:

**Step#1:**
![image](https://github.com/stakwork/sphinx-nav-fiber/assets/87068339/74a20cee-fc1b-4544-b845-942c18807b6c)

**Step#2:**
![image](https://github.com/stakwork/sphinx-nav-fiber/assets/87068339/4646cac9-5cb9-4f48-8e7a-2d0ffde5bb2d)

**Step#3:**
![image](https://github.com/stakwork/sphinx-nav-fiber/assets/87068339/d96addcf-f490-493e-b7a7-6afa6a332b91)
