### PR TITLE
Fix: Blueprint Height - Reduce Excessive Border at Bottom

### DIFF
--- a/src/components/ModalsContainer/BlueprintModal/Body/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/index.tsx
@@ -192,15 +192,19 @@ const Wrapper = styled(Flex)`
   justify-content: center;
   position: relative;
   overflow: hidden;
-  padding: 10px;
-  max-height: 80vh;
+  margin: calc(0px - 10px);
+  max-height: calc(100vh - 20px);
 
   @media (max-width: 1440px) {
-    max-height: 85vh;
+    max-height: calc(95vh - 20px);
   }
 
   @media (max-width: 1024px) {
-    max-height: 70vh;
+    max-height: calc(70vh - 20px);
+  }
+
+  @media (max-width: 924px) {
+    max-height: calc(70vh - 20px);
   }
 `
 


### PR DESCRIPTION
### Problem:
- Should be same width/height as the side (yellow).

closes: #1674

## Issue ticket number and link:
- **Ticket Number:** [ 1674 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1674 ]

### Evidence:

- Please see the attached video as evidence.
 
https://www.loom.com/share/5325735ebb0a481a92c432c046418a2a

![image](https://github.com/stakwork/sphinx-nav-fiber/assets/160427254/b7a953dc-5f72-46e3-803b-c5e918891464)

![image](https://github.com/stakwork/sphinx-nav-fiber/assets/160427254/fb705847-fd17-4909-84e9-4fd468f54ae4)

### Acceptance Criteria
- [x] Blueprint area height at the bottom should be the same as the top and side