### PR TITLE
fix: overlapping bullet and text

### DIFF
--- a/src/components/App/SideBar/Relevance/Episode/index.tsx
+++ b/src/components/App/SideBar/Relevance/Episode/index.tsx
@@ -213,6 +213,7 @@ export const Title = styled(Date)`
   white-space: nowrap;
   text-overflow: ellipsis;
   position: relative;
+  padding-left: 10px;
   &:before {
     content: '';
     display: block;

--- a/src/components/SettingsModal/SettingsView/GraphBlueprint/__tests__/index.tsx
+++ b/src/components/SettingsModal/SettingsView/GraphBlueprint/__tests__/index.tsx
@@ -1,6 +1,6 @@
-import React from 'react'
-import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
+import { render, screen, waitFor } from '@testing-library/react'
+import React from 'react'
 import { GraphBlueprint } from '../index'
 
 jest.mock('../../../../../network/fetchSourcesData', () => ({
@@ -15,8 +15,10 @@ describe('GraphBlueprint', () => {
   it('should display only one Custom node', async () => {
     render(<GraphBlueprint />)
 
-    const customNodes = await screen.findAllByText('Custom')
+    waitFor(async () => {
+      const customNodes = await screen.findAllByText('Custom')
 
-    expect(customNodes).toHaveLength(1)
+      expect(customNodes).toHaveLength(1)
+    })
   })
 })


### PR DESCRIPTION
### Problem:
> Small issue:
> 
> * the dot overlaps the content here
> 
> <img alt="Screenshot 2024-04-18 at 14 24 08" width="375" src="https://private-user-images.githubusercontent.com/142233216/323621008-bac30898-2442-4abf-a52a-e370fde7e057.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MTM1NzQ1MTksIm5iZiI6MTcxMzU3NDIxOSwicGF0aCI6Ii8xNDIyMzMyMTYvMzIzNjIxMDA4LWJhYzMwODk4LTI0NDItNGFiZi1hNTJhLWUzNzBmZGU3ZTA1Ny5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjQwNDIwJTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI0MDQyMFQwMDUwMTlaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT1jY2ViZTdhNzE5NmFiM2FlY2M1MDM4NTNhZGQ3YjY0MjAzOGU3MjNlNmY1NTQwOTY5ZjYwYzYxYTZjMjBjYzkwJlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCZhY3Rvcl9pZD0wJmtleV9pZD0wJnJlcG9faWQ9MCJ9.4Cd-x5N5dXaNWBYA0dnpoHvx5w8gw8w7yqNlSde3l8Q">

### Preview ✅
![overlap](https://github.com/stakwork/sphinx-nav-fiber/assets/117433403/1d2b3181-d21a-4c8f-87b1-80431bb927bc)

