### PR TITLE
Fixed(blue-print): Edge is never upside down and edge overlaps over the middle node Thing

### DIFF
--- a/src/components/ModalsContainer/BlueprintModal/Body/Graph/Links/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Graph/Links/index.tsx
@@ -78,8 +78,8 @@ export const Lines = ({ links, nodes }: Props) => {
           text.position.set(controlPoint2.x, controlPoint2.y, endPoint.z)
           text.lookAt(camera.position)
         } else {
-          endPosition.copy(getPointOnLineAtDistance(endVector, startVector, NODE_RADIUS + CONE_HEIGHT))
-          startPosition.copy(startVector)
+          startPosition.copy(getPointOnLineAtDistance(startVector, endVector, NODE_RADIUS))
+          endPosition.copy(getPointOnLineAtDistance(endVector, startVector, NODE_RADIUS + 0.5))
           middlePoint.lerpVectors(startPosition, endPosition, 0.5)
 
           const textWidth = 30
@@ -102,21 +102,24 @@ export const Lines = ({ links, nodes }: Props) => {
           text.position.set(middlePoint.x, middlePoint.y, middlePoint.z)
           text.lookAt(camera.position)
 
-          const angle = Math.atan2(endPosition.y - startPosition.y, endPosition.x - startPosition.x)
+          let angle = Math.atan2(endPosition.y - startPosition.y, endPosition.x - startPosition.x)
 
           if (angle > Math.PI / 2 || angle < -Math.PI / 2) {
-            text.rotation.set(Math.PI, 0, -angle)
-          } else {
-            text.rotation.set(0, 0, angle)
+            angle += Math.PI
           }
 
+          text.rotation.set(0, 0, angle)
+
           const distance = startPosition.distanceTo(endPosition)
+          const fontSize = distance < textWidth ? 2 : 4
 
           if (distance < textWidth) {
             text.text = truncateText(link.edge_type, MAX_TEXT_LENGTH)
           } else {
             text.text = link.edge_type
           }
+
+          text.fontSize = fontSize
         }
       })
     }


### PR DESCRIPTION
### Problem:
- Edge is never upside down and edge overlaps over the middle node Thing 
- https://github.com/stakwork/sphinx-nav-fiber/pull/1646#issuecomment-2162525707
- https://github.com/stakwork/sphinx-nav-fiber/pull/1646#issuecomment-2162525707

### Evidence:
 - Please see the attached video as evidence.
https://www.loom.com/share/e7d0258d7f3b4b8c9dab1ae9b4a7513f

![image](https://github.com/stakwork/sphinx-nav-fiber/assets/100023456/24126e95-e0a5-4750-a372-b3e47a0e169b)
