### PR TITLE
Disable Attribute Name Field Editing for Custom Node in Blueprint Settings

### DIFF
--- a/src/components/AddTypeModal/Body/CustomAttributesStep/FormInput/index.tsx
+++ b/src/components/AddTypeModal/Body/CustomAttributesStep/FormInput/index.tsx
@@ -16,6 +16,10 @@ import { parseJson, parsedObjProps } from '../../../utils'
 
 const noSpacePattern = /^[a-z0-9_]+$/
 
+interface CustomField extends Record<'id', string> {
+  isNew?: boolean
+}
+
 export const FormInput = ({ parentParam }: { parentParam: string }) => {
   const [loading, setLoading] = useState(false)
   const [parsedData, setParsedData] = useState<parsedObjProps[]>([])
@@ -62,9 +66,10 @@ export const FormInput = ({ parentParam }: { parentParam: string }) => {
       ) : (
         <InputsWrapper py={8}>
           <Grid container spacing={2}>
-            {fields.map((field, index) => {
+            {fields.map((field: CustomField, index) => {
               const type = watch(`attributes[${index}].type`)
               const checked = watch(`attributes[${index}].required`)
+              const isEditable = field.isNew || false
 
               return (
                 <Fragment key={field.id}>
@@ -72,6 +77,7 @@ export const FormInput = ({ parentParam }: { parentParam: string }) => {
                     <TextInput
                       autoComplete="off"
                       className="text-input"
+                      disabled={!isEditable}
                       id="cy-item-name"
                       maxLength={50}
                       name={`attributes.${index}.key` as const}
@@ -112,7 +118,7 @@ export const FormInput = ({ parentParam }: { parentParam: string }) => {
       )}
       <Flex align="flex-start" py={12}>
         <Button
-          onClick={() => append({ key: '', type: 'string', required: true })}
+          onClick={() => append({ key: '', type: 'string', required: true, isNew: true })}
           size="medium"
           startIcon={<PlusIcon />}
           variant="contained"

--- a/src/components/BaseTextInput/WebTextInput/index.tsx
+++ b/src/components/BaseTextInput/WebTextInput/index.tsx
@@ -20,7 +20,7 @@ export const WebTextInput = styled.input<Props>`
   color: ${({ colorName }) => colors[colorName]};
   cursor: ${({ disabled }) => (disabled ? 'default' : 'text')};
   margin: 0;
-  opacity: 1;
+  opacity: ${({ disabled }) => (disabled ? 0.5 : 1)};
   outline: 0;
   padding: 0;
   text-align: ${({ textAlign }) => textAlign};

--- a/src/components/Booster/__tests__/index.spec.tsx
+++ b/src/components/Booster/__tests__/index.spec.tsx
@@ -79,7 +79,7 @@ describe('Booster Component', () => {
     })
   })
 
-  it('shows visual feedback (any svg Icon) during the boosting pryocess', async () => {
+  it('shows visual feedback (any svg Icon) during the boosting process', async () => {
     mockedBoost.mockResolvedValueOnce(undefined)
 
     const { getByTestId } = render(<Booster refId="123" />)


### PR DESCRIPTION
### Problem:
When editing a custom node via Blueprint in Settings, the attribute name field is currently editable, which may lead to unintended changes.

### Expected Behavior:
The attribute name field for custom nodes should be disabled, preventing users from editing it. Users should still be able to modify the type and required status as normal. Additionally, PUT requests should retain the attribute name while allowing changes to type and required status.

closes: #1209

## Issue ticket number and link:
- **Ticket Number:** [ 1209 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1209 ]

### Testing:
- Ensure that users cannot edit the attribute name field when editing a custom node in Blueprint settings.
- Confirm that users can still modify the type and required status of the attribute.
- Verify that making changes to type and required status and submitting a PUT request retains the original attribute name.

### Evidence:
 - Please see the attached video as evidence.
https://www.loom.com/share/a605f28e06dd43d0a9aff9a9059a3224

### Evidence Image:
![image](https://github.com/stakwork/sphinx-nav-fiber/assets/87068339/2962fef2-8f92-4496-90bb-220b0692ad9f)