### PR TITLE
Background color of tabs should be white on first click at source table modal

### DIFF
--- a/src/components/SourcesTableModal/SourcesView/common/index.tsx
+++ b/src/components/SourcesTableModal/SourcesView/common/index.tsx
@@ -71,7 +71,13 @@ export const StyledTableHead = styled(TableHead)`
 `
 
 export const StyledPill = styled(Button)`
-  &.selected {
+  &:first-child.selected {
+    background: ${colors.white};
+    color: ${colors.BG1};
+    pointer-events: none;
+  }
+
+  & + &.selected {
     background: ${colors.white};
     color: ${colors.BG1};
     pointer-events: none;


### PR DESCRIPTION
### Ticket №: #1269

closes #1269

### Problem:

when we click on a tab, its background color does not change to white on the first click. On the second click, the background color becomes white.


### Evidence:

https://www.loom.com/share/e5dc4cc375e74b7dbb226342b0306015?sid=ab03b301-3f7c-4d12-864f-f91f1b38087d