### PR TITLE
Fixed(SidebarSubView): SidebarSubView should close when search text is cleared

### DIFF
--- a/src/components/App/SideBar/index.tsx
+++ b/src/components/App/SideBar/index.tsx
@@ -34,7 +34,7 @@ type ContentProp = {
 
 // eslint-disable-next-line react/display-name
 const Content = forwardRef<HTMLDivElement, ContentProp>(({ onSubmit, subViewOpen }, ref) => {
-  const { isFetching: isLoading, setTeachMe, setSidebarFilter } = useDataStore((s) => s)
+  const { isFetching: isLoading, setTeachMe, setSidebarFilter, setSelectedNode } = useDataStore((s) => s)
 
   const filteredNodes = useFilteredNodes()
 
@@ -79,6 +79,7 @@ const Content = forwardRef<HTMLDivElement, ContentProp>(({ onSubmit, subViewOpen
                 setValue('search', '')
                 clearSearch()
                 setSidebarFilter('all')
+                setSelectedNode(null)
 
                 return
               }


### PR DESCRIPTION
### Problem:
- SidebarSubView is not closing immediately as we clear the search text from the search bar.

closes: #1497

## Issue ticket number and link:
- **Ticket Number:** [ 1497 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1497 ]

### Evidence:
 - Please see the attached video as evidence.
https://www.loom.com/share/5bd63800ac324667a59c5dd97fae8b84

### Acceptance Criteria
- [x] SidebarSubView should be closed as we clear the search text immediately.