### PR TITLE
Fixed(source-search): Make All `Modals` Responsive And Fix `Search Text Overlap` On Loader

### DIFF
--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -24,7 +24,6 @@ const getModalKindStyles = ({ kind = 'regular' }: Pick<Props, 'kind'>) => {
     case 'large':
       return css`
         width: 709px;
-        height: 100%;
       `
     case 'full':
       return css`
@@ -41,13 +40,27 @@ const getModalKindStyles = ({ kind = 'regular' }: Pick<Props, 'kind'>) => {
 const ModalContainer = styled(Flex)<Pick<Props, 'kind'>>`
   z-index: 2000;
   margin: 0 auto;
-  overflow: visible;
   animation: ${scaleAnimation} 0.2s ease-in-out;
   position: relative;
   max-width: 100%;
   overflow: visible;
   background: ${colors};
-  ${getModalKindStyles}
+  ${getModalKindStyles};
+
+  @media (max-width: 1024px) {
+    height: auto;
+    max-height: 80%;
+  }
+
+  @media (max-width: 768px) {
+    height: auto;
+    max-height: 80%;
+  }
+
+  @media (max-width: 480px) {
+    height: auto;
+    max-height: 80%;
+  }
 `
 
 const fadeAnimation = keyframes`

--- a/src/components/SearchBar/index.tsx
+++ b/src/components/SearchBar/index.tsx
@@ -14,7 +14,7 @@ const Input = styled.input.attrs(() => ({
 }))<{ loading?: boolean }>`
   pointer-events: auto;
   height: 48px;
-  padding: 0 30px 0px 20px;
+  padding: 0 40px 0 18px;
   z-index: 2;
   box-shadow: 0px 1px 6px rgba(0, 0, 0, 0.1);
   width: 100%;

--- a/src/components/SettingsModal/SettingsView/index.tsx
+++ b/src/components/SettingsModal/SettingsView/index.tsx
@@ -129,13 +129,26 @@ const TabPanelWrapper = styled(Flex)`
   max-height: 495px;
   height: fit-content;
   min-width: 480px;
-  overflow: hidden;
+  overflow: auto;
   border-radius: 9px;
+
+  @media (max-width: 1024px) {
+    min-height: auto;
+    max-height: 400px;
+    min-width: 480px;
+  }
+
+  @media (max-width: 768px) {
+    min-height: auto;
+    max-height: 300px;
+    min-width: 380px;
+  }
 `
 
 const Wrapper = styled(Flex)`
   min-height: 0;
   flex: 1;
+  overflow: hidden;
 `
 
 const StyledText = styled(Text)`
@@ -143,4 +156,12 @@ const StyledText = styled(Text)`
   font-weight: 600;
   font-family: Barlow;
   padding: 0 0 0 36px;
+
+  @media (max-width: 1024px) {
+    font-size: 20px;
+  }
+
+  @media (max-width: 768px) {
+    font-size: 18px;
+  }
 `

--- a/src/components/SourcesTableModal/SourcesView/index.tsx
+++ b/src/components/SourcesTableModal/SourcesView/index.tsx
@@ -104,7 +104,7 @@ const StyledTabs = styled(Tabs)`
 
 const StyledTab = styled(Tab)`
   && {
-    padding: 20px 0 24px;
+    padding: 30px 0 24px;
     color: ${colors.GRAY6};
     margin-left: 34px;
     font-family: Barlow;
@@ -121,12 +121,36 @@ const StyledTab = styled(Tab)`
 const TabPanelWrapper = styled(Flex)`
   display: flex;
   flex: 1;
-  min-height: 515px;
+  min-height: 572px;
   padding: 20px 0;
-  max-height: 515px;
+  max-height: 572px;
+  overflow: auto;
+
+  @media (max-width: 1024px) {
+    width: 100%;
+    min-height: 400px;
+    max-height: 400px;
+  }
+
+  @media (max-width: 768px) {
+    width: 100%;
+    min-height: 300px;
+    max-height: 300px;
+  }
+
+  @media (max-width: 480px) {
+    width: 100%;
+    min-height: 250px;
+    max-height: 250px;
+  }
 `
 
 const Wrapper = styled(Flex)`
   min-height: 0;
   flex: 1;
+  overflow: hidden;
+
+  @media (max-width: 768px) {
+    padding: 3px;
+  }
 `


### PR DESCRIPTION
### Problem:
- All modals are not responsive on all desktop screens.
- The search text overlaps with the loader icon in the search box.

### closes: #1431
### closes: #1414

## Issue ticket number and link:
- **Ticket Number:** [ 1414,  1431]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1414 and https://github.com/stakwork/sphinx-nav-fiber/issues/1431 ]

### Evidence:
 - Please see the attached video as evidence.
 
https://www.loom.com/share/b0cce17351e547b9b82772df20ff7d4d