### PR TITLE
Fix: Duplicate Attribute Name Field Appears When Editing Custom Node on [BluePrint]

### DIFF
--- a/src/components/SettingsModal/SettingsView/GraphBlueprint/__tests__/index.tsx
+++ b/src/components/SettingsModal/SettingsView/GraphBlueprint/__tests__/index.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { GraphBlueprint } from '../index'
+
+jest.mock('../../../../../network/fetchSourcesData', () => ({
+  getSchemaAll: jest.fn().mockResolvedValue({ schemas: [{ type: 'Custom', is_deleted: false }] }),
+}))
+
+describe('GraphBlueprint', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should display only one Custom node', async () => {
+    render(<GraphBlueprint />)
+
+    const customNodes = await screen.findAllByText('Custom')
+
+    expect(customNodes).toHaveLength(1)
+  })
+})

--- a/src/components/SettingsModal/SettingsView/GraphBlueprint/index.tsx
+++ b/src/components/SettingsModal/SettingsView/GraphBlueprint/index.tsx
@@ -31,7 +31,13 @@ export const GraphBlueprint: React.FC = () => {
   }, [])
 
   const onSchemaCreate = (schema: Schema) => {
-    setSchemaAll([...schemaAll, schema])
+    const exists = schemaAll.some((existingSchema) => existingSchema.type === schema.type)
+
+    if (exists) {
+      setSchemaAll(schemaAll.map((existingSchema) => (existingSchema.type === schema.type ? schema : existingSchema)))
+    } else {
+      setSchemaAll([...schemaAll, schema])
+    }
   }
 
   const onSchemaDelete = (type: string) => {


### PR DESCRIPTION
### Problem:
The duplicate Attribute Name field undermines the editing process and may result in unintended consequences.

### Expected Behavior:
The Attribute Name field should appear only once when editing a custom node.

closes: #1245

## Issue ticket number and link:
- **Ticket Number:** [ 1245 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1245 ]

### Evidence:
 - Please see the attached video as evidence.
https://www.loom.com/share/41c66e58c6b94cb687136c479e085a4f