### PR TITLE
Fix: Add Item Flow Next Button Should Not Allow Enabling with Empty Spaces

### DIFF
--- a/src/components/AddItemModal/SetAttributesStep/index.tsx
+++ b/src/components/AddItemModal/SetAttributesStep/index.tsx
@@ -25,6 +25,8 @@ export const SetAttributesStep: FC<Props> = ({ handleSelectType, skipToStep, nod
   const [loading, setLoading] = useState(false)
   const [attributes, setAttributes] = useState<parsedObjProps[]>()
 
+  const noSpacePattern = /^[^\s][\w\s]*$/
+
   const {
     watch,
     formState: { isValid },
@@ -92,7 +94,15 @@ export const SetAttributesStep: FC<Props> = ({ handleSelectType, skipToStep, nod
                     name={key}
                     placeholder={required ? 'Required' : 'Optional'}
                     rules={{
-                      ...(required ? requiredRule : {}),
+                      ...(required
+                        ? {
+                            ...requiredRule,
+                            pattern: {
+                              message: 'Please avoid special characters and spaces',
+                              value: noSpacePattern,
+                            },
+                          }
+                        : {}),
                     }}
                   />
                 </TextFieldWrapper>

--- a/src/components/AddItemModal/SetAttributesStep/index.tsx
+++ b/src/components/AddItemModal/SetAttributesStep/index.tsx
@@ -14,6 +14,7 @@ import { requiredRule } from '~/constants'
 import { getNodeType } from '~/network/fetchSourcesData'
 import { colors } from '~/utils'
 import { AddItemModalStepID } from '..'
+import { noSpaceAttributePattern } from '~/components/AddItemModal/SourceTypeStep/constants'
 
 type Props = {
   skipToStep: (step: AddItemModalStepID) => void
@@ -24,8 +25,6 @@ type Props = {
 export const SetAttributesStep: FC<Props> = ({ handleSelectType, skipToStep, nodeType }) => {
   const [loading, setLoading] = useState(false)
   const [attributes, setAttributes] = useState<parsedObjProps[]>()
-
-  const noSpacePattern = /^[^\s][\w\s]*$/
 
   const {
     watch,
@@ -99,7 +98,7 @@ export const SetAttributesStep: FC<Props> = ({ handleSelectType, skipToStep, nod
                             ...requiredRule,
                             pattern: {
                               message: 'Please avoid special characters and spaces',
-                              value: noSpacePattern,
+                              value: noSpaceAttributePattern,
                             },
                           }
                         : {}),

--- a/src/components/AddItemModal/SourceStep/index.tsx
+++ b/src/components/AddItemModal/SourceStep/index.tsx
@@ -6,6 +6,7 @@ import { Text } from '~/components/common/Text'
 import { TextInput } from '~/components/common/TextInput'
 import { requiredRule } from '~/constants'
 import { AddItemModalStepID } from '..'
+import { noSpaceSourceStepPattern } from '~/components/AddItemModal/SourceTypeStep/constants'
 
 type Props = {
   type: string
@@ -15,9 +16,7 @@ type Props = {
 }
 
 export const SourceStep: FC<Props> = ({ type, skipToStep, name, sourceLink }) => {
-  const noSpacePattern = /^[^\s].*$/
-
-  const isValidInput = (input: string | undefined) => noSpacePattern.test(input ?? '')
+  const isValidInput = (input: string | undefined) => noSpaceSourceStepPattern.test(input ?? '')
 
   const allowNextStep = type === 'Image' ? isValidInput(name) && isValidInput(sourceLink) : isValidInput(name)
 
@@ -42,7 +41,7 @@ export const SourceStep: FC<Props> = ({ type, skipToStep, name, sourceLink }) =>
             ...requiredRule,
             pattern: {
               message: 'Please avoid special characters and spaces',
-              value: noSpacePattern,
+              value: noSpaceSourceStepPattern,
             },
           }}
         />
@@ -63,7 +62,7 @@ export const SourceStep: FC<Props> = ({ type, skipToStep, name, sourceLink }) =>
                 ...requiredRule,
                 pattern: {
                   message: 'Please avoid special characters and spaces',
-                  value: noSpacePattern,
+                  value: noSpaceSourceStepPattern,
                 },
               }}
             />

--- a/src/components/AddItemModal/SourceStep/index.tsx
+++ b/src/components/AddItemModal/SourceStep/index.tsx
@@ -15,7 +15,11 @@ type Props = {
 }
 
 export const SourceStep: FC<Props> = ({ type, skipToStep, name, sourceLink }) => {
-  const allowNextStep = type === 'Image' ? name && sourceLink : name
+  const noSpacePattern = /^[^\s].*$/
+
+  const isValidInput = (input: string | undefined) => noSpacePattern.test(input ?? '')
+
+  const allowNextStep = type === 'Image' ? isValidInput(name) && isValidInput(sourceLink) : isValidInput(name)
 
   return (
     <Flex>
@@ -36,6 +40,10 @@ export const SourceStep: FC<Props> = ({ type, skipToStep, name, sourceLink }) =>
           placeholder="Paste name here..."
           rules={{
             ...requiredRule,
+            pattern: {
+              message: 'Please avoid special characters and spaces',
+              value: noSpacePattern,
+            },
           }}
         />
       </Flex>
@@ -53,6 +61,10 @@ export const SourceStep: FC<Props> = ({ type, skipToStep, name, sourceLink }) =>
               placeholder="Paste link here..."
               rules={{
                 ...requiredRule,
+                pattern: {
+                  message: 'Please avoid special characters and spaces',
+                  value: noSpacePattern,
+                },
               }}
             />
           </Flex>

--- a/src/components/AddItemModal/SourceTypeStep/constants.ts
+++ b/src/components/AddItemModal/SourceTypeStep/constants.ts
@@ -65,3 +65,7 @@ export const OPTIONS: TOption[] = [
     value: 'Topic',
   },
 ]
+
+export const noSpaceAttributePattern = /^[^\s][\w\s]*$/
+
+export const noSpaceSourceStepPattern = /^[^\s].*$/


### PR DESCRIPTION
### Problem:
- In the Add item flow, users are able to enable items even when they contain empty spaces, contrary to the intended behavior where enabling items with empty spaces should be disallowed.

### closes: #1421

## Issue ticket number and link:
- **Ticket Number:** [ 1421 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1421 ]

### Evidence:
 - Please see the attached video as evidence.
https://www.loom.com/share/f921ae5c9d144f43a1f87e9fa09b0c19

![image](https://github.com/stakwork/sphinx-nav-fiber/assets/87068339/e99556b0-182b-4876-be97-3a2fbedba16b)

![image](https://github.com/stakwork/sphinx-nav-fiber/assets/87068339/1e370b6d-3230-40fd-ac94-19339ce7cf11)
