### PR TITLE
Fixed(Blueprint): Pass Attribute and Delete Inside Attributes Object

### DIFF
--- a/src/components/ModalsContainer/BlueprintModal/Body/Editor/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Editor/index.tsx
@@ -53,8 +53,10 @@ const handleSubmitForm = async (
 
     const requestData = {
       ...withoutAttributes,
-      attributes: convertAttributes(attributes),
-      ...deletedAttributes.reduce<{ [key: string]: string }>((acc, key) => ({ ...acc, [key]: 'delete' }), {}),
+      attributes: {
+        ...convertAttributes(attributes),
+        ...deletedAttributes.reduce<{ [key: string]: string }>((acc, key) => ({ ...acc, [key]: 'delete' }), {}),
+      },
     }
 
     let res: { status: string; ref_id: string }


### PR DESCRIPTION
### Problem:
- When deleting a schema, the delete value should be passed with the attributes object for that attribute

## Issue ticket number and link:
- **Ticket Number:** [ 1697 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1697 ]

### closes: #1697

### Evidence:
 - Please see the attached video as evidence.

https://www.loom.com/share/04808c7d4bc848248c139184edc0cac7

![image](https://github.com/stakwork/sphinx-nav-fiber/assets/160427254/39005745-4b0f-44de-9283-6605781c58f0)

### Acceptance Criteria
- [x]  If a user deletes a param when editing a custom node, pass the attribute and delete value inside the attributes object