### PR TITLE
At Source table modal Edit Topic and Add Edge Topic modals should be open When we click from popover of specific topic

### DIFF
--- a/src/components/SourcesTableModal/SourcesView/Topics/index.tsx
+++ b/src/components/SourcesTableModal/SourcesView/Topics/index.tsx
@@ -118,6 +118,8 @@ export const TopicSources = () => {
       if (typeof topicActions[action] === 'function') {
         topicActions[action]()
       }
+
+      setSelectedTopic(data[topicId])
     }
   }
 


### PR DESCRIPTION
### Ticket №: #1426

closes #1426

### Problem:

- At Source table modal Edit Topic and Add Edge Topic modals are not open When we click from popover of specific topic
- After that if we click on Merge Topic modal then the to modal opens at same time

### Evidence:

https://www.loom.com/share/46608e7b32654f9ab4697506d4ff1710?sid=943a918d-e46a-46e4-a9a8-81c492c6f346