### PR TITLE
Fix: Empty Rows Displayed in BluePrint Table on [Setting Modal]

### DIFF
--- a/src/components/SettingsModal/SettingsView/GraphBlueprint/Table/index.tsx
+++ b/src/components/SettingsModal/SettingsView/GraphBlueprint/Table/index.tsx
@@ -54,9 +54,11 @@ export const Table: React.FC<TableProps> = ({ schemas, setSelectedSchema }) => {
           </TableRow>
         </StyledTableHead>
         <tbody>
-          {schemas?.map((schema) => (
-            <TopicRow key={schema?.type} onOpenActions={handleOpenPopover} schema={schema} />
-          ))}
+          {schemas
+            ?.filter((schema) => schema.type && schema.type.trim() !== '')
+            .map((schema) => (
+              <TopicRow key={schema.type} onOpenActions={handleOpenPopover} schema={schema} />
+            ))}
         </tbody>
       </MaterialTable>
       <PopoverWrapper


### PR DESCRIPTION
### Problem:
The BluePrint Table within the [Setting Modal] incorrectly displays empty rows, which is inconsistent with the intended behavior.

### Expected Behavior:
- Validate that the BluePrint Table within the [Setting Modal] accurately reflects the intended data.
- Ensure that empty rows are not displayed in the table when no corresponding data is available.

closes: #1236

## Issue ticket number and link:
- **Ticket Number:** [ 1236 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1236 ]

### Evidence:
 - Please see the attached video as evidence.
![image](https://github.com/stakwork/sphinx-nav-fiber/assets/163523353/fe06eb6c-a848-4df2-a19d-39b86137197e)