### PR TITLE
Remove useless tooltip from show topic heading

### DIFF
--- a/src/components/App/SideBar/Show/index.tsx
+++ b/src/components/App/SideBar/Show/index.tsx
@@ -113,9 +113,7 @@ export const Show = () => {
                 <div className="subtitle">by {showHost.join(', ') || selectedNode?.show_title}</div>
               </Flex>
 
-              <EpisodeHeaderText kind="bigHeading" title={selectedNode?.show_title || 'Unknown'}>
-                {selectedNode?.show_title || 'Unknown'}
-              </EpisodeHeaderText>
+              <EpisodeHeaderText kind="bigHeading">{selectedNode?.show_title || 'Unknown'}</EpisodeHeaderText>
             </Flex>
           </Flex>
         </Flex>


### PR DESCRIPTION
### Ticket №: #1502

closes #1502

### Problem:

Useless tooltip at 'show' SidebarSubView heading

### Evidence :

https://www.loom.com/share/471197ab779d45ba8e649e168adbcda3?sid=4a61ed4e-87d2-4189-97d3-771d734db742
