### PR TITLE
Fix `Scrollbar` Overflow in `SideBarSubView` Component

### DIFF
--- a/src/components/App/SideBar/SidebarSubView/__tests__/index.tsx
+++ b/src/components/App/SideBar/SidebarSubView/__tests__/index.tsx
@@ -74,7 +74,7 @@ describe('Test SideBarSubView', () => {
     expect(getByTestId('sidebar-sub-view')).toHaveStyle({ visibility: 'hidden' })
   })
 
-  it('asserts that close button resets the selected node and hides the teach me', () => {
+  it('asserts that close button resets the selected node and hide the teach me', () => {
     const [setSelectedNodeMock, setTeachMeMock] = new Array(2).fill(jest.fn())
 
     useDataStoreMock.mockReturnValue({

--- a/src/components/App/SideBar/SidebarSubView/index.tsx
+++ b/src/components/App/SideBar/SidebarSubView/index.tsx
@@ -59,6 +59,7 @@ const Wrapper = styled(Flex)(({ theme }) => ({
   margin: '64px auto 20px 10px',
   borderRadius: '16px',
   zIndex: 29,
+  overflow: 'hidden',
   [theme.breakpoints.up('sm')]: {
     width: '390px',
   },


### PR DESCRIPTION
### Problem:
The scrollbar within the `SideBarSubView` component overflows beyond the rounded corners of the `Wrapper` when various options are displayed, leading to a visual inconsistency and a non-contained scrollbar.

### Expected Behavior:
The scrollbar should be fully contained within the `Wrapper` component, respecting the `borderRadius` property, regardless of the number of options or content displayed within the `SideBarSubView`.

closes: #1224

## Issue ticket number and link:
- **Ticket Number:** [ 1224 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1224 ]

### Solution:
The proposed fix involves adding overflow: hidden to the Wrapper styled component to ensure that all child components, including the scrollbar, are clipped to the Wrapper's bounds. This change maintains the visual integrity of the SideBarSubView's design by preventing any overflow beyond the specified borderRadius.

### Testing:
- Verify that the scrollbar is no longer visible outside the Wrapper's rounded corners.
- Test with a varying number of options to ensure the scrollbar consistently stays within the Wrapper.
- Ensure that the functionality of the SideBarSubView remains unchanged and that all interactive elements are accessible.

### Evidence:
 - Please see the attached video as evidence.
https://www.loom.com/share/e18809c876634babb87e3523edb001f6

### Evidence Image:
![image](https://github.com/stakwork/sphinx-nav-fiber/assets/100023456/84bb92ab-0b8e-4c09-9e8f-59a8a1eb8881)
