### PR TITLE
feat: selected view for generic nodes

### DIFF
--- a/src/components/App/SideBar/SelectedNodeView/Default/index.tsx
+++ b/src/components/App/SideBar/SelectedNodeView/Default/index.tsx
@@ -1,7 +1,40 @@
+import clsx from 'clsx'
 import styled from 'styled-components'
+import { Divider } from '~/components/common/Divider'
 import { Flex } from '~/components/common/Flex'
 import { Text } from '~/components/common/Text'
+import { TypeBadge } from '~/components/common/TypeBadge'
 import { useSelectedNode } from '~/stores/useDataStore'
+import { NodeExtended } from '~/types'
+
+const excludedKeys: Set<string> = new Set([
+  'id',
+  'image_url',
+  'index',
+  'node_type',
+  'ref_id',
+  'scale',
+  'type',
+  'vx',
+  'vy',
+  'vz',
+  'x',
+  'y',
+  'z',
+  'properties',
+  'weight',
+])
+
+const formatKey = (key: string): string =>
+  key
+    .split('_')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
+
+const filterKeys = (selectedNode: NodeExtended): NodeExtended =>
+  Object.entries(selectedNode)
+    .filter(([key]) => !excludedKeys.has(key))
+    .reduce((obj, [key, value]) => ({ ...obj, [formatKey(key)]: value }), {} as NodeExtended)
 
 export const Default = () => {
   const selectedNode = useSelectedNode()
@@ -10,24 +43,92 @@ export const Default = () => {
     return null
   }
 
-  const { name } = selectedNode
+  const filteredKeys = filterKeys(selectedNode)
+  const hashImage = !!selectedNode.image_url
 
   return (
-    <Flex align="flex-start" basis="100%" direction="column" grow={1} justify="center" shrink={1}>
-      <StyledContent grow={1} justify="flex-start" p={12} shrink={1}>
-        <Flex>
-          <Text color="primaryText1" kind="regular">
-            Name:
-          </Text>
-          <Text color="primaryText1" kind="regular">
-            {name}
-          </Text>
-        </Flex>
-      </StyledContent>
-    </Flex>
+    <StyledContent grow={1} justify="flex-start" pt={hashImage ? 0 : 8} shrink={1}>
+      {hashImage ? (
+        <StyledImageWrapper>
+          <img alt="img_a11y" src={selectedNode.image_url} />
+        </StyledImageWrapper>
+      ) : null}
+
+      <Flex ml={24} mt={20} style={{ width: 'fit-content' }}>
+        <TypeBadge type={selectedNode.type || ''} />
+      </Flex>
+
+      <StyledWrapper>
+        {Object.entries(filteredKeys).map(([key, value]) => (
+          <NodeDetail key={key} label={key} value={value} />
+        ))}
+      </StyledWrapper>
+    </StyledContent>
+  )
+}
+
+type Props = { label: string; value: unknown }
+
+const NodeDetail = ({ label, value }: Props) => {
+  const isLong = (value as string).length > 140
+
+  return (
+    <>
+      <StyledDetail className={clsx('node-detail', { 'node-detail__long': isLong })}>
+        <Text className="node-detail__label">{label}</Text>
+        <Text className="node-detail__value">{value as string}</Text>
+      </StyledDetail>
+      <StyledDivider />
+    </>
   )
 }
 
 const StyledContent = styled(Flex)`
   overflow: auto;
+  width: 100%;
+`
+
+const StyledWrapper = styled(Flex)`
+  padding: 4px 24px;
+`
+
+const StyledImageWrapper = styled(Flex)`
+  width: 100%;
+  height: 256px;
+
+  img {
+    width: 100%;
+    height: 100%;
+  }
+`
+
+const StyledDetail = styled(Flex)`
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  gap: 10px;
+  font-family: Barlow;
+  padding: 12px 0;
+  font-size: 14px;
+  line-height: 22px;
+
+  &.node-detail {
+    .node-detail__label {
+      min-width: 116px;
+      font-weight: 600;
+    }
+
+    .node-detail__value {
+      font-weight: 400;
+    }
+
+    &__long {
+      flex-direction: column;
+    }
+  }
+`
+
+const StyledDivider = styled(Divider)`
+  margin: auto 0px 2px 0px;
+  opacity: 0.75;
 `


### PR DESCRIPTION
### Ticket №:

closes #1341

### Solution:

This pull request enhances the selected view middle section for generic nodes,

### Preview 

1. Test with mock data (exactly as figma)
 
 - With no image_url

![save-final-no-img](https://github.com/stakwork/sphinx-nav-fiber/assets/117433403/d0b8ee67-01bb-4c03-94aa-e75acf8d57f6)

- With image_url 

![Screenshot (42)](https://github.com/stakwork/sphinx-nav-fiber/assets/117433403/0e22db50-f96c-4f98-8bf0-98019a64dba1)

2. Actual data 

- With no image_url 

![save-final-actual-data-no-img](https://github.com/stakwork/sphinx-nav-fiber/assets/117433403/7585971e-0f8e-4009-8945-a8fb38515914)


- With image_url 

![save-final-actual-data-img](https://github.com/stakwork/sphinx-nav-fiber/assets/117433403/2d7e4e34-f812-4a50-a7be-c136fbd7ef2d)


