### PR TITLE
Ensure single node renders in graph when it's the only one available

### DIFF
--- a/src/components/ModalsContainer/BlueprintModal/Body/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/index.tsx
@@ -41,9 +41,11 @@ export const Body = () => {
       try {
         const response = await getSchemaAll()
 
-        setSchemaAll(response.schemas.filter((i) => i.ref_id && !i.is_deleted && i.ref_id))
+        const filteredSchemas = response.schemas.filter((i) => i.ref_id && !i.is_deleted)
 
-        setSchemaLinks(response.edges)
+        setSchemaAll(filteredSchemas.length > 0 ? filteredSchemas : response.schemas)
+
+        setSchemaLinks(response.edges.length > 0 ? response.edges : [])
 
         setLoading(false)
       } catch (error) {


### PR DESCRIPTION
### Problem:
- When a blueprint only has one node Thing and no other node types (or edges), Thing isn't rendered in the graph.

closes: #1676

## Issue ticket number and link:
- **Ticket Number:** [ 1676 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1676 ]

### Acceptance Criteria
- [x] If only one node is available, we should still render it in the graph
- [x] GET /schema/all and only one type is returned without the is_deleted = true flag, should still be visible in the graph