### PR TITLE
Fixed(side-bar-sub-view): Implement Collapse Functionality

### DIFF
--- a/src/components/App/SideBar/SidebarSubView/index.tsx
+++ b/src/components/App/SideBar/SidebarSubView/index.tsx
@@ -60,7 +60,6 @@ const Wrapper = styled(Flex)(({ theme }) => ({
   margin: '64px auto 20px 10px',
   borderRadius: '16px',
   zIndex: 29,
-  overflow: 'hidden',
   [theme.breakpoints.up('sm')]: {
     width: '390px',
   },
@@ -84,6 +83,8 @@ const CloseButton = styled(Flex)`
 
 const ScrollWrapper = styled(Flex)`
   flex: 1 1 100%;
+  border-radius: 16px;
+  overflow: hidden;
 `
 
 const CollapseButton = styled(Flex).attrs({


### PR DESCRIPTION
### Problem:
- The 'Collapse Side Panel' option is disappearing within the [SideBarSubView].

### closes: #1417

## Issue ticket number and link:
- **Ticket Number:** [ 1417 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1417 ]

### Evidence:
 - Please see the attached video as evidence.
https://www.loom.com/share/ad45e896ad2a4b6a84b79ecfa5c771a4

![image](https://github.com/stakwork/sphinx-nav-fiber/assets/156602406/df9343fa-f2b8-42a1-ab43-b639198885fa)