### PR TITLE
fix(blueprint): fix form icons overflow and rounded corners issue

### DIFF
--- a/src/components/ModalsContainer/BlueprintModal/Body/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/index.tsx
@@ -192,7 +192,6 @@ const Wrapper = styled(Flex)`
   justify-content: center;
   position: relative;
   overflow: hidden;
-  margin: calc(0px - 10px);
   max-height: calc(100vh - 20px);
 
   @media (max-width: 1440px) {


### PR DESCRIPTION
### Problem:
- The "Edit" and "Add Type" forms are touching the right side of the delete icon.
- The corners of the "Edit," "Add Type," and "Add Edge" forms are not rounded.

![image](https://github.com/stakwork/sphinx-nav-fiber/assets/87068339/71dce9ca-9469-48e9-af8a-7c0d906911f7)

### Evidence:
 - Please see the attached video as evidence.

![image](https://github.com/stakwork/sphinx-nav-fiber/assets/87068339/803dd3ac-3e00-4803-a392-c97d8b98a437)
