### PR TITLE
Resolve UI Display Issue: Blue Line Overflow on Highlighted Tabs for Admin and Sphinx Users

### DIFF
--- a/src/components/SettingsModal/SettingsView/index.tsx
+++ b/src/components/SettingsModal/SettingsView/index.tsx
@@ -97,7 +97,7 @@ const StyledTabs = styled(Tabs)`
     .MuiTabs-indicator {
       background: ${colors.primaryBlue};
     }
-    width: 90%;
+    padding-left: 34px;
   }
 `
 
@@ -109,19 +109,20 @@ const StyledHeader = styled(Flex)`
 
 const StyledTab = styled(Tab)`
   && {
-    padding: 30px 0 24px;
+    min-width: 0;
+    width: auto;
+    padding: 30px 0 19px;
     color: ${colors.GRAY6};
-    margin-left: 10px;
+    margin-right: 87px;
     font-family: Barlow;
     font-size: 16px;
     font-style: normal;
     font-weight: 500;
-    text-align: center;
+    text-align: left;
 
     &.Mui-selected {
       color: ${colors.white};
     }
-    flex-grow: 1;
   }
 `
 


### PR DESCRIPTION
### Problem:
The UI currently experiences an issue where the blue line overflows when tabs are highlighted, affecting both the admin and Sphinx user interfaces.

### Expected Behavior:
Tabs should be highlighted without any overflow of the blue line, ensuring a seamless user experience for both admin and Sphinx users.

closes: #1198

## Issue ticket number and link:
- **Ticket Number:** [ 1198 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1198 ]

### Evidence:
 - Please see the attached video as evidence.

https://www.loom.com/share/9b26e22166104f848fdfd70feae982e7

### Evidence Images:

Admin Side:
![image](https://github.com/stakwork/sphinx-nav-fiber/assets/163523353/fc80e0bd-c40e-4ea0-ac13-42f3768668f3)

Sphinx User Side:
![image](https://github.com/stakwork/sphinx-nav-fiber/assets/163523353/c9aec11a-e44f-44f0-95bd-fdfa6ed9d01f)
