### PR TITLE
Fixed(ActionTool-Bar): Episode Subtitle Text Overflow in ActionTool Bar on SideBarSubView

### DIFF
--- a/src/components/App/ActionsToolbar/PlayerControl/index.tsx
+++ b/src/components/App/ActionsToolbar/PlayerControl/index.tsx
@@ -125,6 +125,9 @@ const Info = styled(Flex).attrs({
   .subtitle {
     font-size: 11px;
     color: ${colors.GRAY6};
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
   }
 `
 


### PR DESCRIPTION
### Problem:
- The episode `subtitle text` is overflowing in the ActionTool Bar on the SideBarSubView. This overflow issue causes misalignment with the `playingNode image` and the `progress bar`, affecting the overall layout and visual alignment.

### closes: #1475

## Issue ticket number and link:
- **Ticket Number:** [ 1475 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1475 ]

### Evidence:
 - Please see the attached image and video as evidence.
 
https://www.loom.com/share/e0b09fd19c0d4285895f80bc46531677

![image](https://github.com/stakwork/sphinx-nav-fiber/assets/87068339/e37ddcd1-8ea1-493e-be51-665d808a9d81)
