### PR TITLE
Fix(Add-Content-Flow): Add Support for X.com to Identify as Tweets

### DIFF
--- a/src/components/AddContentModal/utils/__tests__/index.ts
+++ b/src/components/AddContentModal/utils/__tests__/index.ts
@@ -50,6 +50,10 @@ describe('youtubeRegex', () => {
     expect(getInputType('https://twitter.com/@KevKevPal')).toBe(TWITTER_HANDLE)
   })
 
+  it('should assert we can check for x.com handle regex', async () => {
+    expect(getInputType('https://x.com/@KevKevPal')).toBe(TWITTER_HANDLE)
+  })
+
   it('should assert we can check for youtube live clip regex', async () => {
     expect(getInputType('https://www.youtube.com/@MrBeast')).toBe(YOUTUBE_CHANNEL)
   })

--- a/src/components/AddContentModal/utils/__tests__/index.ts
+++ b/src/components/AddContentModal/utils/__tests__/index.ts
@@ -26,6 +26,10 @@ describe('youtubeRegex', () => {
     expect(getInputType('https://twitter.com/LarryRuane/status/1720496960489095668')).toBe(TWITTER_SOURCE)
   })
 
+  it('should assert we can check for x.com tweet regex', async () => {
+    expect(getInputType('https://x.com/bernaaaljg/status/1795260855002583101')).toBe(TWITTER_SOURCE)
+  })
+
   it('should assert we can check for mp3 url regex', async () => {
     expect(getInputType('https://hahaha.com/i/spaces/1zqKVqwrVzlxB?s=20.mp3')).toBe(LINK)
   })

--- a/src/components/AddContentModal/utils/index.ts
+++ b/src/components/AddContentModal/utils/index.ts
@@ -6,7 +6,7 @@ const youtubeRegex = /(https?:\/\/)?(www\.)?youtube\.com\/watch\?v=([A-Za-z0-9_-
 const youtubeLiveRegex = /(https?:\/\/)?(www\.)?youtube\.com\/live\/([A-Za-z0-9_-]+)/
 const youtubeShortRegex = /(https?:\/\/)?(www\.)?youtu\.be\/([A-Za-z0-9_-]+)/
 const twitterSpaceRegex = /https:\/\/twitter\.com\/i\/spaces\/([A-Za-z0-9_-]+)/
-const tweetUrlRegex = /https:\/\/twitter\.com\/[^/]+\/status\/(\d+)/
+const tweetUrlRegex = /https:\/\/(twitter\.com|x\.com)\/[^/]+\/status\/(\d+)/
 const mp3Regex = /(https?:\/\/)?([A-Za-z0-9_-]+)\.mp3/
 
 const rssRegex = /(https?:\/\/)?(.*\.)?.+\/(feed|rss|rss.xml|.*.rss|.*\?(feed|format)=rss)$/

--- a/src/components/AddContentModal/utils/index.ts
+++ b/src/components/AddContentModal/utils/index.ts
@@ -1,6 +1,6 @@
 import { DOCUMENT, LINK, RSS, TWITTER_HANDLE, TWITTER_SOURCE, WEB_PAGE, YOUTUBE_CHANNEL } from '~/constants'
 
-export const twitterHandlePattern = /\btwitter\.com\/(?:@)?([\w_]+)(?:$|\?[^/]*$)/
+export const twitterHandlePattern = /\b(twitter\.com|x\.com)\/(?:@)?([\w_]+)(?:$|\?[^/]*$)/
 
 const youtubeRegex = /(https?:\/\/)?(www\.)?youtube\.com\/watch\?v=([A-Za-z0-9_-]+)/
 const youtubeLiveRegex = /(https?:\/\/)?(www\.)?youtube\.com\/live\/([A-Za-z0-9_-]+)/

--- a/src/components/AddContentModal/utils/index.ts
+++ b/src/components/AddContentModal/utils/index.ts
@@ -1,6 +1,6 @@
 import { DOCUMENT, LINK, RSS, TWITTER_HANDLE, TWITTER_SOURCE, WEB_PAGE, YOUTUBE_CHANNEL } from '~/constants'
 
-export const twitterHandlePattern = /\b(twitter\.com|x\.com)\/(?:@)?([\w_]+)(?:$|\?[^/]*$)/
+export const twitterHandlePattern = /\b(?:twitter\.com|x\.com)\/(?:@)?([\w_]+)(?:$|\?[^/]*$)/
 
 const youtubeRegex = /(https?:\/\/)?(www\.)?youtube\.com\/watch\?v=([A-Za-z0-9_-]+)/
 const youtubeLiveRegex = /(https?:\/\/)?(www\.)?youtube\.com\/live\/([A-Za-z0-9_-]+)/


### PR DESCRIPTION
### Problem:
- Add `x.com` as part of twitter/tweet identifier in the Add Content regex checker

closes: #1585

## Issue ticket number and link:
- **Ticket Number:** [ 1585 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1585 ]

### Evidence:
 
![image](https://github.com/stakwork/sphinx-nav-fiber/assets/160427254/c029d721-8c78-4fa7-9947-21bd076c383c)


### Acceptance Criteria
- [x] Add x.com for identifying tweets
- [x]  Update tests with x.com example