### PR TITLE
Fixed(Tooltip): `Add Type` Tooltip is Behind the Blueprint Modal

### DIFF
--- a/src/components/ModalsContainer/BlueprintModal/Body/Toolbar/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Toolbar/index.tsx
@@ -29,7 +29,6 @@ const Wrapper = styled(Flex).attrs({
   z-index: 31;
   transition: opacity 1s;
   background: ${colors.BG2};
-  overflow: hidden;
   max-height: 100vh;
 
   @media (max-width: 1440px) {


### PR DESCRIPTION
### Problem:
- In the Blueprint sidebar, the tooltip for the `Add Type` button `tooltip` appears behind the modal, making it difficult for users to see the tooltip content.

closes: #1590

## Issue ticket number and link:
- **Ticket Number:** [ 1590 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1590 ]

### Evidence:
 - Please see the attached video as evidence.
https://www.loom.com/share/adf5a8526f08449faad110f4cb8839bd

![image](https://github.com/stakwork/sphinx-nav-fiber/assets/156602406/87df33bd-9389-4db5-96dd-0e3816111bbc)

### Acceptance Criteria
- [x] The `Add Type tooltip` must be fully visible when the Blueprint modal is open.