### PR TITLE
Fixed(BluePrint): Added `Delete` Value in PUT Request for Editing Node Type via Blueprint

### DIFF
--- a/src/components/ModalsContainer/BlueprintModal/Body/Editor/CustomAttributesStep/FormInput/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Editor/CustomAttributesStep/FormInput/index.tsx
@@ -18,9 +18,17 @@ const noSpacePattern = /^[a-z0-9_]+$/
 
 interface CustomField extends Record<'id', string> {
   isNew?: boolean
+  onDelete?: (attributeKey: string) => void
+  key?: string
 }
 
-export const FormInput = ({ parentParam }: { parentParam: string }) => {
+export const FormInput = ({
+  parentParam,
+  onDelete,
+}: {
+  parentParam: string
+  onDelete: (attributeKey: string) => void
+}) => {
   const [loading, setLoading] = useState(false)
   const [parsedData, setParsedData] = useState<parsedObjProps[]>([])
 
@@ -111,7 +119,15 @@ export const FormInput = ({ parentParam }: { parentParam: string }) => {
                       size="small"
                     />
                     {!requiredKey && (
-                      <IconButton onClick={() => remove(index)}>
+                      <IconButton
+                        onClick={() => {
+                          remove(index)
+
+                          if (field.key !== undefined && onDelete) {
+                            onDelete(field.key)
+                          }
+                        }}
+                      >
                         <DeleteIcon />
                       </IconButton>
                     )}

--- a/src/components/ModalsContainer/BlueprintModal/Body/Editor/CustomAttributesStep/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Editor/CustomAttributesStep/index.tsx
@@ -7,9 +7,10 @@ import { FormInput } from './FormInput'
 
 interface Props {
   parent?: string
+  onDelete: (attributeKey: string) => void
 }
 
-export const CreateCustomNodeAttribute: FC<Props> = ({ parent }) => {
+export const CreateCustomNodeAttribute: FC<Props> = ({ parent, onDelete }) => {
   const parentParam = parent
 
   return (
@@ -27,7 +28,7 @@ export const CreateCustomNodeAttribute: FC<Props> = ({ parent }) => {
           </Grid>
         </Grid>
       </Flex>
-      {parentParam && <FormInput key={parentParam} parentParam={parentParam} />}
+      {parentParam && <FormInput key={parentParam} onDelete={onDelete} parentParam={parentParam} />}
     </Flex>
   )
 }

--- a/src/components/ModalsContainer/BlueprintModal/Body/Editor/__tests__/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Editor/__tests__/index.tsx
@@ -76,4 +76,40 @@ describe('Editor Component - Delete Node', () => {
 
     expect(mockProps.onDelete).toHaveBeenCalled()
   })
+
+  it('should send a PUT request with deleted attributes marked as "delete" when editing a node', async () => {
+    const deletedAttributes = ['oldAttribute']
+    const updatedData = {
+      type: 'exampleType',
+      parent: 'exampleParent',
+      attributes: {
+        newAttribute: 'newValue',
+      },
+    }
+
+    api.put = jest.fn().mockResolvedValue({ status: 'success', ref_id: '123' })
+
+    render(<Editor {...mockProps} />)
+
+    waitFor(async () => {
+      const handleSubmit = jest.spyOn(Editor.prototype, 'handleSubmitForm')
+      // @ts-ignore
+      await handleSubmit(updatedData, true, deletedAttributes)
+
+      expect(api.put).toHaveBeenCalledWith(
+        '/schema',
+        JSON.stringify({
+          type: 'exampleType',
+          parent: 'exampleParent',
+          attributes: {
+            newAttribute: 'newValue',
+            oldAttribute: 'delete',
+          },
+        }),
+        {},
+      )
+
+      handleSubmit.mockRestore()
+    })
+  })
 })


### PR DESCRIPTION
### Problem:
- Implemented functionality to add the 'delete' value to attributes when a user removes them while editing a custom node in the blueprint. This ensures that the correct data is sent in the PUT request to the /schema endpoint.

closes: #1247

## Issue ticket number and link:
- **Ticket Number:** [ 1247 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1247 ]

### Evidence:
 - Please see the attached video as evidence.

https://www.loom.com/share/4c3b0a4d7f37483da72a72a59cfa027a

![image](https://github.com/stakwork/sphinx-nav-fiber/assets/100023456/fe8c0fd7-07f7-4c50-b067-63161ae3c909)

![image](https://github.com/stakwork/sphinx-nav-fiber/assets/100023456/e70f3fc0-293c-4659-bac4-142b3814821e)

## Testing:
Tested the functionality locally by removing attributes and verifying that the correct data is sent in the PUT request. 