### PR TITLE
Hide `Load More` Button in View Content Modal

### DIFF
--- a/src/components/SourcesTableModal/SourcesView/Content/index.tsx
+++ b/src/components/SourcesTableModal/SourcesView/Content/index.tsx
@@ -14,7 +14,6 @@ export const Content = () => {
   const [nodes, setNodes] = useState<Node[]>([])
   const [loading, setLoading] = useState(true)
   const [loadLimit, setLoadLimit] = useState(10)
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [newNodesAvailable, setNewNodesAvailable] = useState(true)
 
   const viewContentParams = {
@@ -28,6 +27,10 @@ export const Content = () => {
 
     try {
       const response = await getNodeContent(viewContentParams)
+
+      if (response.nodes.length === 0) {
+        setNewNodesAvailable(false)
+      }
 
       setNodes(response.nodes)
       setLoading(false)
@@ -61,7 +64,7 @@ export const Content = () => {
             <Table nodes={nodes} />
           </>
         )}
-        {!loading ? (
+        {!loading && nodes.length > 0 ? (
           newNodesAvailable ? (
             <Button onClick={handleLoadMore} size="medium">
               Load More


### PR DESCRIPTION
### Problem:
Currently, when the view content table is empty, the 'Load more' button remains visible, which is contrary to the expected behavior.

### Expected Behavior:
The "Load More" button should be hidden when the view content table is empty.

closes: #1199

## Issue ticket number and link:
- **Ticket Number:** [ 1199 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1199 ]

### Testing:
- Tested the behavior of the "Load More" button when the content table is empty.
- Verified that the button is hidden in this scenario.

### Evidence:
 - Please see the attached image as evidence.
![image](https://github.com/stakwork/sphinx-nav-fiber/assets/100023456/e9df67aa-67f8-49f0-b61e-fb615c929fae)
