### PR TITLE
Fix: Syntax Updates for `Button/Column` Labels and Resolved `Scrollbar Overflow` in Settings Modal

### DIFF
--- a/src/components/SettingsModal/SettingsView/Appearance/index.tsx
+++ b/src/components/SettingsModal/SettingsView/Appearance/index.tsx
@@ -24,7 +24,7 @@ export const Appearance: FC<Props> = ({ onClose }) => {
       <GraphViewControl />
       <Flex mt={308}>
         <Button kind="big" onClick={handleSave}>
-          Save changes
+          Save Changes
         </Button>
       </Flex>
     </Wrapper>

--- a/src/components/SettingsModal/SettingsView/General/index.tsx
+++ b/src/components/SettingsModal/SettingsView/General/index.tsx
@@ -66,7 +66,7 @@ export const General: FC<Props> = ({ initialValues }) => {
               </SubmitLoader>
             ) : (
               <Button disabled={isSubmitting} id="add-node-submit-cta" kind="big" type="submit">
-                Save changes
+                Save Changes
               </Button>
             )}
           </Flex>

--- a/src/components/SettingsModal/SettingsView/index.tsx
+++ b/src/components/SettingsModal/SettingsView/index.tsx
@@ -133,6 +133,8 @@ const TabPanelWrapper = styled(Flex)`
   max-height: 495px;
   height: fit-content;
   min-width: 480px;
+  overflow: hidden;
+  border-radius: 9px;
 `
 
 const Wrapper = styled(Flex)`

--- a/src/components/SettingsModal/SettingsView/utils/__tests__/index.tsx
+++ b/src/components/SettingsModal/SettingsView/utils/__tests__/index.tsx
@@ -1,5 +1,7 @@
+/* eslint-disable padding-line-between-statements */
 import { fireEvent, render, screen } from '@testing-library/react'
 import * as React from 'react'
+import '@testing-library/jest-dom'
 import { SettingsView } from '../../index'
 
 import * as useUserStoreModule from '../../../../../stores/useUserStore'


### PR DESCRIPTION
### Problem:
The interface lacked consistency and clarity due to syntax inconsistencies in buttons [General, Appearance] or column [BluePrint], and the Settings Modal experienced scrollbar overflow issues.

### Expected Behavior:
- Button labels [General, Appearance] or column label [BluePrint] should have consistent and clear syntax for improved interface readability.
- The Settings Modal should no longer experience scrollbar overflow, ensuring proper display and usability.

closes: #1217

## Issue ticket number and link:
- **Ticket Number:** [ 1217 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1217 ]

### Testing:
- Verify that the syntax of buttons [General, Appearance] or column [BluePrint] is updated for consistency and clarity.
- Confirm that the Settings Modal no longer experiences scrollbar overflow.

### Evidence:
 - Please see the attached video as evidence.
https://www.loom.com/share/9593b8e01b3f4dea80e6ef2ad6558835
