### PR TITLE
fix: remove highlight of first TLDR on load

### DIFF
--- a/src/components/App/SideBar/Trending/index.tsx
+++ b/src/components/App/SideBar/Trending/index.tsx
@@ -210,7 +210,7 @@ export const Trending = ({ onSubmit }: Props) => {
                 </Paragraph>
                 {i.tldr && (
                   <StyledTLDRButton
-                    className={clsx({ isPlaying: currentFileIndex === index })}
+                    className={clsx({ isPlaying: currentFileIndex === index && playing })}
                     onClick={(e) => showModal(e, i)}
                   >
                     TLDR


### PR DESCRIPTION
### Problem:

> Ok sure, lets keep the TLDR that is playing white but remove the initial highlight upon loading!

### Solution 

- [x] Remove the initial highlight of first TLDR on load

### Evidence 

