### PR TITLE
Fixed(Blueprint): Sidebar corner is not rounded

### DIFF
--- a/src/components/ModalsContainer/BlueprintModal/Body/Toolbar/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Toolbar/index.tsx
@@ -31,6 +31,8 @@ const Wrapper = styled(Flex).attrs({
   background: ${colors.BG2};
   overflow: hidden;
   max-height: 100vh;
+  border-top-left-radius: 9px;
+  border-bottom-left-radius: 9px;
 
   @media (max-width: 1440px) {
     max-height: 95.2vh;


### PR DESCRIPTION
### Problem:
- The left side of the Blueprint modal corner is not rounded.

closes: #1611

## Issue ticket number and link:
- **Ticket Number:** [ 1611 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1611 ]

### Evidence:
 - Please see the attached video as evidence.
https://www.loom.com/share/3ddc865834ad4faba6489f309566f485

### Acceptance Criteria
- [x] The left side corner of the Blueprint modal should be rounded consistently with the other corners.