### PR TITLE
Fixed(Source-Table): Hide `Load More` Button in View Content Modal

### DIFF
--- a/src/components/SourcesTableModal/SourcesView/Content/index.tsx
+++ b/src/components/SourcesTableModal/SourcesView/Content/index.tsx
@@ -61,15 +61,13 @@ export const Content = () => {
             <Table nodes={nodes} />
           </>
         )}
-        {!loading ? (
-          newNodesAvailable ? (
+        {!loading && nodes.length > 0 && newNodesAvailable ? (
             <Button onClick={handleLoadMore} size="medium">
               Load More
             </Button>
-          ) : (
-            <NoNewNodesMessage>No new nodes available</NoNewNodesMessage>
-          )
-        ) : null}
+        ) : (
+            !loading && nodes.length === 0 && <NoNewNodesMessage>No new nodes available</NoNewNodesMessage>
+        )}
       </TableWrapper>
     </Wrapper>
   )

--- a/src/components/SourcesTableModal/SourcesView/Content/index.tsx
+++ b/src/components/SourcesTableModal/SourcesView/Content/index.tsx
@@ -61,13 +61,15 @@ export const Content = () => {
             <Table nodes={nodes} />
           </>
         )}
-        {!loading && nodes.length > 0 && newNodesAvailable ? (
+        {!loading &&
+          nodes.length > 0 &&
+          (newNodesAvailable ? (
             <Button onClick={handleLoadMore} size="medium">
               Load More
             </Button>
-        ) : (
-            !loading && nodes.length === 0 && <NoNewNodesMessage>No new nodes available</NoNewNodesMessage>
-        )}
+          ) : (
+            <NoNewNodesMessage>No new nodes available</NoNewNodesMessage>
+          ))}
       </TableWrapper>
     </Wrapper>
   )


### PR DESCRIPTION
### Problem:
Currently, when the view content table is empty, the 'Load more' button remains visible, which is contrary to the expected behavior.

### Expected Behavior:
The "Load More" button should be hidden when the view content table is empty.

closes: #1483

## Issue ticket number and link:
- **Ticket Number:** [ 1483 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1483 ]

### Testing:
- Tested the behavior of the "Load More" button when the content table is empty.
- Verified that the button is hidden in this scenario.

### Evidence:
 - Please see the attached video and image as evidence.

https://www.loom.com/share/708b3cc59d0849d1a630baf62629a401

![image](https://github.com/stakwork/sphinx-nav-fiber/assets/87068339/7e60eb8c-3e6b-4e79-ac17-4875ea751c12)
