### PR TITLE
fix: css layout for youtube and twitter node-types

### DIFF
--- a/src/components/App/SideBar/Relevance/Episode/index.tsx
+++ b/src/components/App/SideBar/Relevance/Episode/index.tsx
@@ -82,10 +82,10 @@ export const Episode = ({
   return type ? (
     <EpisodeWrapper className={className} onClick={onClick}>
       {!defaultViewTypes.includes(type) ? (
-        <Flex direction="row">
+        <Flex align="center" direction="row" justify="center">
           {!isSelectedView && (
             <Flex align="center" pr={16}>
-              <Avatar size={64} src={imageUrl || `${imageType}_default.svg`} type={type || ''} />
+              <Avatar size={80} src={imageUrl || `${imageType}_default.svg`} type={type || ''} />
             </Flex>
           )}
 
@@ -105,7 +105,7 @@ export const Episode = ({
               ) : null}
             </Flex>
 
-            <Description data-testid="episode-name">{name}</Description>
+            {name && <Description data-testid="episode-name">{name}</Description>}
             <Description data-testid="episode-description">{description}</Description>
             <Flex align="center" direction="row" justify="flex-start">
               {Boolean(date) && <Date>{moment.unix(date).fromNow()}</Date>}
@@ -154,7 +154,7 @@ export const Description = styled(Flex)`
   font-weight: 400;
   line-height: 17px;
   color: ${colors.white};
-  margin: 16px 0;
+  margin: 8px 0;
   display: -webkit-box;
   -webkit-line-clamp: 2; /* Limit to two lines */
   -webkit-box-orient: vertical;
@@ -213,7 +213,6 @@ export const Title = styled(Date)`
   white-space: nowrap;
   text-overflow: ellipsis;
   position: relative;
-  padding-left: 12px;
   &:before {
     content: '';
     display: block;
@@ -226,8 +225,6 @@ export const Title = styled(Date)`
     flex-shrink: 0;
     height: 4px;
     background: ${colors.GRAY6};
-
-    margin-top: 20px;
   }
 
   &.is-show {


### PR DESCRIPTION
### Ticket №:

closes #1262

-[x] fixed irregular vertical spacing between content for `youtube` and `twitter` node type
-[x] change does not affect styles for other node_types


![fix](https://github.com/stakwork/sphinx-nav-fiber/assets/117433403/aa6661a8-abf5-4562-a116-6c23320374bd)
![youtube](https://github.com/stakwork/sphinx-nav-fiber/assets/117433403/9601be99-eaf3-4123-ac46-5dcfef58a40b)
![long](https://github.com/stakwork/sphinx-nav-fiber/assets/117433403/9884207d-b01f-4e86-860b-f1f057dc69fa)
