### PR TITLE
Fixed(Source-Table): Edit Icon Missing for Some `RSS Links` Column in [Source Table]

### DIFF
--- a/src/components/SourcesTableModal/SourcesView/Sources/Table/index.tsx
+++ b/src/components/SourcesTableModal/SourcesView/Sources/Table/index.tsx
@@ -297,6 +297,11 @@ const EditableCellWrapper = styled(Flex)`
 const StyledLink = styled.a`
   color: ${colors.white};
   text-decoration: underline;
+  max-width: 400px;
+  display: inline-block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   &:visited {
     color: ${colors.white};
   }


### PR DESCRIPTION
### Problem:
- The edit icon is missing for some RSS links in the sources table due to the links overflowing the column. 
- This makes it difficult to access the edit functionality for those specific links.

closes: #1543

## Issue ticket number and link:
- **Ticket Number:** [ 1543 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1543 ]

### Evidence:
 - Please see the attached video as evidence.
https://www.loom.com/share/5955a5198e1448068e534e5e22a31653

![image](https://github.com/stakwork/sphinx-nav-fiber/assets/160427254/68582bc6-bd4b-400d-b33a-d6a6a4b44d7a)

### Acceptance Criteria
- [x] The edit icon should be visible for all RSS links in the sources table.