### PR TITLE
Fixed(Close-Icon): Cross (X) Icon Misalignment and Overflow Issue on Hover in All Modals [Merge Topic, AddEdge]

### DIFF
--- a/src/components/ModalsContainer/AddNodeEdgeModal/Title/ToNode/index.tsx
+++ b/src/components/ModalsContainer/AddNodeEdgeModal/Title/ToNode/index.tsx
@@ -1,9 +1,8 @@
-import { IconButton } from '@mui/material'
 import { debounce } from 'lodash'
 import { FC, useMemo, useState } from 'react'
 import { OPTIONS } from '~/components/AddItemModal/SourceTypeStep/constants'
 import ClearIcon from '~/components/Icons/ClearIcon'
-import { ALPHABETICALLY } from '~/components/SourcesTableModal/SourcesView/constants'
+import { ALPHABETICALLY, StyledIconButton } from '~/components/SourcesTableModal/SourcesView/constants'
 import { AutoComplete, TAutocompleteOption } from '~/components/common/AutoComplete'
 import { Flex } from '~/components/common/Flex'
 import { getEdges } from '~/network/fetchSourcesData'
@@ -72,9 +71,9 @@ export const ToNode: FC<Props> = ({ onSelect, selectedValue, topicId }) => {
   return selectedValue ? (
     <Flex align="center" basis="100%" direction="row" grow={1} shrink={1}>
       <span>{selectedValue.search_value}</span>
-      <IconButton onClick={() => onSelect(null)} size="small">
+      <StyledIconButton onClick={() => onSelect(null)} size="medium">
         <ClearIcon />
-      </IconButton>
+      </StyledIconButton>
     </Flex>
   ) : (
     <AutoComplete

--- a/src/components/ModalsContainer/MergeTopicModal/Title/ToNode/index.tsx
+++ b/src/components/ModalsContainer/MergeTopicModal/Title/ToNode/index.tsx
@@ -1,11 +1,10 @@
-import { IconButton } from '@mui/material'
 import { debounce } from 'lodash'
 import { FC, useMemo, useState } from 'react'
 import { OPTIONS } from '~/components/AddItemModal/SourceTypeStep/constants'
 import { AutoComplete, TAutocompleteOption } from '~/components/common/AutoComplete'
 import { Flex } from '~/components/common/Flex'
 import ClearIcon from '~/components/Icons/ClearIcon'
-import { ALPHABETICALLY } from '~/components/SourcesTableModal/SourcesView/constants'
+import { ALPHABETICALLY, StyledIconButton } from '~/components/SourcesTableModal/SourcesView/constants'
 import { getEdges } from '~/network/fetchSourcesData'
 import { FetchEdgesResponse, TEdge } from '~/types'
 
@@ -72,9 +71,9 @@ export const ToNode: FC<Props> = ({ topicId, onSelect, selectedValue }) => {
   return selectedValue ? (
     <Flex align="center" basis="100%" direction="row" grow={1} shrink={1}>
       <span>{selectedValue.search_value}</span>
-      <IconButton onClick={() => onSelect(null)} size="small">
+      <StyledIconButton onClick={() => onSelect(null)} size="medium">
         <ClearIcon />
-      </IconButton>
+      </StyledIconButton>
     </Flex>
   ) : (
     <AutoComplete

--- a/src/components/SourcesTableModal/SourcesView/Topics/AddEdgeTopicModal/Title/ToNode/index.tsx
+++ b/src/components/SourcesTableModal/SourcesView/Topics/AddEdgeTopicModal/Title/ToNode/index.tsx
@@ -1,9 +1,8 @@
-import { IconButton } from '@mui/material'
 import { debounce } from 'lodash'
 import { FC, useMemo, useState } from 'react'
 import { OPTIONS } from '~/components/AddItemModal/SourceTypeStep/constants'
 import ClearIcon from '~/components/Icons/ClearIcon'
-import { ALPHABETICALLY } from '~/components/SourcesTableModal/SourcesView/constants'
+import { ALPHABETICALLY, StyledIconButton } from '~/components/SourcesTableModal/SourcesView/constants'
 import { AutoComplete, TAutocompleteOption } from '~/components/common/AutoComplete'
 import { Flex } from '~/components/common/Flex'
 import { getEdges } from '~/network/fetchSourcesData'
@@ -72,9 +71,9 @@ export const ToNode: FC<Props> = ({ onSelect, selectedValue, topicId }) => {
   return selectedValue ? (
     <Flex align="center" basis="100%" direction="row" grow={1} shrink={1}>
       <span>{selectedValue.search_value}</span>
-      <IconButton onClick={() => onSelect(null)} size="small">
+      <StyledIconButton onClick={() => onSelect(null)} size="medium">
         <ClearIcon />
-      </IconButton>
+      </StyledIconButton>
     </Flex>
   ) : (
     <AutoComplete

--- a/src/components/SourcesTableModal/SourcesView/Topics/MergeTopicModal/Title/ToNode/index.tsx
+++ b/src/components/SourcesTableModal/SourcesView/Topics/MergeTopicModal/Title/ToNode/index.tsx
@@ -1,11 +1,10 @@
-import { IconButton } from '@mui/material'
 import { debounce } from 'lodash'
 import { FC, useMemo, useState } from 'react'
 import { OPTIONS } from '~/components/AddItemModal/SourceTypeStep/constants'
 import { AutoComplete, TAutocompleteOption } from '~/components/common/AutoComplete'
 import { Flex } from '~/components/common/Flex'
 import ClearIcon from '~/components/Icons/ClearIcon'
-import { ALPHABETICALLY } from '~/components/SourcesTableModal/SourcesView/constants'
+import { ALPHABETICALLY, StyledIconButton } from '~/components/SourcesTableModal/SourcesView/constants'
 import { getEdges } from '~/network/fetchSourcesData'
 import { FetchEdgesResponse, TEdge } from '~/types'
 
@@ -72,9 +71,9 @@ export const ToNode: FC<Props> = ({ topicId, onSelect, selectedValue }) => {
   return selectedValue ? (
     <Flex align="center" basis="100%" direction="row" grow={1} shrink={1}>
       <span>{selectedValue.search_value}</span>
-      <IconButton onClick={() => onSelect(null)} size="small">
+      <StyledIconButton onClick={() => onSelect(null)} size="medium">
         <ClearIcon />
-      </IconButton>
+      </StyledIconButton>
     </Flex>
   ) : (
     <AutoComplete

--- a/src/components/SourcesTableModal/SourcesView/constants.ts
+++ b/src/components/SourcesTableModal/SourcesView/constants.ts
@@ -1,5 +1,7 @@
 import { RSS, TWITTER_HANDLE, YOUTUBE_CHANNEL } from '~/constants'
 import { ISourceMap } from './types'
+import styled from 'styled-components'
+import { IconButton } from '@mui/material'
 
 export const sourcesMapper: ISourceMap = {
   [RSS]: 'RSS link',
@@ -29,3 +31,12 @@ export const TWITTER_LINK = 'https://twitter.com'
 export const IS_ALIAS = 'IS_ALIAS'
 
 export const TWITTER_CONTENT_LINK = 'https://www.twitter.com/anyuser/status/'
+
+export const StyledIconButton = styled(IconButton)`
+  && {
+    vertical-align: middle;
+    margin: 5px 0 0 4px;
+    padding: 4px;
+    transition: background-color 150ms cubic-bezier(0.4, 0, 0.2, 1);
+  }
+`


### PR DESCRIPTION
### Problem:
- Cross (X) icon in all modals where it is misaligned and sometimes overflows the text when hovered over.
- The close icon is small and not aligned with the search text.

closes: #1596

## Issue ticket number and link:
- **Ticket Number:** [ 1596 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1596 ]

### Evidence:
 - Please see the attached video as evidence.
https://www.loom.com/share/9ac147daa8a4422c8185984ba8006441

![image](https://github.com/stakwork/sphinx-nav-fiber/assets/160427254/07b8aa78-8349-476b-9dc4-564e5224d09d)

![image](https://github.com/stakwork/sphinx-nav-fiber/assets/160427254/f337bfca-819d-4c7d-a047-6cdda6505f69)

![image](https://github.com/stakwork/sphinx-nav-fiber/assets/160427254/2a3a3541-a351-4635-a9ad-ab7b9a94eecc)

### Acceptance Criteria
- [x] The cross (X) icon in all modals should be properly aligned with the search text.