### PR TITLE
Disable merge topics button if not selectedNode from the dropdown

### DIFF
--- a/src/components/SourcesTableModal/SourcesView/Topics/MergeTopicModal/index.tsx
+++ b/src/components/SourcesTableModal/SourcesView/Topics/MergeTopicModal/index.tsx
@@ -80,7 +80,7 @@ export const MergeTopicModal: FC<Props> = ({ onClose, multiTopics }) => {
         <Button
           color="secondary"
           data-testid="merge-topics-button"
-          disabled={loading || isSwapped}
+          disabled={loading || isSwapped || !selectedToNode}
           onClick={handleSave}
           size="large"
           variant="contained"


### PR DESCRIPTION
### Ticket №: #1423

closes #1423

### Problem:

'merge topics' button is enable as there is no topic is selected from dropdown for merge

### Evidence:

![image](https://github.com/stakwork/sphinx-nav-fiber/assets/98140673/92735d27-8ca0-46b6-b23a-f66e8e2558f3)
