### PR TITLE
Fixed(sidebarSubView): Display Default Image if Node Image Fails to Load

### DIFF
--- a/src/components/App/SideBar/SelectedNodeView/Default/index.tsx
+++ b/src/components/App/SideBar/SelectedNodeView/Default/index.tsx
@@ -21,7 +21,14 @@ export const Default = () => {
     <StyledContainer>
       {hasImage ? (
         <StyledImageWrapper>
-          <img alt="img_a11y" src={selectedNode.image_url} />
+          <img
+            alt="img_a11y"
+            onError={(e) => {
+              e.currentTarget.src = 'generic_placeholder_img.png'
+              e.currentTarget.className = 'default-img'
+            }}
+            src={selectedNode.image_url}
+          />
         </StyledImageWrapper>
       ) : null}
 
@@ -78,6 +85,15 @@ const StyledImageWrapper = styled(Flex)`
     max-width: 100%;
     max-height: 100%;
     object-fit: contain;
+  }
+
+  .default-img {
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
+    width: 100px;
+    height: 100px;
+    border-radius: 2px;
   }
 `
 


### PR DESCRIPTION
### Problem:
- When an image fails to load, there is no fallback image displayed, resulting in a broken image icon. A fallback image should be displayed if there is an image present but it fails to load.

closes: #1490

## Issue ticket number and link:
- **Ticket Number:** [ 1490 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1490 ]

### Evidence:
 - Please see the attached video as evidence.
https://www.loom.com/share/9ffa228d4a0348ee8b733b2f0e31d335

![image](https://github.com/stakwork/sphinx-nav-fiber/assets/87068339/51435312-be2f-4c35-8f86-caf597b5a096)

### Acceptance Criteria
- [x] A fallback image is displayed when the node's image fails to load.