### PR TITLE
Return schema list when in Blueprint in alphabetical order

### DIFF
--- a/src/components/ModalsContainer/BlueprintModal/Body/AddEdgeNode/Title/ToNode/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/AddEdgeNode/Title/ToNode/index.tsx
@@ -51,6 +51,7 @@ export const ToNode: FC<Props> = ({ onSelect, dataTestId }) => {
                   value: schema.type,
                 },
           )
+          .sort((a, b) => a.label.localeCompare(b.label))
 
         setOptions(schemaOptions)
       } catch (error) {

--- a/src/components/ModalsContainer/BlueprintModal/Body/Editor/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Editor/index.tsx
@@ -97,9 +97,9 @@ const fetchAndSetOptions = async (
     const data = await getNodeSchemaTypes()
     const schemas = data.schemas || []
 
-    const filteredSchemas = schemas.filter(
-      (schema) => !schema.is_deleted && schema.type && (!filterFunc || filterFunc(schema)),
-    )
+    const filteredSchemas = schemas
+      .filter((schema) => !schema.is_deleted && schema.type && (!filterFunc || filterFunc(schema)))
+      .sort((a, b) => a.type.localeCompare(b.type))
 
     const options = filteredSchemas.map((schema) =>
       schema.type === 'thing'


### PR DESCRIPTION
### Ticket №:

closes #1694

### Change 

- [x] Return schema list when in Blueprint in alphabetical order

![Screen Shot 2024-06-20 at 22 45 22](https://github.com/stakwork/sphinx-nav-fiber/assets/117433403/5eca28f7-d1bd-4635-89ff-6cdb70e9c7df)

