### PR TITLE
Ensure `Required` Fields Are Displayed First

### DIFF
--- a/src/components/AddItemModal/SetAttributesStep/index.tsx
+++ b/src/components/AddItemModal/SetAttributesStep/index.tsx
@@ -44,17 +44,19 @@ export const SetAttributesStep: FC<Props> = ({ skipToStep, nodeType }) => {
 
   const capitalizeFirstLetter = (string: string) => string.charAt(0).toUpperCase() + string.slice(1).replace(/_/g, ' ')
 
-  const sortedAttributes = attributes?.sort((a, b) => {
-    if (a.required && !b.required) {
-      return -1
-    }
+  const sortedAttributes = attributes
+    ? [...attributes].sort((a, b) => {
+        if (a.required && !b.required) {
+          return -1
+        }
 
-    if (!a.required && b.required) {
-      return 1
-    }
+        if (!a.required && b.required) {
+          return 1
+        }
 
-    return 0
-  })
+        return 0
+      })
+    : []
 
   return (
     <Flex>

--- a/src/components/AddItemModal/SetAttributesStep/index.tsx
+++ b/src/components/AddItemModal/SetAttributesStep/index.tsx
@@ -44,6 +44,18 @@ export const SetAttributesStep: FC<Props> = ({ skipToStep, nodeType }) => {
 
   const capitalizeFirstLetter = (string: string) => string.charAt(0).toUpperCase() + string.slice(1).replace(/_/g, ' ')
 
+  const sortedAttributes = attributes?.sort((a, b) => {
+    if (a.required && !b.required) {
+      return -1
+    }
+
+    if (!a.required && b.required) {
+      return 1
+    }
+
+    return 0
+  })
+
   return (
     <Flex>
       <Flex align="center" direction="row" justify="space-between" mb={18}>
@@ -59,7 +71,7 @@ export const SetAttributesStep: FC<Props> = ({ skipToStep, nodeType }) => {
           </Flex>
         ) : (
           <Flex className="input__wrapper">
-            {attributes?.map(({ key, required }: parsedObjProps) => (
+            {sortedAttributes?.map(({ key, required }: parsedObjProps) => (
               <>
                 <TextFeildWrapper>
                   <Text>{capitalizeFirstLetter(key)}</Text>


### PR DESCRIPTION
### Problem:
Currently, the frontend does not consistently render required fields first, leading to potential confusion for users.

### Expected Behavior:
Required fields should always be displayed first in the frontend, followed by optional fields. This ensures clarity and consistency in the user interface.

closes: #1234

## Issue ticket number and link:
- **Ticket Number:** [ 1234 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1234 ]

### Testing:
- Verify that required fields are displayed before optional fields in all relevant forms or UI components.
- Test various scenarios with different combinations of required and optional fields to ensure consistent behavior.

### Evidence:
 - Please see the attached video as evidence.
https://www.loom.com/share/188d6e2c58ee4774bfe6d282b3c6497a

### Evidence Image:
![image](https://github.com/stakwork/sphinx-nav-fiber/assets/100023456/e092e57d-01b1-471d-9c2a-763f7a33afb8)
