### PR TITLE
Display Error Message from Backend: `Source Already Exists`

### DIFF
--- a/src/components/AddContentModal/index.tsx
+++ b/src/components/AddContentModal/index.tsx
@@ -130,7 +130,7 @@ const handleSubmitForm = async (
         try {
           const errorRes = await err.json()
 
-          errorMessage = errorRes.message || errorRes.errorCode || NODE_ADD_ERROR
+          errorMessage = errorRes.message || errorRes.status || errorRes?.errorCode || NODE_ADD_ERROR
         } catch (parseError) {
           errorMessage = NODE_ADD_ERROR
         }


### PR DESCRIPTION
### Problem:
- Display error message from backend: "Source already exists."

closes: #1570

## Issue ticket number and link:
- **Ticket Number:** [ 1570 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1570 ]

### Acceptance Criteria
- [x] When adding a source that already exists in the graph we should display the error message returned from the backend