### PR TITLE
Fixed(Video-Player): Not Starting at the Correct Timestamp

### DIFF
--- a/src/components/App/SideBar/SidebarSubView/MediaPlayer/index.tsx
+++ b/src/components/App/SideBar/SidebarSubView/MediaPlayer/index.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components'
 import { Avatar } from '~/components/common/Avatar'
 import { Flex } from '~/components/common/Flex'
 import { usePlayerStore } from '~/stores/usePlayerStore'
-import { colors } from '~/utils'
+import { colors, videoTimeToSeconds } from '~/utils'
 import { Toolbar } from './ToolBar'
 
 type Props = {
@@ -75,9 +75,10 @@ const MediaPlayerComponent: FC<Props> = ({ hidden }) => {
   const handleProgressChange = (_: Event, value: number | number[]) => {
     const newValue = Array.isArray(value) ? value[0] : value
 
-    if (playerRef.current) {
-      playerRef.current.seekTo(newValue)
-      setPlayingTime(newValue)
+    setPlayingTime(newValue)
+
+    if (playerRef.current && !isSeeking) {
+      playerRef.current.seekTo(newValue, 'seconds')
     }
   }
 
@@ -107,6 +108,16 @@ const MediaPlayerComponent: FC<Props> = ({ hidden }) => {
       const videoDuration = playerRef.current.getDuration()
 
       setDuration(videoDuration)
+
+      if (!isSeeking && (playingTime === 0 || Math.abs(playingTime - videoTimeToSeconds('00:00:00')) < 1)) {
+        if (playingNode?.type === 'youtube' && playingNode?.timestamp) {
+          const [startTimestamp] = playingNode.timestamp.split('-')
+          const startTimeInSeconds = videoTimeToSeconds(startTimestamp)
+
+          playerRef.current.seekTo(startTimeInSeconds, 'seconds')
+          setPlayingTime(startTimeInSeconds)
+        }
+      }
     }
   }
 


### PR DESCRIPTION
### Problem:
- All videos in the image below are all starting at the beginning but they should start based on the timestamp:

closes: #1519

## Issue ticket number and link:
- **Ticket Number:** [ 1519 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1519 ]

### Evidence:
 - Please see the attached video as evidence.
https://www.loom.com/share/0057f7932e97401ab62f2ad5e93dd44e

![image](https://github.com/stakwork/sphinx-nav-fiber/assets/156602406/68c5678d-716c-4958-9dd6-1cec55de7176)

![image](https://github.com/stakwork/sphinx-nav-fiber/assets/156602406/2990896b-9808-47a9-8da5-174c27594dca)

### Acceptance Criteria
- [x] Player should start at the correct timestamp and not from the beginning