### PR TITLE
 Ensure the Trending Topics are visible in the graph 

### DIFF
--- a/src/components/Universe/Graph/Cubes/index.tsx
+++ b/src/components/Universe/Graph/Cubes/index.tsx
@@ -16,11 +16,14 @@ import { isMainTopic } from './constants'
 export const Cubes = memo(() => {
   const data = useGraphData()
   const selectedNode = useSelectedNode()
-  const nearbyNodeIds = useDataStore((s) => s.nearbyNodeIds)
-  const setHoveredNode = useDataStore((s) => s.setHoveredNode)
-  const showSelectionGraph = useDataStore((s) => s.showSelectionGraph)
-  const selectionGraphData = useDataStore((s) => s.selectionGraphData)
+
+  const { nearbyNodeIds, setHoveredNode, showSelectionGraph, selectionGraphData, trendingTopics } = useDataStore(
+    (s) => s,
+  )
+
   const setTranscriptOpen = useAppStore((s) => s.setTranscriptOpen)
+
+  const isTrendingTopic = (node: NodeExtended) => trendingTopics.map((t) => t.name).includes(node.name)
 
   const ignoreNodeEvent = useCallback(
     (node: NodeExtended) => {
@@ -92,7 +95,7 @@ export const Cubes = memo(() => {
           const isSelected = f?.ref_id === selectedNode?.ref_id
           const isNearbyOrPersistent = nearbyNodeIds.includes(f.ref_id || '') || isMainTopic(f)
 
-          return isNearbyOrPersistent || isSelected
+          return isNearbyOrPersistent || isSelected || isTrendingTopic(f)
         })
         .map((node) => {
           if (node.node_type === 'topic') {

--- a/src/network/fetchGraphData/__tests__/index.ts
+++ b/src/network/fetchGraphData/__tests__/index.ts
@@ -53,24 +53,20 @@ describe('formatFetchNodes', () => {
         {
           id: undefined,
           image_url: undefined,
-          index: 0,
           label: 'test',
           name: 'test',
           node_type: 'test',
           scale: 1.5,
           type: 'test',
-          vx: 0,
-          vy: 0,
-          vz: 0,
+          x: expect.any(Number),
+          y: expect.any(Number),
+          z: expect.any(Number),
           weight: NaN,
-          x: 0,
-          y: 0,
-          z: 0,
         },
       ],
     }
 
-    expect(formatFetchNodes(emptyInput)).toStrictEqual(emptyResponse)
+    expect(formatFetchNodes(emptyInput, 'searchterm', 'split')).toEqual(emptyResponse)
   })
 
   it('should give us the expected output for two of the same node', () => {
@@ -86,24 +82,20 @@ describe('formatFetchNodes', () => {
         {
           id: undefined,
           image_url: undefined,
-          index: 0,
           label: 'test',
           name: 'test',
           node_type: 'test',
           scale: 1.5,
           type: 'test',
-          vx: 0,
-          vy: 0,
-          vz: 0,
+          x: expect.any(Number),
+          y: expect.any(Number),
+          z: expect.any(Number),
           weight: NaN,
-          x: 0,
-          y: 0,
-          z: 0,
         },
       ],
     }
 
-    expect(formatFetchNodes(emptyInput)).toStrictEqual(emptyResponse)
+    expect(formatFetchNodes(emptyInput, 'searchterm', 'split')).toEqual(emptyResponse)
   })
 
   it('should give us the expected output for two different nodes', () => {
@@ -113,7 +105,7 @@ describe('formatFetchNodes', () => {
       related: [node1, dataSeriesNode],
     }
 
-    const formattedResponse = formatFetchNodes(emptyInput)
+    const formattedResponse = formatFetchNodes(emptyInput, 'searchterm', 'split')
 
     expect(formattedResponse.links).toStrictEqual([])
     expect(formattedResponse.nodes[0].label).toBe('test')
@@ -121,21 +113,18 @@ describe('formatFetchNodes', () => {
     expect(formattedResponse.nodes[0].node_type).toBe('test')
     expect(formattedResponse.nodes[0].scale).toBe(1.5)
     expect(formattedResponse.nodes[0].type).toBe('test')
-    expect(formattedResponse.nodes[0].index).toBe(0)
+    expect(formattedResponse.nodes[0].x).toEqual(expect.any(Number))
+    expect(formattedResponse.nodes[0].y).toEqual(expect.any(Number))
+    expect(formattedResponse.nodes[0].z).toEqual(expect.any(Number))
 
     expect(formattedResponse.nodes[1].label).toBe('test2')
     expect(formattedResponse.nodes[1].name).toBe('test2')
     expect(formattedResponse.nodes[1].node_type).toBe('data_series')
     expect(formattedResponse.nodes[1].scale).toBe(1.5)
     expect(formattedResponse.nodes[1].type).toBe('data_series')
-    expect(formattedResponse.nodes[1].index).toBe(1)
-
-    expect(formattedResponse.nodes[2].label).toBe('test2')
-    expect(formattedResponse.nodes[2].name).toBe('test2')
-    expect(formattedResponse.nodes[2].node_type).toBe('data_series')
-    expect(formattedResponse.nodes[2].scale).toBe(1.5)
-    expect(formattedResponse.nodes[2].type).toBe('data_series')
-    expect(formattedResponse.nodes[2].index).toBe(2)
+    expect(formattedResponse.nodes[1].x).toEqual(expect.any(Number))
+    expect(formattedResponse.nodes[1].y).toEqual(expect.any(Number))
+    expect(formattedResponse.nodes[1].z).toEqual(expect.any(Number))
   })
 
   it('should create topic nodes for each topic from tweet, and guest node for posted_by', () => {


### PR DESCRIPTION
### Ticket №:

closes #1305 

### Description:

Ensured that trending topics returned from `/get_trends` are displayed on the graph

### Evidence

- changed trending topics color on graph to yellow for demonstration

https://www.loom.com/share/a71eb0506a524de68b48698a232832d0?sid=b0b2d98d-29c4-4ae0-8a66-0e6a22dc7a4e
