### PR TITLE
Fixed(Add_Content_Flow): Sending `tweet_id` for Source Instead of Only Entire URL Link

### DIFF
--- a/src/components/AddContentModal/__tests__/index.tsx
+++ b/src/components/AddContentModal/__tests__/index.tsx
@@ -1,0 +1,106 @@
+/* eslint-disable padding-line-between-statements */
+import '@testing-library/jest-dom'
+import { render, waitFor, fireEvent } from '@testing-library/react'
+import { api } from '~/network/api'
+import { getLSat } from '~/utils'
+import { sphinxBridge } from '~/testSphinxBridge'
+import * as sphinx from 'sphinx-bridge'
+import { AddContentModal } from '../index'
+import { FormProvider, useForm } from 'react-hook-form'
+import React from 'react'
+
+jest.mock('~/network/api')
+jest.mock('~/utils')
+jest.mock('sphinx-bridge')
+jest.mock('~/testSphinxBridge')
+jest.mock('react-toastify/dist/ReactToastify.css', () => null)
+
+jest.mock('~/stores/useModalStore', () => ({
+  useModal: () => ({
+    close: jest.fn(),
+  }),
+}))
+
+const TestComponent = () => {
+  const form = useForm()
+  return (
+    <FormProvider {...form}>
+      <AddContentModal />
+    </FormProvider>
+  )
+}
+
+describe('AddContentModal', () => {
+  it('should send the correct tweet_id when sourceType is x.com', () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    ;(sphinx.enable as jest.Mock).mockResolvedValue({ pubkey: 'test_pubkey' })
+    ;(sphinxBridge.enable as jest.Mock).mockResolvedValue({ pubkey: 'test_pubkey' })
+    ;(getLSat as jest.Mock).mockResolvedValue('test_lsat_token')
+    ;(api.post as jest.Mock).mockResolvedValue({})
+
+    const { getByText, getByPlaceholderText } = render(<TestComponent />)
+
+    waitFor(() => {
+      expect(getByText('Add Content')).toBeInTheDocument()
+      fireEvent.change(getByPlaceholderText(/Paste your url here.../i), {
+        target: { value: 'https://x.com/linear/status/1801364934464241783' },
+      })
+      const nextButton = getByText('Next')
+      fireEvent.click(nextButton)
+
+      const skipButton = getByText('Skip')
+      fireEvent.click(skipButton)
+
+      const approveButton = getByText('Approve')
+      fireEvent.click(approveButton)
+
+      expect(api.post).toHaveBeenCalledWith(
+        '/add_node',
+        JSON.stringify({
+          tweet_id: '1801364934464241783',
+          content_type: 'tweet',
+          pubkey: 'test_pubkey',
+        }),
+        { Authorization: 'test_lsat_token' },
+      )
+    })
+  })
+
+  it('should send the correct tweet_id when sourceType is twitter.com', () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    ;(sphinx.enable as jest.Mock).mockResolvedValue({ pubkey: 'test_pubkey' })
+    ;(sphinxBridge.enable as jest.Mock).mockResolvedValue({ pubkey: 'test_pubkey' })
+    ;(getLSat as jest.Mock).mockResolvedValue('test_lsat_token')
+    ;(api.post as jest.Mock).mockResolvedValue({})
+
+    const { getByText, getByPlaceholderText } = render(<TestComponent />)
+
+    waitFor(() => {
+      expect(getByText('Add Content')).toBeInTheDocument()
+      fireEvent.change(getByPlaceholderText(/Paste your url here.../i), {
+        target: { value: 'https://twitter.com/linear/status/1801364934464241783' },
+      })
+
+      const nextButton = getByText('Next')
+      fireEvent.click(nextButton)
+
+      const skipButton = getByText('Skip')
+      fireEvent.click(skipButton)
+
+      const approveButton = getByText('Approve')
+      fireEvent.click(approveButton)
+
+      expect(api.post).toHaveBeenCalledWith(
+        '/add_node',
+        JSON.stringify({
+          tweet_id: '1801364934464241783',
+          content_type: 'tweet',
+          pubkey: 'test_pubkey',
+        }),
+        { Authorization: 'test_lsat_token' },
+      )
+    })
+  })
+})

--- a/src/components/AddContentModal/index.tsx
+++ b/src/components/AddContentModal/index.tsx
@@ -48,7 +48,7 @@ const handleSubmitForm = async (
     body.media_url = data.source
     body.content_type = 'audio_video'
   } else if (sourceType === TWITTER_SOURCE) {
-    const regex = /(?:https?:\/\/)?(?:www\.)?twitter\.com\/\w+\/status\/\d+/s
+    const regex = /(?:https?:\/\/)?(?:www\.)?(twitter|x)\.com\/\w+\/status\/(\d+)/s
 
     if (regex.test(data.source)) {
       const idRegex = /\/status\/(\d+)/


### PR DESCRIPTION
### Problem:
- Sending entire URL link for the source when we should only send the tweet_id

closes: #1672

## Issue ticket number and link:
- **Ticket Number:** [ 1672 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1672 ]

### Evidence:
 - Please see the attached video as evidence.
 
https://www.loom.com/share/ca0ccbe0355e4686a1cbe80b161dae57

![image](https://github.com/stakwork/sphinx-nav-fiber/assets/87068339/448e3dac-d1b3-402d-88b3-e37a6828377e)

![image](https://github.com/stakwork/sphinx-nav-fiber/assets/87068339/e0bbc9ff-ac05-46b8-a275-e594955d8771)

### Acceptance Criteria
- [x]  Add test that the tweet_id is always the correct format sent