### PR TITLE
Update Multi-select Action Bar to Overlay Over Table Header

### DIFF
--- a/src/components/SourcesTableModal/SourcesView/Topics/MergeTopicModal/__tests__/index.tsx
+++ b/src/components/SourcesTableModal/SourcesView/Topics/MergeTopicModal/__tests__/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable padding-line-between-statements */
 import { render, fireEvent, waitFor } from '@testing-library/react'
 import { MergeTopicModal } from '../index'
 import * as TopicsStore from '~/stores/useTopicsStore'

--- a/src/components/SourcesTableModal/SourcesView/Topics/Table/index.tsx
+++ b/src/components/SourcesTableModal/SourcesView/Topics/Table/index.tsx
@@ -139,7 +139,7 @@ export const Table: React.FC<TopicTableProps> = ({
                           <ClearIcon />
                         </IconButton>
                       </StyledTableCell>
-                      <StyledTableCell>
+                      <StyledTableCell colSpan={3}>
                         <StatusBarSection>
                           <CheckCountBoxSection>
                             <CheckedCount>{checkedCount}</CheckedCount>
@@ -161,7 +161,6 @@ export const Table: React.FC<TopicTableProps> = ({
                           </MuteStatusSection>
                         </StatusBarSection>
                       </StyledTableCell>
-                      <StyledTableCell className="empty" />
                       <StyledTableCell className="empty" />
                       <StyledTableCell className="empty" />
                       <StyledTableCell className="empty" />


### PR DESCRIPTION
### Problem:
- When multi-selecting an item, the action bar should be overlayed over the table header and not below.

## Issue ticket number and link:
- **Ticket Number:** [ 1357 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1357 ]

### Evidence:
 - Please see the attached image as evidence.
 
![image](https://github.com/stakwork/sphinx-nav-fiber/assets/156602406/44b34075-d258-4022-a545-28c97d6e1a44)