### PR TITLE
Fixed(Topic-Table): Text Not `Cleared` in `Search Field` After Clicking `Cross (X)` Button in Topic Table

### DIFF
--- a/src/components/SourcesTableModal/SourcesView/common/search/index.tsx
+++ b/src/components/SourcesTableModal/SourcesView/common/search/index.tsx
@@ -42,6 +42,10 @@ const Search: React.FC<SearchProps> = ({
   const debouncedSearch = useMemo(() => debounce(handleSearch, 300), [handleSearch])
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    if (e.nativeEvent instanceof KeyboardEvent && e.nativeEvent.key === ' ') {
+      return
+    }
+
     const trimmedValue = e.target.value.trim()
 
     setSearchTerm(trimmedValue)


### PR DESCRIPTION
### Problem:
- When clicking the cross button in the search field of the Topic Table, the text is not cleared. The search field retains the entered text instead of being reset to an empty state. This issue affects the usability of the search function, as users have to manually delete the text before entering a new search query.

closes: #1552

## Issue ticket number and link:
- **Ticket Number:** [ 1552 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1552 ]

### Evidence:
 - Please see the attached video as evidence.
https://www.loom.com/share/538d6a49dffd4ed59d3e2f152741cbcf

### Acceptance Criteria
- [x] The search field should be reset to an empty state after the cross button is clicked.