### PR TITLE
Fix Timestamp Seeking Issue in Video Player

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -2,3 +2,9 @@ import '@testing-library/jest-dom'
 import fetch from 'node-fetch'
 
 global.fetch = fetch
+
+global.setImmediate = (callback, ...args) => setTimeout(callback, 0, ...args)
+
+global.clearImmediate = (id) => {
+  clearTimeout(id)
+}

--- a/src/components/App/SideBar/Episode/index.tsx
+++ b/src/components/App/SideBar/Episode/index.tsx
@@ -35,10 +35,11 @@ export const Episode = () => {
 
   const [selectedTimestamp, setSelectedTimestamp] = useState<NodeExtended | null>(null)
 
-  const [playingNode, setPlayingNodeLink, setPlayingTime] = usePlayerStore((s) => [
+  const [playingNode, setPlayingNodeLink, setPlayingTime, setIsSeeking] = usePlayerStore((s) => [
     s.playingNode,
     s.setPlayingNodeLink,
     s.setPlayingTime,
+    s.setIsSeeking,
   ])
 
   const selectedNodeTimestamps = useMemo(
@@ -53,14 +54,17 @@ export const Episode = () => {
 
   const updateActiveTimestamp = useCallback(
     (timestamp: NodeExtended) => {
+      const newTime = videoTimeToSeconds(timestamp?.timestamp?.split('-')[0] || '00:00:01')
+
       if (playingNode && timestamp.link && playingNode?.link !== timestamp.link) {
         setPlayingNodeLink(timestamp.link)
       }
 
-      setPlayingTime(videoTimeToSeconds(timestamp?.timestamp?.split('-')[0] || '00:00:01'))
+      setPlayingTime(newTime)
+      setIsSeeking(true)
       setSelectedTimestamp(timestamp)
     },
-    [playingNode, setPlayingNodeLink, setSelectedTimestamp, setPlayingTime],
+    [playingNode, setPlayingNodeLink, setIsSeeking, setSelectedTimestamp, setPlayingTime],
   )
 
   useEffect(() => {

--- a/src/components/App/SideBar/SidebarSubView/MediaPlayer/index.tsx
+++ b/src/components/App/SideBar/SidebarSubView/MediaPlayer/index.tsx
@@ -31,9 +31,18 @@ const MediaPlayerComponent: FC<Props> = ({ hidden }) => {
     setVolume,
     setHasError,
     resetPlayer,
+    isSeeking,
+    setIsSeeking,
   } = usePlayerStore((s) => s)
 
   useEffect(() => () => resetPlayer(), [resetPlayer])
+
+  useEffect(() => {
+    if (isSeeking && playerRef.current) {
+      playerRef.current.seekTo(playingTime, 'seconds')
+      setIsSeeking(false)
+    }
+  }, [playingTime, isSeeking, setIsSeeking])
 
   const togglePlay = () => {
     setIsPlaying(!isPlaying)
@@ -68,9 +77,11 @@ const MediaPlayerComponent: FC<Props> = ({ hidden }) => {
   }
 
   const handleProgress = (progress: { playedSeconds: number }) => {
-    const currentTime = progress.playedSeconds
+    if (!isSeeking) {
+      const currentTime = progress.playedSeconds
 
-    setPlayingTime(currentTime)
+      setPlayingTime(currentTime)
+    }
   }
 
   const handleReady = () => {
@@ -157,6 +168,7 @@ const MediaPlayerComponent: FC<Props> = ({ hidden }) => {
         onPlay={handlePlay}
         onProgress={handleProgress}
         onReady={handleReady}
+        // onSeek={(e) => setPlayingTime(e)}
         playing={isPlaying}
         url={playingNode?.link || ''}
         volume={volume}

--- a/src/components/App/SideBar/SidebarSubView/MediaPlayer/index.tsx
+++ b/src/components/App/SideBar/SidebarSubView/MediaPlayer/index.tsx
@@ -168,7 +168,6 @@ const MediaPlayerComponent: FC<Props> = ({ hidden }) => {
         onPlay={handlePlay}
         onProgress={handleProgress}
         onReady={handleReady}
-        // onSeek={(e) => setPlayingTime(e)}
         playing={isPlaying}
         url={playingNode?.link || ''}
         volume={volume}

--- a/src/components/App/SideBar/SidebarSubView/__tests__/index.tsx
+++ b/src/components/App/SideBar/SidebarSubView/__tests__/index.tsx
@@ -74,7 +74,7 @@ describe('Test SideBarSubView', () => {
     expect(getByTestId('sidebar-sub-view')).toHaveStyle({ visibility: 'hidden' })
   })
 
-  it('asserts that close button resets the selected node and hides the teach me', () => {
+  it('asserts that close button resets the selected nodes and hides the teach me', () => {
     const [setSelectedNodeMock, setTeachMeMock] = new Array(2).fill(jest.fn())
 
     useDataStoreMock.mockReturnValue({

--- a/src/components/App/SideBar/SidebarSubView/__tests__/index.tsx
+++ b/src/components/App/SideBar/SidebarSubView/__tests__/index.tsx
@@ -74,7 +74,7 @@ describe('Test SideBarSubView', () => {
     expect(getByTestId('sidebar-sub-view')).toHaveStyle({ visibility: 'hidden' })
   })
 
-  it('asserts that close button resets the selected nodes and hides the teach me', () => {
+  it('asserts that close button resets the selected node and hides the teach me', () => {
     const [setSelectedNodeMock, setTeachMeMock] = new Array(2).fill(jest.fn())
 
     useDataStoreMock.mockReturnValue({

--- a/src/stores/usePlayerStore/index.ts
+++ b/src/stores/usePlayerStore/index.ts
@@ -6,6 +6,7 @@ type PlayerStore = {
   isPlaying: boolean
   miniPlayerIsVisible: boolean
   hasError: boolean
+  isSeeking: boolean
   playingTime: number
   duration: number
   volume: number
@@ -19,6 +20,7 @@ type PlayerStore = {
   setHasError: (hasError: boolean) => void
   setPlayingNode: (playingNode: NodeExtended | null) => void
   setPlayingNodeLink: (link: string) => void
+  setIsSeeking: (isSeeking: boolean) => void
 }
 
 const defaultData: Omit<
@@ -32,10 +34,12 @@ const defaultData: Omit<
   | 'resetPlayer'
   | 'setMiniPlayerIsVisible'
   | 'setPlayingNodeLink'
+  | 'setIsSeeking'
 > = {
   isPlaying: false,
   miniPlayerIsVisible: false,
   hasError: false,
+  isSeeking: false,
   playingTime: 0,
   playingNode: null,
   duration: 0,
@@ -45,6 +49,7 @@ const defaultData: Omit<
 export const usePlayerStore = create<PlayerStore>()(
   devtools((set, get) => ({
     ...defaultData,
+    setIsSeeking: (isSeeking) => set({ isSeeking }),
     setIsPlaying: (isPlaying) => set({ isPlaying }),
     setMiniPlayerIsVisible: (miniPlayerIsVisible) => {
       if (!miniPlayerIsVisible) {


### PR DESCRIPTION
### Problem:
When a user clicks on a timestamp within an episode, the video player seeks to the correct time but then immediately returns to the initial position. This behavior prevents users from navigating to different parts of the video based on the selected timestamp.

### Expected Behavior:
Upon clicking a timestamp, the video player should seek to the specified time and remain at that position, allowing the user to view the content from the chosen timestamp.

closes: #1223

## Issue ticket number and link:
- **Ticket Number:** [ 1223 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1223 ]

### Solution:
The pull request addresses the issue by introducing a new state variable isSeeking in the usePlayerStore. This variable is used to determine when a seek operation is initiated by a user action. The MediaPlayer component has been updated to only seek when isSeeking is true, and the isSeeking state is reset after the seek operation is complete. This prevents the video player from resetting to the initial position after seeking.

### Changes Made:
- Added isSeeking state to usePlayerStore to track when user initiates a seek.
-  Implemented setIsSeeking action within usePlayerStore.
- Updated Episode component to set isSeeking to true when a timestamp is clicked.
- Modified MediaPlayer component to seek only when isSeeking is true.
- Adjusted handleProgress function in MediaPlayer to avoid updating playingTime during a seek operation.

### Testing:
- Click on various timestamps within an episode to ensure the video player seeks to the correct time.
- Verify that the video player remains at the sought position and does not reset to the beginning.
- Test the behavior across different browsers and devices to ensure consistency.
- Check that other player functionalities (play, pause, volume control, etc.) remain unaffected.

### Evidence:
 - Please see the attached video as evidence.
 https://www.loom.com/share/4ff8513232c34d4396de652d490247c9