### PR TITLE
Fix: Select Parent Options `Capitalization` and `Scrollbar` Alignment in Setting Modal

### DIFF
--- a/src/components/AddTypeModal/Body/CustomAttributesStep/FormInput/index.tsx
+++ b/src/components/AddTypeModal/Body/CustomAttributesStep/FormInput/index.tsx
@@ -127,4 +127,5 @@ export const FormInput = ({ parentParam }: { parentParam: string }) => {
 const InputsWrapper = styled(Flex)`
   max-height: 260px;
   overflow: auto;
+  width: calc(100% + 20px);
 `

--- a/src/components/AddTypeModal/Body/__tests__/index.spec.tsx
+++ b/src/components/AddTypeModal/Body/__tests__/index.spec.tsx
@@ -1,7 +1,9 @@
+/* eslint-disable padding-line-between-statements */
 import React from 'react'
 import { render, screen } from '@testing-library/react'
 import { Body } from '../index'
 import * as fetchSourcesData from '~/network/fetchSourcesData'
+import '@testing-library/jest-dom'
 
 describe('Body Component', () => {
   it('filters out deleted types from the dropdown', async () => {
@@ -43,6 +45,6 @@ describe('Body Component', () => {
 
     expect(screen.queryByText('Persontest')).not.toBeInTheDocument()
 
-    expect(screen.getByText('place')).toBeInTheDocument()
+    expect(screen.getByText('Place')).toBeInTheDocument()
   })
 })

--- a/src/components/AddTypeModal/Body/index.tsx
+++ b/src/components/AddTypeModal/Body/index.tsx
@@ -101,6 +101,8 @@ export const Body = ({ onSchemaCreate, selectedSchema, onDelete }: Props) => {
     [visible, reset],
   )
 
+  const capitalizeFirstLetter = (string: string) => string.charAt(0).toUpperCase() + string.slice(1)
+
   useEffect(() => {
     const init = async () => {
       setParentsLoading(true)
@@ -114,7 +116,7 @@ export const Body = ({ onSchemaCreate, selectedSchema, onDelete }: Props) => {
             schema?.type === 'thing'
               ? { label: 'No Parent', value: schema.type }
               : {
-                  label: schema.type,
+                  label: capitalizeFirstLetter(schema.type),
                   value: schema.type,
                 },
           )


### PR DESCRIPTION
### Problem:
The Setting Modal exhibits two main issues:
- The Select Parent options are not `capitalized` properly.
- The `scrollbar` within the modal is not positioned on the `right side`, leading to misalignment.

### Expected Behavior:
- The `Select Parent Options` feature should capitalize the first letters of its options in the Setting Modal.
- The `scrollbar` within the modal should be positioned on the right side, ensuring proper alignment.

closes: #1216

## Issue ticket number and link:
- **Ticket Number:** [ 1216 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1216 ]

### Testing:
- Verify that the Select Parent options are capitalized correctly within the Setting Modal.
- Confirm that the scrollbar is positioned on the right side of the modal, aligning with standard UI conventions.

### Evidence:
 - Please see the attached video as evidence.
https://www.loom.com/share/e21d8c0f93564944929bcd9ea39a8687

### Evidence Image:
Image#1:

`Select Parent Options Capitalized`
 
![image](https://github.com/stakwork/sphinx-nav-fiber/assets/156602406/0acc9826-338a-407e-86b3-8c0fd23b3f07)

Image#2:

`Scrollbar is positioned on the right side`

![image](https://github.com/stakwork/sphinx-nav-fiber/assets/156602406/26d96020-db8d-4767-a492-433d8a85caeb)
