### PR TITLE
Fix: Correct Display of Video Time on Progress Bar in Episode [SideBarSubView]

### DIFF
--- a/src/components/App/SideBar/Episode/index.tsx
+++ b/src/components/App/SideBar/Episode/index.tsx
@@ -58,6 +58,14 @@ export const Episode = () => {
 
       if (playingNode && timestamp.link && playingNode?.link !== timestamp.link) {
         setPlayingNodeLink(timestamp.link)
+        setPlayingTime(0)
+        setIsSeeking(true)
+      } else if (!playingNode || playingNode?.link !== timestamp.link) {
+        if (timestamp.link !== undefined) {
+          setPlayingNodeLink(timestamp.link)
+          setPlayingTime(0)
+          setIsSeeking(true)
+        }
       }
 
       setPlayingTime(newTime)

--- a/src/components/App/SideBar/SidebarSubView/MediaPlayer/index.tsx
+++ b/src/components/App/SideBar/SidebarSubView/MediaPlayer/index.tsx
@@ -23,6 +23,7 @@ const MediaPlayerComponent: FC<Props> = ({ hidden }) => {
   const [isFullScreen, setIsFullScreen] = useState(false)
   const [isMouseNearBottom, setIsMouseNearBottom] = useState(false)
   const [status, setStatus] = useState<'buffering' | 'error' | 'ready'>('ready')
+  const [isReady, setIsReady] = useState(false)
 
   const {
     isPlaying,
@@ -43,6 +44,14 @@ const MediaPlayerComponent: FC<Props> = ({ hidden }) => {
   const isYouTubeVideo = playingNode?.link?.includes('youtube') || playingNode?.link?.includes('youtu.be')
 
   useEffect(() => () => resetPlayer(), [resetPlayer])
+
+  useEffect(() => {
+    if (playingNode && !isReady) {
+      setPlayingTime(0)
+      setDuration(0)
+      setIsReady(false)
+    }
+  }, [playingNode, setPlayingTime, setDuration, setIsReady, isReady])
 
   useEffect(() => {
     if (isSeeking && playerRef.current) {


### PR DESCRIPTION
### Problem:
When a user clicks on any episode, initially, the video progress bar displays the time according to the Timestamp. However, after some time, the progress bar reverts back to the original video time, creating inconsistency in the displayed time.

closes: #1367

## Issue ticket number and link:
- **Ticket Number:** [ 1367 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1367 ]

### Evidence:
 - Please see the attached video as evidence.
 https://www.loom.com/share/e001e18cedb44b84a4695b2fcb4b930f