### PR TITLE
Fixed(Trending-Topic): Show Duplicate Trending Topics

### DIFF
--- a/src/components/App/SideBar/Trending/index.tsx
+++ b/src/components/App/SideBar/Trending/index.tsx
@@ -53,7 +53,11 @@ export const Trending = ({ onSubmit }: Props) => {
       const res = await getTrends()
 
       if (res.length && Array.isArray(res)) {
-        setTrendingTopics(res)
+        const topicsMap = new Map(res.map((item) => [item.name, item]))
+
+        const uniqueTopics = Array.from(topicsMap.values())
+
+        setTrendingTopics(uniqueTopics)
       }
     } catch (err) {
       setTrendingTopics(TRENDING_TOPICS.map((i) => ({ name: i, count: 0 })))


### PR DESCRIPTION
### Problem:
- Topics are showing as duplicates in the trending topics table.

### Evidence:
 - Please see the attached Image as evidence.
![image](https://github.com/stakwork/sphinx-nav-fiber/assets/87068339/e575c884-768c-42f3-8765-75a187fbc4df)

### Acceptance Criteria
- [x] The trending topics table should accurately reflect the current trending topics without any duplicates.