### PR TITLE
Should close second sidebar when click on stats tab

### DIFF
--- a/src/components/Stats/__tests__/index.tsx
+++ b/src/components/Stats/__tests__/index.tsx
@@ -132,8 +132,9 @@ describe('Component Test Stats', () => {
   it('asserts that OnClick, prediction/content/latest endpoint is called with media type query', () => {
     const mockedSetBudget = jest.fn()
     const fetchDataMock = jest.fn()
+    const setSelectedNode = jest.fn()
     mockedUseUserStore.mockReturnValue([mockBudget, mockedSetBudget])
-    mockedUseDataStore.mockReturnValue([mockStats, jest.fn(), fetchDataMock])
+    mockedUseDataStore.mockReturnValue([mockStats, setSelectedNode, jest.fn(), fetchDataMock])
 
     const { getByText } = render(<Stats />)
 

--- a/src/components/Stats/index.tsx
+++ b/src/components/Stats/index.tsx
@@ -79,6 +79,7 @@ export const StatsConfig: StatConfigItem[] = [
 
 export const Stats = () => {
   const [budget, setBudget] = useUserStore((s) => [s.budget, s.setBudget])
+
   const [stats, setStats, fetchData, setSelectedNode] = useDataStore((s) => [
     s.stats,
     s.setStats,

--- a/src/components/Stats/index.tsx
+++ b/src/components/Stats/index.tsx
@@ -79,10 +79,17 @@ export const StatsConfig: StatConfigItem[] = [
 
 export const Stats = () => {
   const [budget, setBudget] = useUserStore((s) => [s.budget, s.setBudget])
-  const [stats, setStats, fetchData] = useDataStore((s) => [s.stats, s.setStats, s.fetchData])
+  const [stats, setStats, fetchData, setSelectedNode] = useDataStore((s) => [
+    s.stats,
+    s.setStats,
+    s.fetchData,
+    s.setSelectedNode,
+  ])
 
   function handleStatClick(mediaType: string) {
     fetchData(setBudget, { ...(mediaType ? { media_type: mediaType } : {}), skip_cache: 'true' })
+
+    setSelectedNode(null)
   }
 
   useEffect(() => {


### PR DESCRIPTION

### Ticket №: #1409

closes #1409

### Problem:

When we select a node from sidebar then that node details open in second sidebar and that node appear in graph But when we select a new sats tab in the navbar of graph screen then the sidebar and graph refresh but the second sidebar still remains open that is the bug.

### Evidence:

https://www.loom.com/share/31f9d53b4f7944c1bf7cb30adbcbfb93?sid=8b8f2467-84ca-4d4e-a74c-af9eec8df9fa


