### PR TITLE
Fix: `Description`, `Transcript`, and `Booster` Functionality Issues on Episode [SideBarSubView]

### DIFF
--- a/src/components/App/SideBar/Media/__tests__/index.tsx
+++ b/src/components/App/SideBar/Media/__tests__/index.tsx
@@ -43,7 +43,7 @@ describe('Media Component Tests', () => {
     expect(container).toBeEmptyDOMElement()
   })
 
-  it('Correctly formats and displays the episodeTitle using formatDescription', () => {
+  it('Correctly formats and display the episodeTitle using formatDescription', () => {
     render(<Media node={mockNode} />)
     expect(mockedFormatDescription).toHaveBeenCalledWith(mockNode.episode_title)
   })

--- a/src/components/App/SideBar/Media/index.tsx
+++ b/src/components/App/SideBar/Media/index.tsx
@@ -36,7 +36,7 @@ export const Media = ({ node }: Props) => {
 
   const [boostAmount, setBoostAmount] = useState<number>(boost || 0)
 
-  if (!selectedNode) {
+  if (!node && !selectedNode) {
     return null
   }
 
@@ -58,15 +58,15 @@ export const Media = ({ node }: Props) => {
 
         <BoostWrapper>
           <BoostAmt amt={boostAmount} />
-          <Booster content={selectedNode} count={boostAmount} refId={refId} updateCount={setBoostAmount} />
+          <Booster content={node || selectedNode} count={boostAmount} refId={refId} updateCount={setBoostAmount} />
         </BoostWrapper>
         <StyledDivider />
         <TextWrapper>
-          <Description node={selectedNode} searchTerm={searchTerm} stateless />
+          <Description node={node || selectedNode} searchTerm={searchTerm} stateless />
         </TextWrapper>
         <StyledDivider />
         <TextWrapper>
-          <Transcript key={id} node={selectedNode} stateless />
+          <Transcript key={id} node={node || selectedNode} stateless />
         </TextWrapper>
       </Wrapper>
     </div>


### PR DESCRIPTION
### Problem:
- The Description feature within the Episode [SideBarSubView] fails to display relevant content associated with the episode.
- The Transcript functionality does not render any text or transcript data for the episode within the [SideBarSubView].
- The Booster functionality, intended to display the boost value or count for the episode, is not functioning properly within the [SideBarSubView].

### Expected Behavior:
- The Description feature should accurately display relevant content associated with the episode within the [SideBarSubView].
- The Transcript functionality must render the transcript text for the episode within the [SideBarSubView].
- The Booster component should correctly display the boost value or count for the episode within the [SideBarSubView].

closes: #1242

## Issue ticket number and link:
- **Ticket Number:** [ 1242 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1242 ]

### Testing:
- Tested the Description feature to ensure it displays relevant content accurately.
- Verified that the Transcript functionality renders transcript text for the episode.
- Confirmed that the Booster component displays the boost value or count correctly.

### Evidence:
 - Please see the attached video as evidence.
https://www.loom.com/share/f9f8ff5403434e81aafe7e608b641e49
