### PR TITLE
Fixed(update-lable): Update Labels and Box Colors for High-Level Node Types in Graph

### DIFF
--- a/src/components/common/TypeBadge/index.tsx
+++ b/src/components/common/TypeBadge/index.tsx
@@ -133,7 +133,7 @@ const EpisodeWrapper = styled(Flex).attrs({
   }
 
   .badge__label {
-    color: ${({ label }) => (label === 'topic' ? colors.black : colors.white)};
+    color: ${({ label }) => (label.toLowerCase() === 'topic' ? colors.black : colors.white)};
     font-family: Barlow;
     font-size: 8px;
     font-style: normal;


### PR DESCRIPTION
### Problem:
- The topic badge text is white and hard to read.

### closes: #1358

## Issue ticket number and link:
- **Ticket Number:** [ 1358 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1358 ]

### Evidence:
 - Please see the attached image as evidence.
 
![image](https://github.com/stakwork/sphinx-nav-fiber/assets/87068339/54e4055e-f931-4ddb-bdad-21e0a475f514)
