### PR TITLE
Fixed(addItemFlow): Item Properties Not Rendering Immediately on Creation

### DIFF
--- a/src/components/AddItemModal/index.tsx
+++ b/src/components/AddItemModal/index.tsx
@@ -183,6 +183,9 @@ export const AddItemModal = () => {
       date: parseInt((new Date().getTime() / 1000).toFixed(0), 10),
       weight: 4,
       ...(data.sourceLink ? { source_link: data.sourceLink } : {}),
+      properties: {
+        ...data,
+      },
     }
 
     addNewNode(node)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -88,7 +88,7 @@ export type Node = {
   profile_picture?: string
   verified?: boolean
   unique_id?: string
-  properties?: { [key: string]: never }
+  properties?: { [key: string]: never | undefined }
 }
 
 export type DataSeriesNode = {
@@ -127,7 +127,7 @@ export type NodeExtended = Node & {
   latitude?: number
   coordinates?: Coordinates
   audio?: Audio[]
-  properties?: { [key: string]: never }
+  properties?: { [key: string]: never | undefined }
 }
 
 export type Link<T = string> = {


### PR DESCRIPTION
### Problem:
- When adding an item through the AddItem flow, the success response just shows the label. We should render the name and properties too (image if one is there)

- No name on sidebar
- No name or properties rendered in middle section

closes: #1520

## Issue ticket number and link:
- **Ticket Number:** [ 1520 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1520 ]

### Evidence:
 - Please see the attached video as evidence.
https://www.loom.com/share/de29afba42054f9686bed052de210b1e

![image](https://github.com/stakwork/sphinx-nav-fiber/assets/160427254/095f3729-ec21-42cc-8982-9635d8921d06)

### Acceptance Criteria
- [x] After creating an Item, we should render the name and properties immediately