### PR TITLE
Fixed(Add-Content-Flow): Remove Useless `Tooltip` in Add Content flow

### DIFF
--- a/src/components/AddContentModal/BudgetStep/index.tsx
+++ b/src/components/AddContentModal/BudgetStep/index.tsx
@@ -82,12 +82,11 @@ export const BudgetStep: FC<Props> = ({ onClick, loading, type, error }) => {
         </Button>
       </Flex>
       {error ? (
-        <StyledError role="tooltip">
+        <StyledError>
           <StyledErrorText>
             <MdError className="errorIcon" />
             <span>{error}</span>
           </StyledErrorText>
-          <div className="tooltip">{error}</div>
         </StyledError>
       ) : null}
     </Flex>
@@ -183,30 +182,6 @@ const StyledError = styled(Flex)`
   color: ${colors.primaryRed};
   position: relative;
   margin-top: 20px;
-
-  .tooltip {
-    position: absolute;
-    background-color: ${colors.black};
-    opacity: 0.8;
-    border-radius: 4px;
-    color: ${colors.white};
-    top: -10px;
-    left: 335px;
-    padding: 4px 8px;
-    font-size: 13px;
-    font-family: Barlow;
-    visibility: hidden;
-    width: 175px;
-    z-index: 1;
-  }
-
-  &:hover .tooltip {
-    visibility: visible;
-  }
-
-  &:focus .tooltip {
-    visibility: visible;
-  }
 `
 
 const IconWrapper = styled.span`


### PR DESCRIPTION
### Problem:
- An unnecessary tooltip appears in the Add Content flow. This tooltip does not provide any useful information and may confuse users.

closes: #1571

## Issue ticket number and link:
- **Ticket Number:** [ 1571 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1571 ]

### Evidence:
 - Please see the attached video as evidence.
https://www.loom.com/share/28515a6691244aa9bf80146b9d044500

![image](https://github.com/stakwork/sphinx-nav-fiber/assets/160427254/c89a1ceb-2975-496b-9ae5-1ce8a9abbdba)

### Acceptance Criteria
- [x] The tooltip should be removed in Add Content flow