### PR TITLE
Added `Tooltip` Functionality to Stats Bar

### DIFF
--- a/src/components/Stats/index.tsx
+++ b/src/components/Stats/index.tsx
@@ -1,6 +1,7 @@
 import { noop } from 'lodash'
 import { useEffect } from 'react'
 import styled from 'styled-components'
+import { Tooltip } from '~/components/common/ToolTip'
 import AudioIcon from '~/components/Icons/AudioIcon'
 import BudgetIcon from '~/components/Icons/BudgetIcon'
 import NodesIcon from '~/components/Icons/NodesIcon'
@@ -115,9 +116,10 @@ export const Stats = () => {
         {StatsConfig.map(({ name, icon, key, mediaType, tooltip }) =>
           stats[key as keyof TStats] !== '0' ? (
             <Stat key={name} data-testid={mediaType} onClick={() => handleStatClick(mediaType)}>
-              <div className="icon">{icon}</div>
-              <div className="text">{stats[key as keyof TStats]}</div>
-              <div className="tooltip">{tooltip}</div>
+              <Tooltip content={tooltip} margin="13px">
+                <div className="icon">{icon}</div>
+                <div className="text">{stats[key as keyof TStats]}</div>
+              </Tooltip>
             </Stat>
           ) : (
             <></>
@@ -126,15 +128,16 @@ export const Stats = () => {
       </StatisticsWrapper>
       <StatisticsBudget>
         <Budget>
-          <div className="icon">
-            <BudgetIcon />
-          </div>
-          <div className="text">
-            <p>
-              {`${formatBudget(budget)} `} <span className="budgetUnit">SAT</span>
-            </p>
-          </div>
-          <div className="tooltip">Budget</div>
+          <Tooltip content="Budget" margin="18px">
+            <div className="icon">
+              <BudgetIcon />
+            </div>
+            <div className="text">
+              <p>
+                {`${formatBudget(budget)} `} <span className="budgetUnit">SAT</span>
+              </p>
+            </div>
+          </Tooltip>
         </Budget>
       </StatisticsBudget>
     </StatisticsContainer>
@@ -180,15 +183,9 @@ const Stat = styled(Flex).attrs({
   margin: 0 8px;
   border-radius: 200px;
   cursor: pointer;
-  position: relative;
 
   &:hover {
     background: ${colors.BUTTON1_PRESS};
-
-    .tooltip {
-      visibility: visible;
-      opacity: 1;
-    }
   }
 
   &:active {
@@ -201,29 +198,6 @@ const Stat = styled(Flex).attrs({
   }
 
   .text {
-  }
-
-  .tooltip {
-    visibility: hidden;
-    min-width: auto;
-    background-color: white;
-    color: black;
-    text-align: center;
-    border-radius: 4px;
-    padding: 5px 8px;
-    position: absolute;
-    z-index: 1;
-    top: 100%;
-    left: 50%;
-    transform: translateX(-50%);
-    margin-top: 8px;
-    opacity: 0;
-    transition: opacity 0.3s;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    font-size: 12px;
-    font-weight: 600;
   }
 `
 
@@ -248,10 +222,6 @@ const Budget = styled(Flex).attrs({
 
   &:hover {
     background: ${colors.BUTTON1_PRESS};
-    .tooltip {
-      visibility: visible;
-      opacity: 1;
-    }
   }
 
   &:active {
@@ -262,6 +232,7 @@ const Budget = styled(Flex).attrs({
     display: flex;
     align-items: center;
     justify-content: center;
+    margin-right: 10px;
   }
 
   .budgetUnit {
@@ -272,26 +243,5 @@ const Budget = styled(Flex).attrs({
     display: flex;
     align-items: center;
     justify-content: center;
-  }
-
-  .tooltip {
-    visibility: hidden;
-    min-width: auto;
-    background-color: white;
-    color: black;
-    text-align: center;
-    border-radius: 4px;
-    padding: 5px 8px;
-    position: absolute;
-    z-index: 1;
-    top: 93%;
-    right: 2.5%;
-    opacity: 0;
-    transition: opacity 0.3s;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    font-size: 12px;
-    font-weight: 600;
   }
 `

--- a/src/components/Stats/index.tsx
+++ b/src/components/Stats/index.tsx
@@ -22,6 +22,7 @@ interface StatConfigItem {
   key: keyof TStats
   dataKey: keyof TStatParams
   mediaType: string
+  tooltip: string
 }
 
 export const StatsConfig: StatConfigItem[] = [
@@ -31,6 +32,7 @@ export const StatsConfig: StatConfigItem[] = [
     key: 'numNodes',
     dataKey: 'num_nodes',
     mediaType: '',
+    tooltip: 'All Nodes',
   },
   {
     name: 'Episodes',
@@ -38,6 +40,7 @@ export const StatsConfig: StatConfigItem[] = [
     key: 'numEpisodes',
     dataKey: 'num_episodes',
     mediaType: 'episode',
+    tooltip: 'Episodes',
   },
   {
     name: 'Audio',
@@ -45,6 +48,7 @@ export const StatsConfig: StatConfigItem[] = [
     key: 'numAudio',
     dataKey: 'num_audio',
     mediaType: 'audio',
+    tooltip: 'Audios',
   },
   {
     name: 'Video',
@@ -52,6 +56,7 @@ export const StatsConfig: StatConfigItem[] = [
     key: 'numVideo',
     dataKey: 'num_video',
     mediaType: 'video',
+    tooltip: 'Videos',
   },
   {
     name: 'Twitter Spaces',
@@ -59,6 +64,7 @@ export const StatsConfig: StatConfigItem[] = [
     key: 'numTwitterSpace',
     dataKey: 'num_tweet',
     mediaType: 'twitter',
+    tooltip: 'Posts',
   },
   {
     name: 'Document',
@@ -66,6 +72,7 @@ export const StatsConfig: StatConfigItem[] = [
     key: 'numDocuments',
     dataKey: 'num_documents',
     mediaType: 'document',
+    tooltip: 'Documents',
   },
 ]
 
@@ -105,11 +112,12 @@ export const Stats = () => {
   return (
     <StatisticsContainer>
       <StatisticsWrapper>
-        {StatsConfig.map(({ name, icon, key, mediaType }) =>
+        {StatsConfig.map(({ name, icon, key, mediaType, tooltip }) =>
           stats[key as keyof TStats] !== '0' ? (
             <Stat key={name} data-testid={mediaType} onClick={() => handleStatClick(mediaType)}>
               <div className="icon">{icon}</div>
               <div className="text">{stats[key as keyof TStats]}</div>
+              <div className="tooltip">{tooltip}</div>
             </Stat>
           ) : (
             <></>
@@ -126,6 +134,7 @@ export const Stats = () => {
               {`${formatBudget(budget)} `} <span className="budgetUnit">SAT</span>
             </p>
           </div>
+          <div className="tooltip">Budget</div>
         </Budget>
       </StatisticsBudget>
     </StatisticsContainer>
@@ -171,9 +180,15 @@ const Stat = styled(Flex).attrs({
   margin: 0 8px;
   border-radius: 200px;
   cursor: pointer;
+  position: relative;
 
   &:hover {
     background: ${colors.BUTTON1_PRESS};
+
+    .tooltip {
+      visibility: visible;
+      opacity: 1;
+    }
   }
 
   &:active {
@@ -186,6 +201,29 @@ const Stat = styled(Flex).attrs({
   }
 
   .text {
+  }
+
+  .tooltip {
+    visibility: hidden;
+    min-width: auto;
+    background-color: white;
+    color: black;
+    text-align: center;
+    border-radius: 4px;
+    padding: 5px 8px;
+    position: absolute;
+    z-index: 1;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    margin-top: 8px;
+    opacity: 0;
+    transition: opacity 0.3s;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-size: 12px;
+    font-weight: 600;
   }
 `
 
@@ -210,6 +248,10 @@ const Budget = styled(Flex).attrs({
 
   &:hover {
     background: ${colors.BUTTON1_PRESS};
+    .tooltip {
+      visibility: visible;
+      opacity: 1;
+    }
   }
 
   &:active {
@@ -230,5 +272,26 @@ const Budget = styled(Flex).attrs({
     display: flex;
     align-items: center;
     justify-content: center;
+  }
+
+  .tooltip {
+    visibility: hidden;
+    min-width: auto;
+    background-color: white;
+    color: black;
+    text-align: center;
+    border-radius: 4px;
+    padding: 5px 8px;
+    position: absolute;
+    z-index: 1;
+    top: 93%;
+    right: 2.5%;
+    opacity: 0;
+    transition: opacity 0.3s;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-size: 12px;
+    font-weight: 600;
   }
 `

--- a/src/components/common/ToolTip/index.tsx
+++ b/src/components/common/ToolTip/index.tsx
@@ -1,0 +1,48 @@
+import styled from 'styled-components'
+
+interface TooltipProps {
+  content: string
+  children: React.ReactNode
+  margin?: string
+}
+
+const TooltipContainer = styled.div`
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+`
+
+const TooltipText = styled.div<{ margin?: string }>`
+  visibility: hidden;
+  width: auto;
+  background-color: white;
+  color: black;
+  text-align: center;
+  border-radius: 4px;
+  padding: 5px 8px;
+  position: absolute;
+  z-index: 1;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  margin-top: ${({ margin }) => margin || '0px'};
+  opacity: 0;
+  transition: opacity 0.3s;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 12px;
+  font-weight: 600;
+
+  ${TooltipContainer}:hover & {
+    visibility: visible;
+    opacity: 1;
+  }
+`
+
+export const Tooltip = ({ content, children, margin }: TooltipProps) => (
+  <TooltipContainer>
+    {children}
+    <TooltipText margin={margin}>{content}</TooltipText>
+  </TooltipContainer>
+)


### PR DESCRIPTION
### Problem:
- Add tooltip to stats bar on hover.

closes: #1360

## Issue ticket number and link:
- **Ticket Number:** [ 1360 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1360 ]

### Evidence:
 - Please see the attached video as evidence.
https://www.loom.com/share/335c705ba1194158a43f7fc66ab576c6

![image](https://github.com/stakwork/sphinx-nav-fiber/assets/160427254/f86e79c6-3ae5-4720-9671-fc3256a29251)
