### PR TITLE
test: retry tests config setting

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     },
   },
   e2e: {
+    retries: 5,
     baseUrl: 'http://localhost:3000',
     defaultCommandTimeout: 10000,
     pageLoadTimeout: 90000,


### PR DESCRIPTION
### Ticket №:
no ticket
### Problem:
Right now on Jarvis-backend the cypress test suite intemittently fails which makes it difficult if the change has broken the test suite when I didnt
### Solution:
This will rerun the cypress test if it fails up to 5 times 
### Changes:
A single line config change
### Testing:
Tested using this PR which passed easier than earlier
https://github.com/stakwork/jarvis-backend/pull/1250

