### PR TITLE
Update top section for blueprint and edit name functionality

### DIFF
--- a/src/components/ModalsContainer/BlueprintModal/Body/Editor/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Editor/index.tsx
@@ -98,6 +98,7 @@ export const Editor = ({ onSchemaCreate, selectedSchema, onDelete, setSelectedSc
   const [parentsLoading, setParentsLoading] = useState(false)
   const [parentOptions, setParentOptions] = useState<TOption[] | null>(null)
   const [displayParentError, setDisplayParentError] = useState(false)
+  const [selectedNodeParent, setSelectedNodeParent] = useState<TOption[] | null>(null)
 
   useEffect(
     () => () => {
@@ -144,6 +145,24 @@ export const Editor = ({ onSchemaCreate, selectedSchema, onDelete, setSelectedSc
     }
   }, [selectedSchema])
 
+  useEffect(() => {
+    if (selectedSchema) {
+      setValue('type', selectedSchema?.type as string)
+      setValue('parent', selectedSchema.parent)
+
+      const parentNode: TOption[] = [
+        {
+          label: selectedSchema.parent ? capitalizeFirstLetter(selectedSchema.parent) : 'No Parent',
+          value: selectedSchema.parent as string,
+        },
+      ]
+
+      setSelectedNodeParent(parentNode)
+    } else {
+      reset(defaultValues)
+    }
+  }, [selectedSchema, setValue, reset])
+
   const parent = watch('parent')
 
   const handleClose = () => {
@@ -176,6 +195,10 @@ export const Editor = ({ onSchemaCreate, selectedSchema, onDelete, setSelectedSc
     setLoading(false)
 
     try {
+      if (data.type !== selectedSchema?.type) {
+        await api.put(`/schema/${selectedSchema?.ref_id}`, JSON.stringify({ type: data.type }))
+      }
+
       const res = await handleSubmitForm(
         { ...data, ...(selectedSchema ? { ref_id: selectedSchema?.ref_id } : {}) },
         !!selectedSchema,
@@ -251,13 +274,39 @@ export const Editor = ({ onSchemaCreate, selectedSchema, onDelete, setSelectedSc
                 </>
               ) : (
                 <>
-                  {selectedSchema.parent ? (
-                    <Flex mb={12}>
-                      <Text kind="headingBold">Parent: {selectedSchema.parent}</Text>
-                    </Flex>
-                  ) : null}
                   <Flex mb={12}>
-                    <Text kind="headingBold">Type: {selectedSchema.type}</Text>
+                    <Flex mb={12}>
+                      <Text>Name</Text>
+                    </Flex>
+                    <Flex mb={12}>
+                      <TextInput
+                        defaultValue={selectedSchema?.type}
+                        id="cy-item-name"
+                        maxLength={250}
+                        name="type"
+                        placeholder="Enter type name"
+                        rules={{
+                          ...requiredRule,
+                        }}
+                        value={parent}
+                      />
+                    </Flex>
+                  </Flex>
+                  <Flex mb={12}>
+                    <Flex mb={12}>
+                      <Text>Parent</Text>
+                    </Flex>
+
+                    <AutoComplete
+                      isLoading={parentsLoading}
+                      onSelect={(e) => {
+                        setValue('parent', e?.value || '')
+                        setDisplayParentError(false)
+                      }}
+                      options={selectedNodeParent || []}
+                      selectedValue={parentOptions?.find((option) => option.label === selectedSchema?.parent)}
+                    />
+                    {displayParentError && <StyledError>A parent type must be selected</StyledError>}
                   </Flex>
                 </>
               )}


### PR DESCRIPTION
### Ticket №: #1500

closes #1500

### Problem:

- After selecting a node in the blueprint we should render the new display to show the nodes name and parent
- Type new name in the input field
- Confirm change via save
- Call PUT /schema/{ref_id} and pass the new type in the request if Name has changed

### Evidence:

https://www.loom.com/share/9a0d0f0f90fd488e83c9942cf649160d?sid=c762d426-3cfe-47d5-8b06-43bec84bbd90


