### PR TITLE
Fixed(Feed-Back): Make Feedback feature available to only sphinx users

### DIFF
--- a/src/components/App/MainToolbar/__tests__/index.tsx
+++ b/src/components/App/MainToolbar/__tests__/index.tsx
@@ -7,6 +7,11 @@ import { MainToolbar } from '..'
 import { ThemeProvider } from '@mui/material'
 import { appTheme } from '../../Providers'
 import { ThemeProvider as StyleThemeProvider } from 'styled-components'
+import { isSphinx } from '../../../../utils/isSphinx'
+
+jest.mock('~/utils/isSphinx', () => ({
+  isSphinx: jest.fn(),
+}))
 
 jest.mock('~/stores/useModalStore', () => ({
   useModal: jest.fn(),
@@ -100,9 +105,12 @@ describe('MainToolbar Component Tests', () => {
     expect(openMock).toHaveBeenCalled()
   })
 
-  it('should render feedback button when userFeedbackFeatureFlag is true', () => {
+  it('should render feedback button only if userFeedbackFeatureFlag is true and isSphinx returns true', () => {
     ;(useFeatureFlagStore as unknown as jest.Mock).mockReturnValue({
       userFeedbackFeatureFlag: true,
+    })
+    ;(isSphinx as unknown as jest.Mock).mockReturnValue({
+      sphinxEnabled: true,
     })
 
     render(
@@ -116,9 +124,12 @@ describe('MainToolbar Component Tests', () => {
     expect(feedbackButton).toBeInTheDocument()
   })
 
-  it('should not render feedback button when userFeedbackFeatureFlag is false', () => {
+  it('should not render feedback button if userFeedbackFeatureFlag is true but isSphinx returns false', () => {
     ;(useFeatureFlagStore as unknown as jest.Mock).mockReturnValue({
       userFeedbackFeatureFlag: false,
+    })
+    ;(isSphinx as unknown as jest.Mock).mockReturnValue({
+      sphinxEnabled: false,
     })
 
     render(

--- a/src/components/App/MainToolbar/index.tsx
+++ b/src/components/App/MainToolbar/index.tsx
@@ -11,6 +11,7 @@ import { useFeatureFlagStore } from '~/stores/useFeatureFlagStore'
 import { useModal } from '~/stores/useModalStore'
 import { useUserStore } from '~/stores/useUserStore'
 import { colors } from '~/utils/colors'
+import { isSphinx } from '~/utils/isSphinx'
 
 export const MainToolbar = () => {
   const { open: openSourcesModal } = useModal('sourcesTable')
@@ -24,6 +25,7 @@ export const MainToolbar = () => {
   const userFeedbackFeatureFlag = useFeatureFlagStore((s) => s.userFeedbackFeatureFlag)
 
   const [isAdmin] = useUserStore((s) => [s.isAdmin])
+  const sphinxEnabled = isSphinx()
 
   return (
     <Wrapper>
@@ -64,7 +66,7 @@ export const MainToolbar = () => {
         </IconWrapper>
         <Text>Settings</Text>
       </ActionButton>
-      {userFeedbackFeatureFlag ? (
+      {userFeedbackFeatureFlag && sphinxEnabled ? (
         <FeedbackButton data-testid="feedback-modal" onClick={openFeedbackModal}>
           <IconWrapper>
             <FeedbackIcon />


### PR DESCRIPTION
### Problem:
- Enable Feedback feature to only Sphinx users.

closes: #1667

## Issue ticket number and link:
- **Ticket Number:** [ 1667 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1667 ]

### Evidence:

![image](https://github.com/stakwork/sphinx-nav-fiber/assets/160427254/64eadd3b-2899-4c38-a85e-16ad08997978)

### Acceptance Criteria
- [x] Add additional check for Sphinx Users for the Feedback feature
- [x] Add test to ensure this feature only display if feedback feature flag = true and sphinx.enable returns true