### PR TITLE
Fixed:  Search State Not Reset After Closing Merge Topic Modal and Opening New One [Graph Add Modal]

### DIFF
--- a/src/components/ModalsContainer/MergeTopicModal/index.tsx
+++ b/src/components/ModalsContainer/MergeTopicModal/index.tsx
@@ -58,6 +58,7 @@ export const MergeNodeModal = () => {
   }, [selectedNode])
 
   const closeHandler = () => {
+    setSelectedToNode(null)
     close()
   }
 
@@ -90,7 +91,7 @@ export const MergeNodeModal = () => {
   }
 
   return (
-    <BaseModal id="mergeToNode" kind="small" onClose={close} preventOutsideClose>
+    <BaseModal id="mergeToNode" kind="small" onClose={closeHandler} preventOutsideClose>
       <FormProvider {...form}>
         {topicIsLoading ? (
           <Flex align="center" my={24}>


### PR DESCRIPTION
### Problem:
- the search state is not reset after closing the Merge Topic modal and then opening a new one. 
- As a result, the search input retains its previous state, causing the `Merge Topic` button to remain enabled when opening a new node merge modal.

closes: #1598

## Issue ticket number and link:
- **Ticket Number:** [ 1598 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1598 ]

### Evidence:
 - Please see the attached video as evidence.
https://www.loom.com/share/2aa166a518bf4adcae09a5bdf953bc4f

### Acceptance Criteria
- [x] When the Merge Topic modal is closed, the search input state should be cleared.
- [x] Any search results or filters applied should be reset when reopening the modal.