### PR TITLE
Fixed(addItemFlow): Update Regex in addItemFlow

### DIFF
--- a/src/components/AddItemModal/SetAttributesStep/index.tsx
+++ b/src/components/AddItemModal/SetAttributesStep/index.tsx
@@ -3,6 +3,7 @@ import { FC, useEffect, useState } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { ClipLoader } from 'react-spinners'
 import styled from 'styled-components'
+import { noSpacePattern } from '~/components/AddItemModal/SourceTypeStep/constants'
 import { parseJson, parsedObjProps } from '~/components/ModalsContainer/BlueprintModal/Body/Editor/utils'
 import { Flex } from '~/components/common/Flex'
 import { Text } from '~/components/common/Text'
@@ -11,7 +12,6 @@ import { requiredRule } from '~/constants'
 import { getNodeType } from '~/network/fetchSourcesData'
 import { colors } from '~/utils'
 import { AddItemModalStepID } from '..'
-import { noSpaceAttributePattern } from '~/components/AddItemModal/SourceTypeStep/constants'
 
 type Props = {
   skipToStep: (step: AddItemModalStepID) => void
@@ -25,6 +25,7 @@ export const SetAttributesStep: FC<Props> = ({ handleSelectType, skipToStep, nod
 
   const {
     watch,
+    setValue,
     formState: { isValid },
   } = useFormContext()
 
@@ -67,6 +68,22 @@ export const SetAttributesStep: FC<Props> = ({ handleSelectType, skipToStep, nod
     skipToStep('sourceType')
   }
 
+  const handleNextButton = () => {
+    attributes?.forEach(({ key, required }) => {
+      if (required) {
+        const value = watch(key)
+
+        if (typeof value === 'string') {
+          setValue(key, value.trim(), { shouldValidate: true })
+        }
+      }
+    })
+
+    if (isValid && !loading && attributes?.every((attr) => !attr.required || watch(attr.key))) {
+      skipToStep('setBudget')
+    }
+  }
+
   return (
     <Flex>
       <Flex align="center" direction="row" justify="space-between" mb={18}>
@@ -95,8 +112,8 @@ export const SetAttributesStep: FC<Props> = ({ handleSelectType, skipToStep, nod
                       ? {
                           ...requiredRule,
                           pattern: {
-                            message: 'Please avoid special characters and spaces',
-                            value: noSpaceAttributePattern,
+                            message: 'No leading whitespace allowed',
+                            value: noSpacePattern,
                           },
                         }
                       : {}),
@@ -118,7 +135,7 @@ export const SetAttributesStep: FC<Props> = ({ handleSelectType, skipToStep, nod
           <Button
             color="secondary"
             disabled={!isValid || loading || attributes?.some((attr) => attr.required && !watch(attr.key))}
-            onClick={() => skipToStep('setBudget')}
+            onClick={handleNextButton}
             size="large"
             variant="contained"
           >

--- a/src/components/AddItemModal/SourceStep/index.tsx
+++ b/src/components/AddItemModal/SourceStep/index.tsx
@@ -6,7 +6,7 @@ import { Text } from '~/components/common/Text'
 import { TextInput } from '~/components/common/TextInput'
 import { requiredRule } from '~/constants'
 import { AddItemModalStepID } from '..'
-import { noSpaceSourceStepPattern } from '~/components/AddItemModal/SourceTypeStep/constants'
+import { noSpacePattern } from '~/components/AddItemModal/SourceTypeStep/constants'
 
 type Props = {
   type: string
@@ -16,7 +16,7 @@ type Props = {
 }
 
 export const SourceStep: FC<Props> = ({ type, skipToStep, name, sourceLink }) => {
-  const isValidInput = (input: string | undefined) => noSpaceSourceStepPattern.test(input ?? '')
+  const isValidInput = (input: string | undefined) => noSpacePattern.test(input ?? '')
 
   const allowNextStep = type === 'Image' ? isValidInput(name) && isValidInput(sourceLink) : isValidInput(name)
 
@@ -40,8 +40,8 @@ export const SourceStep: FC<Props> = ({ type, skipToStep, name, sourceLink }) =>
           rules={{
             ...requiredRule,
             pattern: {
-              message: 'Please avoid special characters and spaces',
-              value: noSpaceSourceStepPattern,
+              message: 'No leading whitespace allowed',
+              value: noSpacePattern,
             },
           }}
         />
@@ -62,7 +62,7 @@ export const SourceStep: FC<Props> = ({ type, skipToStep, name, sourceLink }) =>
                 ...requiredRule,
                 pattern: {
                   message: 'Please avoid special characters and spaces',
-                  value: noSpaceSourceStepPattern,
+                  value: noSpacePattern,
                 },
               }}
             />

--- a/src/components/AddItemModal/SourceTypeStep/constants.ts
+++ b/src/components/AddItemModal/SourceTypeStep/constants.ts
@@ -66,6 +66,4 @@ export const OPTIONS: TOption[] = [
   },
 ]
 
-export const noSpaceAttributePattern = /^[^\s][\w\s]*$/
-
-export const noSpaceSourceStepPattern = /^[^\s].*$/
+export const noSpacePattern = /^[^\s].*$/


### PR DESCRIPTION
### Problem:
- Image link and source link are not added in additemflow due to wrong validation
- We should also support special characters

closes: #1521

## Issue ticket number and link:
- **Ticket Number:** [ 1521 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1521 ]

### Evidence:
 - Please see the attached video as evidence.
https://www.loom.com/share/3340e3cc979c470db482898560c5f289

![image](https://github.com/stakwork/sphinx-nav-fiber/assets/87068339/fd19f5fa-5d68-4a42-982b-29608027e32f)

### Acceptance Criteria
- [x] Link should be added in the additemflow.
- [x] Special characters should be allowed like £$%&* etc.