### PR TITLE
Fix(Sources-Table): Resolve multi-select merging of topics

### DIFF
--- a/src/components/SourcesTableModal/SourcesView/Topics/MergeTopicModal/Title/index.tsx
+++ b/src/components/SourcesTableModal/SourcesView/Topics/MergeTopicModal/Title/index.tsx
@@ -10,7 +10,7 @@ import { TEdge, Topic } from '~/types'
 import { ToNode } from './ToNode'
 
 type Props = {
-  from: Topic
+  from: Topic[]
   onSelect: (edge: TEdge | null) => void
   isSwapped: boolean
   setIsSwapped: () => void
@@ -21,44 +21,57 @@ interface SectionProps {
   swap: boolean
 }
 
-export const TitleEditor: FC<Props> = ({ from, onSelect, selectedToNode, isSwapped, setIsSwapped }) => (
-  <Flex>
-    <Flex align="center" direction="row" justify="space-between" mb={18}>
-      <Flex align="center" direction="row">
-        <StyledText>Merge topic</StyledText>
+interface IconMidContainerProps {
+  disabled: boolean
+}
+
+export const TitleEditor: FC<Props> = ({ from, onSelect, selectedToNode, isSwapped, setIsSwapped }) => {
+  const topicNames = from?.map((t) => t.name).join(', ')
+
+  const fromTopicNames = from && from.length === 1 ? from[0].name : `${topicNames?.substring(0, 25)} ...`
+
+  return (
+    <Flex>
+      <Flex align="center" direction="row" justify="space-between" mb={18}>
+        <Flex align="center" direction="row">
+          <StyledText>Merge topic</StyledText>
+        </Flex>
       </Flex>
+      <Div swap={isSwapped}>
+        <SectionWrapper>
+          <FromSection disabled label={!isSwapped ? 'From' : 'To'} swap={isSwapped} value={fromTopicNames} />
+        </SectionWrapper>
+
+        <Flex my={16}>
+          <StyledLabel>Type</StyledLabel>
+          <Text>IS AlIAS</Text>
+        </Flex>
+
+        <Flex>
+          <ToSection>
+            <ToLabel>{!isSwapped ? 'To' : 'From'}</ToLabel>
+            <ToNode onSelect={onSelect} selectedValue={selectedToNode} topicId={from[from.length - 1]?.ref_id} />
+          </ToSection>
+        </Flex>
+
+        <NodeConnectorDiv>
+          <IconTopContainer>
+            <NodeCircleIcon />
+          </IconTopContainer>
+          <IconMidContainer
+            disabled={Boolean(from?.length !== 1)}
+            onClick={from?.length === 1 ? setIsSwapped : undefined}
+          >
+            <FlipIcon />
+          </IconMidContainer>
+          <IconBottomContainer>
+            <ArrowRight />
+          </IconBottomContainer>
+        </NodeConnectorDiv>
+      </Div>
     </Flex>
-    <Div swap={isSwapped}>
-      <SectionWrapper>
-        <FromSection disabled label={!isSwapped ? 'From' : 'To'} swap={isSwapped} value={from.name} />
-      </SectionWrapper>
-
-      <Flex my={16}>
-        <StyledLabel>Type</StyledLabel>
-        <Text>IS AlIAS</Text>
-      </Flex>
-
-      <Flex>
-        <ToSection>
-          <ToLabel>{!isSwapped ? 'To' : 'From'}</ToLabel>
-          <ToNode onSelect={onSelect} selectedValue={selectedToNode} topicId={from?.ref_id} />
-        </ToSection>
-      </Flex>
-
-      <NodeConnectorDiv>
-        <IconTopContainer>
-          <NodeCircleIcon />
-        </IconTopContainer>
-        <IconMidContainer onClick={setIsSwapped}>
-          <FlipIcon />
-        </IconMidContainer>
-        <IconBottomContainer>
-          <ArrowRight />
-        </IconBottomContainer>
-      </NodeConnectorDiv>
-    </Div>
-  </Flex>
-)
+  )
+}
 
 const StyledText = styled(Text)`
   font-size: 22px;
@@ -146,13 +159,13 @@ const IconTopContainer = styled.div`
   color: #23252f;
 `
 
-const IconMidContainer = styled.div`
+const IconMidContainer = styled.div<IconMidContainerProps>`
   position: absolute;
   color: transparent;
   top: 50%;
   left: 0;
   transform: translateY(-50%) translateX(-50%);
-  cursor: pointer;
+  cursor: ${(props) => (props.disabled ? 'not-allowed' : 'pointer')};
   width: 32px;
   height: 32px;
   background-color: #303342;

--- a/src/components/SourcesTableModal/SourcesView/Topics/Table/index.tsx
+++ b/src/components/SourcesTableModal/SourcesView/Topics/Table/index.tsx
@@ -187,6 +187,9 @@ export const Table: React.FC<TopicTableProps> = ({
                             </>
                           )}
                         </MuteStatusSection>
+                        <MultiSelectMerge onClick={() => handlePopoverAction('mergeTopic')}>
+                          <MergeIcon /> Merge
+                        </MultiSelectMerge>
                       </StatusBarSection>
                     </StyledTableCell>
                   </TableRow>
@@ -353,4 +356,17 @@ const TableInnerWrapper = styled(Flex)`
   overflow: auto;
   flex: 1;
   width: 100%;
+`
+
+const MultiSelectMerge = styled.div`
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  gap: 6px;
+  padding: 1px 6px;
+  &:hover {
+    background-color: rgba(255, 255, 255, 0.2);
+    padding: 1px 6px;
+    border-radius: 4px;
+  }
 `

--- a/src/network/fetchSourcesData/index.ts
+++ b/src/network/fetchSourcesData/index.ts
@@ -50,8 +50,8 @@ export type TPriceParams = {
 }
 
 export type TMergeTopicsParams = {
-  from: string
-  to: string
+  from?: string | string[]
+  to?: string
 }
 
 export type TAddEdgeParams = {


### PR DESCRIPTION
### Problem:
- Add Merge action to Multi-select action bar.
- Icon - Reuse icon that is in the dropdown (see image above for merge)
- Selecting Merge should trigger the current Merge flow but pre-fill From with comma separated list ( add ... if going to overlay)
- POST request should be updated to include an array of ref_id's (same endpoint)
- If in multi-select, disable the switch button.

closes: #1297

## Issue ticket number and link:
- **Ticket Number:** [ 1297 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1297 ]

### Evidence:
 - Please see the attached video as evidence.
https://www.loom.com/share/5e12779e086b45c78c85c0b4dc343f2d