### PR TITLE
Center `Loading` Icon on `Episode` and `YouTube` [SideBarSubView]

### DIFF
--- a/src/components/App/SideBar/SidebarSubView/MediaPlayer/index.tsx
+++ b/src/components/App/SideBar/SidebarSubView/MediaPlayer/index.tsx
@@ -207,7 +207,7 @@ const Cover = styled(Flex)`
 
 const Buffering = styled(Flex)`
   position: absolute;
-  top: 20%;
+  top: 39%;
   left: 50%;
   transform: translateX(-50%);
   z-index: 1;


### PR DESCRIPTION
### Problem:
The loading icon on the Episode and Youtube [SideBarSubView] is not centered, leading to a discrepancy in the UI presentation.

### Expected Behavior:
The loading icon on the Episode and Youtub [SideBarSubView] should be centered, ensuring a visually balanced layout.

closes: #1218

## Issue ticket number and link:
- **Ticket Number:** [ 1218 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1218 ]

### Testing:
- Confirm that the loading icon is centered within the Episode and Youtub [SideBarSubView].
- Verify the centering behavior across different devices and screen resolutions.

### Evidence:
 - Please see the attached video as evidence.
https://www.loom.com/share/fd38946e858f4dd8a7e99e0d2c8f2b76

### Evidence Image:
![image](https://github.com/stakwork/sphinx-nav-fiber/assets/100023456/ce60761c-8f1d-4523-9757-69b558ca20b1)