### PR TITLE
Fixed(Timestamp): `Timestamp` Does Not Update According to `Progress Bar` in Type Episode on [SideBarSubView]

### DIFF
--- a/src/components/App/SideBar/Episode/index.tsx
+++ b/src/components/App/SideBar/Episode/index.tsx
@@ -35,11 +35,12 @@ export const Episode = () => {
 
   const [selectedTimestamp, setSelectedTimestamp] = useState<NodeExtended | null>(null)
 
-  const [playingNode, setPlayingNodeLink, setPlayingTime, setIsSeeking] = usePlayerStore((s) => [
+  const [playingNode, setPlayingNodeLink, setPlayingTime, setIsSeeking, playingTime] = usePlayerStore((s) => [
     s.playingNode,
     s.setPlayingNodeLink,
     s.setPlayingTime,
     s.setIsSeeking,
+    s.playingTime,
   ])
 
   const selectedNodeTimestamps = useMemo(
@@ -80,6 +81,24 @@ export const Episode = () => {
       updateActiveTimestamp(selectedNodeTimestamps[0])
     }
   }, [selectedNodeTimestamps, selectedTimestamp, updateActiveTimestamp])
+
+  useEffect(() => {
+    if (selectedNodeTimestamps?.length) {
+      const currentTimestamp = selectedNodeTimestamps.find((timestamp) => {
+        if (!timestamp.timestamp) {
+          return false
+        }
+
+        const timestampSeconds = videoTimeToSeconds(timestamp.timestamp.split('-')[0])
+
+        return Math.abs(timestampSeconds - playingTime) < 1
+      })
+
+      if (currentTimestamp && currentTimestamp.ref_id !== selectedTimestamp?.ref_id) {
+        setSelectedTimestamp(currentTimestamp)
+      }
+    }
+  }, [playingTime, selectedNodeTimestamps, selectedTimestamp])
 
   if (!selectedNode) {
     return null


### PR DESCRIPTION
### Problem:
The timestamp is not updated according to the progress bar in the episode. `For example`, when the progress bar shows a timeline of 10:00, the timestamp should change automatically, but it still shows the initial timestamp.

### Expected Behavior:
The "Load More" button should be hidden when the view content table is empty.

closes: #1485

## Issue ticket number and link:
- **Ticket Number:** [ 1485 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1485 ]

### Evidence:
 - Please see the attached video as evidence.
https://www.loom.com/share/174cdd9d5d5842aaa38ddd620b1d2473


### Acceptance Criteria
- [x] The timestamp updates in real-time according to the progress bar in the episode.
- [x] When the progress bar shows a timeline of 10:00, the timestamp reflects this exact time without delay.
- [x] The timestamp should not remain static or show the initial timestamp once the progress bar moves.