### PR TITLE
Fixed(Main-Page): Video Thumbnails Not Display on Main Page

### DIFF
--- a/src/network/fetchGraphData/helpers/handleNodes/index.ts
+++ b/src/network/fetchGraphData/helpers/handleNodes/index.ts
@@ -79,9 +79,9 @@ export const handleNodes = (dataInit: FetchDataResponse, searchterm: string) => 
       }
 
       // replace aws bucket url with cloudfront, and add size indicator to end
-      const smallImageUrl = imageUrl
-        ?.replace(AWS_IMAGE_BUCKET_URL, CLOUDFRONT_IMAGE_BUCKET_URL)
-        .replace('.jpg', '_s.jpg')
+      const smallImageUrl = imageUrl?.startsWith(AWS_IMAGE_BUCKET_URL)
+        ? imageUrl.replace(AWS_IMAGE_BUCKET_URL, CLOUDFRONT_IMAGE_BUCKET_URL).replace('.jpg', '_s.jpg')
+        : imageUrl
 
       nodes.push({
         ...node,


### PR DESCRIPTION
### Problem:
- The image is not displayed, but it is retrieved from the backend.

closes: #1613

## Issue ticket number and link:
- **Ticket Number:** [ 1613 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1613 ]

### Evidence:
 - Please see the attached video as evidence.
https://www.loom.com/share/e7c3db102eda49979db57097d0a622e3

![image](https://github.com/stakwork/sphinx-nav-fiber/assets/87068339/eeeee84d-734c-40d1-916b-862caf247e18)

![image](https://github.com/stakwork/sphinx-nav-fiber/assets/87068339/cabf5016-c7da-4f50-b91e-5168320c833f)

### Acceptance Criteria
- [x] Video thumbnails should be displayed correctly on the main site page.