### PR TITLE
Ensure `SideBar` and `SideBarSubView` Sources Link Out to the Browser.

### DIFF
--- a/src/components/App/SideBar/Relevance/Episode/index.tsx
+++ b/src/components/App/SideBar/Relevance/Episode/index.tsx
@@ -95,7 +95,11 @@ export const Episode = ({
                 {type && <TypeBadge type={type} />}
               </Flex>
               {type === 'youtube' && sourceLink ? (
-                <StyledLink href={`${sourceLink}?open=system`} onClick={(e) => e.stopPropagation()}>
+                <StyledLink
+                  href={`${sourceLink}${sourceLink.includes('?') ? '&' : '?'}open=system`}
+                  onClick={(e) => e.stopPropagation()}
+                  target="_blank"
+                >
                   <LinkIcon />
                 </StyledLink>
               ) : null}

--- a/src/components/App/SideBar/TwitData/__tests__/index.tsx
+++ b/src/components/App/SideBar/TwitData/__tests__/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable padding-line-between-statements */
 import '@testing-library/jest-dom'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import moment from 'moment'
@@ -84,12 +85,18 @@ describe('TwitData Component', () => {
   })
 
   it('external link to the tweet is correctly constructed', () => {
+    const mockOpen = jest.fn()
+
+    window.open = mockOpen
+
     const { getByText } = render(<TwitData />)
     const viewTweetButton = getByText('View Tweet')
 
-    expect(viewTweetButton.closest('a')).toHaveAttribute(
-      'href',
+    fireEvent.click(viewTweetButton)
+
+    expect(mockOpen).toHaveBeenCalledWith(
       `https://twitter.com/Interior/status/${mockSelectedNode.tweet_id}?open=system`,
+      '_blank',
     )
   })
 })

--- a/src/components/App/SideBar/TwitData/index.tsx
+++ b/src/components/App/SideBar/TwitData/index.tsx
@@ -61,9 +61,17 @@ export const TwitData = () => {
             </Flex>
           </Flex>
           <Flex align="stretch" mt={22}>
-            <a href={`https://twitter.com/Interior/status/${twitId}?open=system`}>
-              <StyledButton endIcon={<LinkIcon />}>View Tweet </StyledButton>
-            </a>
+            <StyledButton
+              endIcon={<LinkIcon />}
+              onClick={() =>
+                window.open(
+                  `https://twitter.com/Interior/status/${twitId}${twitId.includes('?') ? '&' : '?'}open=system`,
+                  '_blank',
+                )
+              }
+            >
+              View Tweet
+            </StyledButton>
           </Flex>
         </Flex>
         <StyledDivider />
@@ -79,7 +87,7 @@ export const TwitData = () => {
 const PictureWrapper = styled(Flex)`
   img {
     width: 64px;
-    height: 64px
+    height: 64px;
     border-radius: 50%;
     object-fit: cover;
   }


### PR DESCRIPTION
### Problem:
Currently, the `SideBar` and `SideBarSubView` sources fail to link out to the browser as expected. This means `tweets` and `YouTube` links are not opening in a new tab as intended.

### Expected Behavior:
When users click on `tweets` or `YouTube` links within the `SideBar` or `SideBarSubView` sources, they should open in a new browser tab for better user experience and navigation flow.

closes: #1197

## Issue ticket number and link:
- **Ticket Number:** [ 1197 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1197 ]

### Testing:
- Testing has been conducted to ensure that clicking on tweets and YouTube links within the SideBar and SideBarSubView sources correctly opens them in a new browser tab.

### Evidence:
 - Please see the attached video as evidence.
https://www.loom.com/share/d478a602523045d4a9aa3ab90c8702ba