### PR TITLE
Fix Search Text `Overlapping` with Search Icon and Style `Unmute ALL` Button in [Sources Table]

### DIFF
--- a/src/components/SourcesTableModal/SourcesView/Sources/Search/index.tsx
+++ b/src/components/SourcesTableModal/SourcesView/Sources/Search/index.tsx
@@ -147,7 +147,7 @@ const StyledInput = styled(InputBase)`
     border-radius: 6px;
     pointer-events: auto;
     background-color: ${colors.BG2};
-    padding: 0px 8px 0px 16px !important;
+    padding: 0px 34px 0px 16px !important;
     box-shadow: 0px 1px 6px rgba(0, 0, 0, 0.1);
 
     &:focus,

--- a/src/components/SourcesTableModal/SourcesView/Topics/Search/index.tsx
+++ b/src/components/SourcesTableModal/SourcesView/Topics/Search/index.tsx
@@ -133,7 +133,7 @@ const StyledInput = styled(InputBase)`
     border-radius: 6px;
     pointer-events: auto;
     background-color: ${colors.BG2};
-    padding: 0px 8px 0px 16px !important;
+    padding: 0px 34px 0px 16px !important;
     box-shadow: 0px 1px 6px rgba(0, 0, 0, 0.1);
 
     &:focus,

--- a/src/components/SourcesTableModal/SourcesView/Topics/Table/index.tsx
+++ b/src/components/SourcesTableModal/SourcesView/Topics/Table/index.tsx
@@ -139,7 +139,7 @@ export const Table: React.FC<TopicTableProps> = ({
                           <ClearIcon />
                         </IconButton>
                       </StyledTableCell>
-                      <StyledTableCell>
+                      <StyledTableCell colSpan={3}>
                         <StatusBarSection>
                           <CheckCountBoxSection>
                             <CheckedCount>{checkedCount}</CheckedCount>
@@ -161,7 +161,6 @@ export const Table: React.FC<TopicTableProps> = ({
                           </MuteStatusSection>
                         </StatusBarSection>
                       </StyledTableCell>
-                      <StyledTableCell className="empty" />
                       <StyledTableCell className="empty" />
                       <StyledTableCell className="empty" />
                       <StyledTableCell className="empty" />
@@ -342,6 +341,7 @@ const MuteStatusSection = styled.div`
   flex-wrap: nowrap;
   gap: 8px;
   padding: 1px 8px;
+  white-space: nowrap;
   &:hover {
     background-color: rgba(255, 255, 255, 0.2);
     padding: 1px 8px;
@@ -358,7 +358,7 @@ const CheckCountBoxSection = styled.div`
 const StatusBarSection = styled.span`
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  gap: 27px;
 `
 
 const TableInnerWrapper = styled(Flex)`

--- a/src/components/SourcesTableModal/SourcesView/common/index.tsx
+++ b/src/components/SourcesTableModal/SourcesView/common/index.tsx
@@ -108,4 +108,9 @@ export const ActionStyledTableHead = styled(TableHead)`
   ${StyledTableCell} {
     color: ${colors.white};
   }
+
+  ${StyledTableCell}.empty {
+    width: 0;
+    padding: 0;
+  }
 `


### PR DESCRIPTION
### Problem:
- The search text is overlapping with the search icon, making it difficult to read and use the search functionality effectively.
- The 'Unmute All' button lacks proper styling, which impacts its visibility and usability.

### closes: #1449

## Issue ticket number and link:
- **Ticket Number:** [ 1449 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1449 ]

### Evidence:
 - Please see the attached image as evidence.
 
- `Unmute ALL` Button :

![image](https://github.com/stakwork/sphinx-nav-fiber/assets/87068339/bc8873d5-cd4d-4b2c-aaa4-f1eb7138bd91)

- Search Text `Overlapping` with Search Icon 

![image](https://github.com/stakwork/sphinx-nav-fiber/assets/87068339/325e3f7f-08f1-4671-b331-cefbc1a014dd)

![image](https://github.com/stakwork/sphinx-nav-fiber/assets/87068339/832780f2-078d-4167-b8c8-f201db329296)
