### PR TITLE
Fixed[Blueprint Modal]: Error Encountered While Creating a New Node Add Type in [Blueprint Modal]

### DIFF
--- a/src/components/ModalsContainer/BlueprintModal/Body/Editor/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Editor/index.tsx
@@ -213,7 +213,10 @@ export const Editor = ({
     setLoading(true)
 
     try {
-      if (data.type !== selectedSchema?.type || getValues().parent !== selectedSchema?.parent) {
+      if (
+        (selectedSchema && data.type !== selectedSchema?.type) ||
+        (selectedSchema && getValues().parent !== selectedSchema?.parent)
+      ) {
         const newParent = getValues().parent ?? selectedSchema?.parent
 
         setGraphLoading(true)


### PR DESCRIPTION
### Problem:
- When I create a new node in `Add Type`, I receive a 500 error because `selectedSchema.ref_id` is undefined, as shown in the image below.

closes: #1663

## Issue ticket number and link:
- **Ticket Number:** [ 1663 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1663 ]

### Evidence:
 - Please see the attached video as evidence.
 https://www.loom.com/share/901c629d3f584145aac1f4bea3efcb75
  
![image](https://github.com/stakwork/sphinx-nav-fiber/assets/87068339/9fa1f516-4a10-4feb-9c13-b3f34f90d9fa)

### Acceptance Criteria
- [x]  Verify that a new node can be created successfully in Add Type .