### PR TITLE
Fix: Enable `Play/Pause` Functionality on `Tapping` and `Space Button` for Video Playback

### DIFF
--- a/cypress/e2e/admin/signin.cy.ts
+++ b/cypress/e2e/admin/signin.cy.ts
@@ -7,7 +7,7 @@ describe('Admin Login', () => {
       url: 'http://localhost:8444/api/about*',
     }).as('updateAbout')
 
-    const title = `TestingNavFiber`
+    const title = `Testing NavFiber`
 
     // Open settings modal
     cy.get('div[data-testid="settings-modal"]').should('be.visible').click()

--- a/cypress/e2e/admin/signin.cy.ts
+++ b/cypress/e2e/admin/signin.cy.ts
@@ -7,7 +7,7 @@ describe('Admin Login', () => {
       url: 'http://localhost:8444/api/about*',
     }).as('updateAbout')
 
-    const title = `Testing NavFiber`
+    const title = `TestingNavFiber`
 
     // Open settings modal
     cy.get('div[data-testid="settings-modal"]').should('be.visible').click()

--- a/src/components/App/SideBar/SidebarSubView/MediaPlayer/index.tsx
+++ b/src/components/App/SideBar/SidebarSubView/MediaPlayer/index.tsx
@@ -140,6 +140,9 @@ const MediaPlayerComponent: FC<Props> = ({ hidden }) => {
       if (isFullScreen && event.key === 'Escape') {
         event.preventDefault()
         event.stopPropagation()
+      } else if (event.key === ' ') {
+        event.preventDefault()
+        togglePlay()
       }
     }
 
@@ -152,27 +155,33 @@ const MediaPlayerComponent: FC<Props> = ({ hidden }) => {
     }
   })
 
+  const handlePlayerClick = () => {
+    togglePlay()
+  }
+
   return playingNode?.link ? (
     <Wrapper ref={wrapperRef} hidden={hidden}>
       <Cover>
         <Avatar size={120} src={playingNode?.image_url || ''} type="clip" />
       </Cover>
-      <ReactPlayer
-        ref={playerRef}
-        controls={false}
-        height={!isFullScreen ? '200px' : window.screen.height}
-        onBuffer={() => setStatus('buffering')}
-        onBufferEnd={() => setStatus('ready')}
-        onError={handleError}
-        onPause={handlePause}
-        onPlay={handlePlay}
-        onProgress={handleProgress}
-        onReady={handleReady}
-        playing={isPlaying}
-        url={playingNode?.link || ''}
-        volume={volume}
-        width="100%"
-      />
+      <PlayerWrapper onClick={handlePlayerClick}>
+        <ReactPlayer
+          ref={playerRef}
+          controls={false}
+          height={!isFullScreen ? '200px' : window.screen.height}
+          onBuffer={() => setStatus('buffering')}
+          onBufferEnd={() => setStatus('ready')}
+          onError={handleError}
+          onPause={handlePause}
+          onPlay={handlePlay}
+          onProgress={handleProgress}
+          onReady={handleReady}
+          playing={isPlaying}
+          url={playingNode?.link || ''}
+          volume={volume}
+          width="100%"
+        />
+      </PlayerWrapper>
       {status === 'error' ? (
         <ErrorWrapper className="error-wrapper">Error happened, please try later</ErrorWrapper>
       ) : null}
@@ -228,6 +237,11 @@ const ErrorWrapper = styled(Flex)`
   height: 60px;
   padding: 12px 16px;
   color: ${colors.primaryRed};
+`
+
+const PlayerWrapper = styled.div`
+  width: 100%;
+  cursor: pointer;
 `
 
 export const MediaPlayer = memo(MediaPlayerComponent)

--- a/src/components/App/SideBar/SidebarSubView/MediaPlayer/index.tsx
+++ b/src/components/App/SideBar/SidebarSubView/MediaPlayer/index.tsx
@@ -15,6 +15,7 @@ type Props = {
 const MediaPlayerComponent: FC<Props> = ({ hidden }) => {
   const playerRef = useRef<ReactPlayer | null>(null)
   const wrapperRef = useRef<HTMLDivElement | null>(null)
+  const [isFocused, setIsFocused] = useState(false)
   const [isFullScreen, setIsFullScreen] = useState(false)
   const [isMouseNearBottom, setIsMouseNearBottom] = useState(false)
   const [status, setStatus] = useState<'buffering' | 'error' | 'ready'>('ready')
@@ -140,7 +141,7 @@ const MediaPlayerComponent: FC<Props> = ({ hidden }) => {
       if (isFullScreen && event.key === 'Escape') {
         event.preventDefault()
         event.stopPropagation()
-      } else if (event.key === ' ') {
+      } else if (isFocused && event.key === ' ') {
         event.preventDefault()
         togglePlay()
       }
@@ -160,7 +161,13 @@ const MediaPlayerComponent: FC<Props> = ({ hidden }) => {
   }
 
   return playingNode?.link ? (
-    <Wrapper ref={wrapperRef} hidden={hidden}>
+    <Wrapper
+      ref={wrapperRef}
+      hidden={hidden}
+      onBlur={() => setIsFocused(false)}
+      onFocus={() => setIsFocused(true)}
+      tabIndex={0}
+    >
       <Cover>
         <Avatar size={120} src={playingNode?.image_url || ''} type="clip" />
       </Cover>
@@ -215,6 +222,9 @@ const Wrapper = styled(Flex)<Props>`
   border-top-left-radius: 16px;
   overflow: hidden;
   height: ${(props) => (props.hidden ? '0px' : 'auto')};
+  &:focus {
+    outline: none;
+  }
 `
 
 const Cover = styled(Flex)`


### PR DESCRIPTION
### Problem:
- Currently, tapping on the video or pressing the space button does not trigger the expected play/pause functionality.

### Expected Behavior:
- Tapping the video should initiate playback if paused and pause playback if playing.
- Pressing the space button should perform the same actions accordingly.

closes: #1227

## Issue ticket number and link:
- **Ticket Number:** [ 1227 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1227 ]

### Testing:
- Tested tapping the video to ensure it initiates playback if paused and pauses playback if playing.
- Verified that pressing the space button performs the same actions accordingly for video playback.

### Evidence:
 - Please see the attached video as evidence.
https://www.loom.com/share/5511d398f21145cba85acf809010fc86