### PR TITLE
Fixed(Modals): Some Option Labels Not Fully Visible in Dropdowns Across All Modals [Merge Topic, AddEdge]

### DIFF
--- a/src/components/common/AutoComplete/index.tsx
+++ b/src/components/common/AutoComplete/index.tsx
@@ -116,6 +116,10 @@ export const AutoComplete: FC<Props> = ({
               justify="space-between"
               onClick={option?.action}
               shrink={1}
+              style={{
+                fontSize: '14px',
+                wordBreak: 'break-word',
+              }}
             >
               <div className="option">{option.label !== '' ? option.label : 'Not Selected'}</div>
               {option?.type && <TypeBadge type={option.type} />}


### PR DESCRIPTION
### Problem:
- Some option labels are not fully visible in dropdown menus across all modals. This issue causes important information to be truncated, making it difficult for users to understand the full context of the options available.

closes: #1602

## Issue ticket number and link:
- **Ticket Number:** [ 1602 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1602 ]

### Evidence:
 - Please see the attached video as evidence.
https://www.loom.com/share/94069660dd8f492b8b1e593c535c1b73

![image](https://github.com/stakwork/sphinx-nav-fiber/assets/87068339/7a4dea80-5b59-4372-aff3-eb843cd61462)

### Acceptance Criteria
- [x] All option labels in dropdown menus across all modals should be fully visible without any truncation.
- [x] Ensure that no part of the text is cut off or hidden, regardless of the length of the label.