### PR TITLE
Fix: Updating a Node Should Render Changes on the Frontend Immediately

### DIFF
--- a/src/components/ModalsContainer/EditNodeNameModal/Body/index.tsx
+++ b/src/components/ModalsContainer/EditNodeNameModal/Body/index.tsx
@@ -6,9 +6,9 @@ import styled from 'styled-components'
 import { validateImageInputType } from '~/components/ModalsContainer/EditNodeNameModal/utils'
 import { Flex } from '~/components/common/Flex'
 import { getTopicsData, putNodeData } from '~/network/fetchSourcesData'
-import { useSelectedNode } from '~/stores/useDataStore'
+import { useDataStore, useSelectedNode } from '~/stores/useDataStore'
 import { useModal } from '~/stores/useModalStore'
-import { Topic } from '~/types'
+import { NodeExtended, Topic } from '~/types'
 import { colors } from '~/utils/colors'
 import { TitleEditor } from '../Title'
 
@@ -90,9 +90,14 @@ export const Body = () => {
     setLoading(true)
 
     const propName = 'name'
+    const updatedData = { [propName]: topicValue.trim(), image_url: imageUrl.trim() }
 
     try {
-      await putNodeData(node?.ref_id || '', { [propName]: topicValue.trim(), image_url: imageUrl.trim() })
+      await putNodeData(node?.ref_id || '', updatedData)
+
+      const { updateNode } = useDataStore.getState()
+
+      updateNode({ ...node, ...updatedData } as NodeExtended)
 
       closeHandler()
     } catch (error) {

--- a/src/stores/useDataStore/index.ts
+++ b/src/stores/useDataStore/index.ts
@@ -74,6 +74,7 @@ export type DataStore = {
   setHideNodeDetails: (_: boolean) => void
   setTeachMe: (_: boolean) => void
   addNewNode: (node: NodeExtended) => void
+  updateNode: (updatedNode: NodeExtended) => void
   removeNode: (id: string) => void
   setSidebarFilterCounts: (filterCounts: SidebarFilterWithCount[]) => void
 }
@@ -106,6 +107,7 @@ const defaultData: Omit<
   | 'setHideNodeDetails'
   | 'setTeachMe'
   | 'addNewNode'
+  | 'updateNode'
   | 'removeNode'
 > = {
   categoryFilter: null,
@@ -219,6 +221,29 @@ export const useDataStore = create<DataStore>()(
     setShowSelectionGraph: (showSelectionGraph) => set({ showSelectionGraph }),
     setHideNodeDetails: (hideNodeDetails) => set({ hideNodeDetails }),
     setTeachMe: (showTeachMe) => set({ showTeachMe }),
+    updateNode: (updatedNode) => {
+      set((state) => {
+        const nodes = state.data?.nodes || []
+        const links = state.data?.links || []
+
+        const updatedNodes = nodes.map((node) => {
+          if (node.ref_id === updatedNode.ref_id) {
+            return { ...node, ...updatedNode }
+          }
+
+          return node
+        })
+
+        return {
+          ...state,
+          data: {
+            ...state.data,
+            nodes: updatedNodes,
+            links,
+          },
+        }
+      })
+    },
     addNewNode: (node) => {
       const { data } = get()
 


### PR DESCRIPTION
### Problem:
When editing a node, changes made should be immediately reflected on the frontend UI. Currently, changes such as updating the name or image_url of a node are not immediately visible to users on the frontend.

### Expected Behavior:
- Changes made to a node's name should be updated in real-time on the frontend UI.
- Similarly, changes made to a node's image_url should also be reflected immediately on the frontend.

closes: #1206

## Issue ticket number and link:
- **Ticket Number:** [ 1206 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1206 ]
