### PR TITLE
Source table modal tables must have sticky headers

### DIFF
--- a/src/components/SourcesTableModal/SourcesView/common/index.tsx
+++ b/src/components/SourcesTableModal/SourcesView/common/index.tsx
@@ -52,6 +52,10 @@ export const StyledTableRow = styled(TableRow)`
 export const StyledTableHead = styled(TableHead)`
   && {
     border-bottom: 1px solid ${colors.black};
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background-color: ${colors.BG1};
   }
 
   ${StyledTableCell} {


### PR DESCRIPTION
### Ticket №: #1254

closes #1254

### Problem:

The header of the table of modals is movable with rows, which is not good UX.

### As a Proof:

https://www.loom.com/share/cd0a69e519e34f878d398ee596f19c66?sid=3f3558ab-1b84-4b26-ad45-2bada1ced739
