### PR TITLE
Fix UI `Search Placeholder` and `Column Names` in Sources Table

### DIFF
--- a/src/components/SourcesTableModal/SourcesView/Sources/index.tsx
+++ b/src/components/SourcesTableModal/SourcesView/Sources/index.tsx
@@ -71,7 +71,7 @@ export const Sources = () => {
           defaultIcon={<SearchIcon />}
           loadingIcon={<ClipLoader color={colors.PRIMARY_BLUE} size={24} />}
           onSearch={setSearch}
-          placeholder="Find Topic"
+          placeholder="Find Source"
         />
       </InputWrapper>
       <Flex className="filters" direction="row" pb={16} px={36}>

--- a/src/components/SourcesTableModal/SourcesView/constants.ts
+++ b/src/components/SourcesTableModal/SourcesView/constants.ts
@@ -7,8 +7,8 @@ export const sourcesMapper: ISourceMap = {
   [YOUTUBE_CHANNEL]: 'Youtube channel',
 }
 
-export const SOURCE_TABLE = 'Sources table'
-export const QUEUED_SOURCES = 'Queued sources'
+export const SOURCE_TABLE = 'Sources Table'
+export const QUEUED_SOURCES = 'Queued Sources'
 export const TOPICS = 'Topics'
 export const VIEW_CONTENT = 'View Content'
 


### PR DESCRIPTION
### Problem:
The search placeholder in the Sources table currently reads "Find Topic", which is misleading and does not accurately represent the action it performs. Additionally, there are inconsistencies and inaccuracies in the column names of the Sources table that need to be addressed to improve user experience and clarity.

### Expected Behavior:
The search placeholder in the Sources table should be updated to "Find Source" to more accurately reflect its functionality. Furthermore, the column names within the Sources table should be reviewed and corrected to ensure they are consistent and accurately describe the data presented.

closes: #1200

## Issue ticket number and link:
- **Ticket Number:** [ 1200 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1200 ]

### Evidence:
 - Please see the attached image as evidence.
![image](https://github.com/stakwork/sphinx-nav-fiber/assets/156602406/f50f1759-a4a5-4f6a-9d2e-7e04ff6d55ac)
