### PR TITLE
Refresh of Application Page When Selecting Dropdown Option from Trending Topics

### DIFF
--- a/src/components/App/SideBar/Dropdown/index.tsx
+++ b/src/components/App/SideBar/Dropdown/index.tsx
@@ -13,7 +13,8 @@ import { colors } from '~/utils/colors'
 export const SelectWithPopover = () => {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
   const { sidebarFilter, setSidebarFilter, sidebarFilterCounts } = useDataStore((s) => s)
-  const currentFilterCount = sidebarFilterCounts.find((f) => f.name === sidebarFilter)?.count || 0
+  const currentFilter = sidebarFilter === 'undefined' ? '' : sidebarFilter.toLowerCase()
+  const currentFilterCount = sidebarFilterCounts.find((f) => f.name === currentFilter)?.count || 0
 
   const capitalizeFirstLetter = (text: string): string => {
     if (!text) {
@@ -41,7 +42,7 @@ export const SelectWithPopover = () => {
       <Action onClick={handleOpenPopover}>
         <div className="text">Show</div>
         <div className="value" data-testid="value">
-          {`${capitalizeFirstLetter(sidebarFilter)} (${currentFilterCount})`}
+          {`${capitalizeFirstLetter(currentFilter)} (${currentFilterCount})`}
         </div>
         <div className="icon">{!anchorEl ? <ChevronDownIcon /> : <ChevronUpIcon />}</div>
       </Action>
@@ -63,16 +64,21 @@ export const SelectWithPopover = () => {
         }}
       >
         <FormControl>
-          {sidebarFilterCounts.map(({ name, count }) => (
-            <MenuItem
-              key={name}
-              className={clsx({ active: name === sidebarFilter })}
-              onClick={() => handleSelectChange(name)}
-            >
-              <span className="icon">{name === sidebarFilter ? <CheckIcon /> : null}</span>
-              <span>{`${capitalizeFirstLetter(name)} (${count})`}</span>
-            </MenuItem>
-          ))}
+          {sidebarFilterCounts
+            .filter(({ name }) => name)
+            .map(({ name, count }) => (
+              <MenuItem
+                key={name}
+                className={clsx({ active: name === sidebarFilter })}
+                onClick={(e) => {
+                  e.preventDefault()
+                  handleSelectChange(name)
+                }}
+              >
+                <span className="icon">{name === sidebarFilter ? <CheckIcon /> : null}</span>
+                <span>{`${capitalizeFirstLetter(name)} (${count})`}</span>
+              </MenuItem>
+            ))}
         </FormControl>
       </StyledPopover>
     </div>

--- a/src/stores/useDataStore/index.ts
+++ b/src/stores/useDataStore/index.ts
@@ -154,17 +154,12 @@ export const useDataStore = create<DataStore>()(
         await saveSearchTerm()
       }
 
-      const sidebarFilters = ['all', ...new Set(data.nodes.map((i) => i.node_type?.toLowerCase()))]
+      const sidebarFilters = ['all', ...new Set(data.nodes.map((i) => (i.node_type || '').toLowerCase()))]
 
-      const sidebarFilterCounts = sidebarFilters
-        .map((filter) => ({
-          name: filter,
-          count:
-            filter === 'all'
-              ? data.nodes.length
-              : data.nodes.filter((node) => filter === node.node_type?.toLowerCase()).length,
-        }))
-        .sort((a, b) => b.count - a.count)
+      const sidebarFilterCounts = sidebarFilters.map((filter) => ({
+        name: filter,
+        count: data.nodes.filter((node) => filter === 'all' || node.node_type?.toLowerCase() === filter).length,
+      }))
 
       set({
         data,
@@ -278,11 +273,13 @@ export const useDataStore = create<DataStore>()(
 export const useSelectedNode = () => useDataStore((s) => s.selectedNode)
 
 export const useFilteredNodes = () =>
-  useDataStore((s) =>
-    (s.data?.nodes || []).filter((i) =>
-      s.sidebarFilter === 'all' ? true : i.node_type.toLocaleLowerCase() === s.sidebarFilter.toLocaleLowerCase(),
-    ),
-  )
+  useDataStore((s) => {
+    if (s.sidebarFilter === 'all') {
+      return s.data?.nodes || []
+    }
+
+    return (s.data?.nodes || []).filter((i) => i.node_type?.toLowerCase() === s.sidebarFilter.toLowerCase())
+  })
 
 export const useUpdateGraphData = () => {
   const data = useDataStore((state) => state.data)


### PR DESCRIPTION
### Problem:
When following the steps below, the application page resets:

1- Click on any Trending Topic.
2- Then click on any dropdown and select an option.
This results in the loss of current state and a reset of the application page.

### closes: #1432

## Issue ticket number and link:
- **Ticket Number:** [ 1432 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1432 ]

### Evidence:
 - Please see the attached video as evidence.
https://www.loom.com/share/79cccf9f031e490a8b2dd4255f30dfd3