### PR TITLE
Fix Inaccurate Reflection of Video Boost Amount According to Sidebar

### DIFF
--- a/src/components/App/SideBar/Media/index.tsx
+++ b/src/components/App/SideBar/Media/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import styled from 'styled-components'
 import { Booster } from '~/components/Booster'
 import { Divider } from '~/components/common/Divider'
@@ -35,6 +35,10 @@ export const Media = ({ node }: Props) => {
   } = node || selectedNode || {}
 
   const [boostAmount, setBoostAmount] = useState<number>(boost || 0)
+
+  useEffect(() => {
+    setBoostAmount(boost ?? 0)
+  }, [boost])
 
   if (!node && !selectedNode) {
     return null


### PR DESCRIPTION
### Problem:
- The Video `Boost amount` displayed in the sidebar does not accurately reflect the actual boost applied to videos, leading to inconsistencies between the displayed and actual data.


closes: #1349

## Issue ticket number and link:
- **Ticket Number:** [ 1349 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1349 ]

### Evidence Image:
![image](https://github.com/stakwork/sphinx-nav-fiber/assets/87068339/919cc80d-50f4-4497-9e4a-9e9feec69df1)

![image](https://github.com/stakwork/sphinx-nav-fiber/assets/87068339/9eb29589-e003-4010-bdb6-97bc88076c84)
 

### Evidence:
 - Please see the attached video as evidence.
https://www.loom.com/share/45eac7cea2dc461d82182edee2f306ef