### PR TITLE
Fixed(AddItemFlow): Error message not displayed on UI in [AddItemFlow]

### DIFF
--- a/src/components/AddItemModal/BudgetStep/index.tsx
+++ b/src/components/AddItemModal/BudgetStep/index.tsx
@@ -70,12 +70,11 @@ export const BudgetStep: FC<Props> = ({ onClick, loading, error }) => {
         </Button>
       </Flex>
       {error ? (
-        <StyledError role="tooltip">
+        <StyledError>
           <StyledErrorText>
             <MdError className="errorIcon" />
             <span>{error}</span>
           </StyledErrorText>
-          <div className="tooltip">{error}</div>
         </StyledError>
       ) : null}
     </Flex>
@@ -171,28 +170,4 @@ const StyledError = styled(Flex)`
   color: ${colors.primaryRed};
   position: relative;
   margin-top: 20px;
-
-  .tooltip {
-    position: absolute;
-    background-color: ${colors.black};
-    opacity: 0.8;
-    border-radius: 4px;
-    color: ${colors.white};
-    top: -10px;
-    left: 335px;
-    padding: 4px 8px;
-    font-size: 13px;
-    font-family: Barlow;
-    visibility: hidden;
-    width: 175px;
-    z-index: 1;
-  }
-
-  &:hover .tooltip {
-    visibility: visible;
-  }
-
-  &:focus .tooltip {
-    visibility: visible;
-  }
 `

--- a/src/components/AddItemModal/index.tsx
+++ b/src/components/AddItemModal/index.tsx
@@ -163,6 +163,7 @@ export const AddItemModal = () => {
   }
 
   const skipToStep = (step: AddItemModalStepID) => {
+    setError('')
     setStepId(step)
   }
 
@@ -194,6 +195,7 @@ export const AddItemModal = () => {
   }
 
   const onSubmit = form.handleSubmit(async (data) => {
+    setError('')
     setLoading(true)
 
     try {
@@ -236,7 +238,7 @@ export const AddItemModal = () => {
       />
     ),
     source: <SourceStep name={name} skipToStep={skipToStep} sourceLink={sourceLink || ''} type={nodeType} />,
-    setBudget: <BudgetStep loading={loading} onClick={() => null} />,
+    setBudget: <BudgetStep error={error} loading={loading} onClick={() => null} />,
     createConfirmation: <CreateConfirmation onclose={handleClose} type={type} />,
     setAttribues: <SetAttributesStep handleSelectType={handleSelectType} nodeType={nodeType} skipToStep={skipToStep} />,
   }


### PR DESCRIPTION
### Problem:
- The error message is not displayed on the UI during the final step of the "Add Item" process.

closes: #1538

## Issue ticket number and link:
- **Ticket Number:** [ 1538 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1538 ]

### Evidence:
 - Please see the attached video as evidence.
https://www.loom.com/share/0e6c06f2afe142c483d9f1149c68afdc

![image](https://github.com/stakwork/sphinx-nav-fiber/assets/87068339/58ac852e-118a-4527-9ed0-b6350b23d64f)

### Acceptance Criteria
- [x] When an error occurs during the "Add Item" process, the error message should be displayed on the UI.