### PR TITLE
Resolved: Added `Delete` Value in PUT Request for Editing Node Type via Blueprint

### DIFF
--- a/src/components/SettingsModal/SettingsView/GraphBlueprint/BlueprintModal/Body/Editor/CustomAttributesStep/FormInput/index.tsx
+++ b/src/components/SettingsModal/SettingsView/GraphBlueprint/BlueprintModal/Body/Editor/CustomAttributesStep/FormInput/index.tsx
@@ -18,9 +18,17 @@ const noSpacePattern = /^[a-z0-9_]+$/
 
 interface CustomField extends Record<'id', string> {
   isNew?: boolean
+  onDelete?: (attributeKey: string) => void
+  key?: string
 }
 
-export const FormInput = ({ parentParam }: { parentParam: string }) => {
+export const FormInput = ({
+  parentParam,
+  onDelete,
+}: {
+  parentParam: string
+  onDelete: (attributeKey: string) => void
+}) => {
   const [loading, setLoading] = useState(false)
   const [parsedData, setParsedData] = useState<parsedObjProps[]>([])
 
@@ -106,7 +114,15 @@ export const FormInput = ({ parentParam }: { parentParam: string }) => {
                       onChange={(e) => setValue(`attributes[${index}].required`, e.target.checked)}
                       size="small"
                     />
-                    <IconButton onClick={() => remove(index)}>
+                    <IconButton
+                      onClick={() => {
+                        remove(index)
+
+                        if (field.key !== undefined && onDelete) {
+                          onDelete(field.key)
+                        }
+                      }}
+                    >
                       <DeleteIcon />
                     </IconButton>
                   </Grid>

--- a/src/components/SettingsModal/SettingsView/GraphBlueprint/BlueprintModal/Body/Editor/CustomAttributesStep/index.tsx
+++ b/src/components/SettingsModal/SettingsView/GraphBlueprint/BlueprintModal/Body/Editor/CustomAttributesStep/index.tsx
@@ -7,9 +7,10 @@ import { FormInput } from './FormInput'
 
 interface Props {
   parent?: string
+  onDelete: (attributeKey: string) => void
 }
 
-export const CreateCustomNodeAttribute: FC<Props> = ({ parent }) => {
+export const CreateCustomNodeAttribute: FC<Props> = ({ parent, onDelete }) => {
   const parentParam = parent
 
   return (
@@ -27,7 +28,7 @@ export const CreateCustomNodeAttribute: FC<Props> = ({ parent }) => {
           </Grid>
         </Grid>
       </Flex>
-      {parentParam && <FormInput key={parentParam} parentParam={parentParam} />}
+      {parentParam && <FormInput key={parentParam} onDelete={onDelete} parentParam={parentParam} />}
     </Flex>
   )
 }


### PR DESCRIPTION
### Problem:
- Implemented functionality to add the 'delete' value to attributes when a user removes them while editing a custom node in the blueprint. This ensures that the correct data is sent in the PUT request to the /schema endpoint.

closes: #1247

## Issue ticket number and link:
- **Ticket Number:** [ 1247 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1247 ]

## Testing:
Tested the functionality locally by removing attributes and verifying that the correct data is sent in the PUT request. 