### PR TITLE
fix(tweet-ui): Update Tweet node UI for new endpoint

### DIFF
--- a/src/components/App/SideBar/Dropdown/index.tsx
+++ b/src/components/App/SideBar/Dropdown/index.tsx
@@ -11,8 +11,6 @@ import { useDataStore } from '~/stores/useDataStore'
 import { colors } from '~/utils/colors'
 
 export const SelectWithPopover = () => {
-  console.log(123)
-
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
   const { sidebarFilter, setSidebarFilter, sidebarFilterCounts } = useDataStore((s) => s)
   const currentFilter = sidebarFilter === 'undefined' ? '' : sidebarFilter.toLowerCase()

--- a/src/components/App/SideBar/Relevance/Episode/index.tsx
+++ b/src/components/App/SideBar/Relevance/Episode/index.tsx
@@ -75,7 +75,7 @@ export const Episode = ({
   const description = type === 'show' ? showTitle : episodeTitle
   const subtitle = type === 'show' ? '' : showTitle
 
-  const defaultViewTypes = ['tweet', 'person', 'guest', 'topic', 'document']
+  const defaultViewTypes = ['Tweet', 'person', 'guest', 'topic', 'document']
 
   const imageType = type === 'video' ? 'video' : 'audio'
 
@@ -130,7 +130,7 @@ export const Episode = ({
             <TypePerson imageUrl={imageUrl} name={name || ''} title={showTitle || ''} />
           )}
           {['image'].includes(type as string) && <TypeCustom imageUrl={sourceLink} name={name || ''} />}
-          {type === 'tweet' && (
+          {type === 'Tweet' && (
             <TypeTweet
               date={date}
               imageUrl={imageUrl}

--- a/src/components/App/SideBar/Relevance/index.tsx
+++ b/src/components/App/SideBar/Relevance/index.tsx
@@ -11,6 +11,7 @@ import { formatDescription } from '~/utils/formatDescription'
 import { saveConsumedContent } from '~/utils/relayHelper'
 import { useIsMatchBreakpoint } from '~/utils/useIsMatchBreakpoint'
 import { Episode } from './Episode'
+import { adaptTweetNode } from '~/utils/twitterAdapter'
 
 type Props = {
   isSearchResult: boolean
@@ -82,6 +83,8 @@ const _Relevance = ({ isSearchResult }: Props) => {
     <>
       <ScrollView ref={scrollViewRef} id="search-result-list" shrink={1}>
         {(currentNodes ?? []).map((n, index) => {
+          const adaptedNode = adaptTweetNode(n)
+
           const {
             image_url: imageUrl,
             date,
@@ -96,7 +99,7 @@ const _Relevance = ({ isSearchResult }: Props) => {
             name,
             verified = false,
             twitter_handle: twitterHandle,
-          } = n || {}
+          } = adaptedNode || {}
 
           return (
             <Episode

--- a/src/components/App/SideBar/SelectedNodeView/index.tsx
+++ b/src/components/App/SideBar/SelectedNodeView/index.tsx
@@ -42,7 +42,7 @@ const _View = () => {
       return <Data />
     case 'tribe_message':
       return <Messages />
-    case 'tweet':
+    case 'Tweet':
       return <TwitData />
     case 'topic':
       return <Topic />

--- a/src/components/App/SideBar/TwitData/index.tsx
+++ b/src/components/App/SideBar/TwitData/index.tsx
@@ -13,9 +13,11 @@ import { useSelectedNode } from '~/stores/useGraphStore'
 import { colors } from '~/utils/colors'
 import { BoostAmt } from '../../Helper/BoostAmt'
 import { Date } from '../Relevance/Episode'
+import { adaptTweetNode } from '~/utils/twitterAdapter'
 
 export const TwitData = () => {
   const selectedNode = useSelectedNode()
+  const adaptedNode = selectedNode ? adaptTweetNode(selectedNode) : null
 
   const {
     date,
@@ -26,15 +28,15 @@ export const TwitData = () => {
     image_url: profilePicture,
     twitter_handle: twitterHandle,
     ref_id: refId,
-  } = selectedNode || {}
+  } = adaptedNode || {}
 
-  const twitId: string = selectedNode?.tweet_id || ''
+  const twitId: string = adaptedNode?.tweet_id || ''
   const [boostAmount, setBoostAmount] = useState<number>(boost || 0)
 
   const searchTerm = useAppStore((s) => s.currentSearch)
 
   return (
-    selectedNode && (
+    adaptedNode && (
       <>
         <Flex direction="column" p={24}>
           <Flex align="center" direction="row" pr={16}>
@@ -73,7 +75,7 @@ export const TwitData = () => {
         <StyledDivider />
         <Flex direction="row" justify="space-between" pt={14} px={24}>
           <BoostAmt amt={boostAmount} />
-          <Booster content={selectedNode} count={boostAmount} refId={refId} updateCount={setBoostAmount} />
+          <Booster content={adaptedNode} count={boostAmount} refId={refId} updateCount={setBoostAmount} />
         </Flex>
       </>
     )

--- a/src/components/ModalsContainer/BlueprintModal/Body/Editor/utils/__tests__/index.ts
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Editor/utils/__tests__/index.ts
@@ -1,7 +1,7 @@
 /* eslint-disable padding-line-between-statements */
 import '@testing-library/jest-dom'
 import { Vector3 } from 'three'
-import { convertAttributes, parseJson, parsedObjProps, getLoopControlPoints, truncateText } from '..'
+import { convertAttributes, parseJson, parsedObjProps, getLoopControlPoints } from '..'
 
 describe('convertAttributes function', () => {
   it('should convert attributes properly when all attributes are required', () => {

--- a/src/components/ModalsContainer/ChangeNodeTypeModal/SourceTypeStep/index.tsx
+++ b/src/components/ModalsContainer/ChangeNodeTypeModal/SourceTypeStep/index.tsx
@@ -45,7 +45,6 @@ export const SourceTypeStep: FC<Props> = ({ skipToStep, allowNextStep, onSelectT
           setLoading(false)
         }
       } else {
-        console.log('data')
         setOption([...OPTIONS, initialValue])
       }
     }

--- a/src/components/ModalsContainer/RemoveNodeModal/Body/index.tsx
+++ b/src/components/ModalsContainer/RemoveNodeModal/Body/index.tsx
@@ -101,8 +101,6 @@ export const Body = () => {
       closeHandler()
       closeEditNodeModal()
     } catch (error) {
-      console.log(error)
-
       console.warn(error)
     } finally {
       setLoading(false)

--- a/src/components/SettingsModal/SettingsView/General/index.tsx
+++ b/src/components/SettingsModal/SettingsView/General/index.tsx
@@ -27,7 +27,6 @@ export const General: FC<Props> = ({ initialValues }) => {
         setAppMetaData(data)
       }
     } catch (error) {
-      console.log(error)
       console.warn(error)
     }
   })

--- a/src/network/fetchGraphData/const.ts
+++ b/src/network/fetchGraphData/const.ts
@@ -14,8 +14,6 @@ export const defaultData: GraphData = {
 }
 
 export const getGraphDataPositions = (graphStyle: GraphStyle, nodes: NodeExtended[], links: Link[]) => {
-  console.log('position data')
-
   // give nodes and links positions based on graphStyle
   if (graphStyle === 'split') {
     return generateSplitGraphPositions(nodes, links)

--- a/src/network/fetchGraphDataNew/utils/prepareGraphDataForce.ts
+++ b/src/network/fetchGraphDataNew/utils/prepareGraphDataForce.ts
@@ -107,8 +107,6 @@ export const generateForceGraphPositions = (nodes: NodeNew[], edges: EdgeNew[]):
 
   const types = Object.keys(nodesByType)
 
-  console.log(types)
-
   const center: Center = { x: 0, y: 0, z: 0, radius: 1000 }
 
   const updatedNodes: NodeExtendedNew[] = types.reduce((acc: NodeExtendedNew[], curr: string, index) => {

--- a/src/stores/useGraphStore/index.ts
+++ b/src/stores/useGraphStore/index.ts
@@ -186,8 +186,6 @@ export const useGraphStore = create<GraphStore>()((set, get) => ({
     },
 
     addRadialForce: () => {
-      console.log('addRadialForce')
-
       const { simulation } = get()
 
       simulation
@@ -205,8 +203,6 @@ export const useGraphStore = create<GraphStore>()((set, get) => ({
     },
 
     addDefaultForce: () => {
-      console.log('addDefaultForce')
-
       const { simulation } = get()
 
       simulation
@@ -224,8 +220,6 @@ export const useGraphStore = create<GraphStore>()((set, get) => ({
     },
 
     addSplitForce: () => {
-      console.log('addSplitForce')
-
       const { simulation } = get()
       const { nodeTypes } = useDataStore.getState()
 

--- a/src/utils/twitterAdapter/index.tsx
+++ b/src/utils/twitterAdapter/index.tsx
@@ -1,0 +1,49 @@
+import { Node } from '~/types'
+
+// eslint-disable-next-line  @typescript-eslint/no-explicit-any
+export const adaptTweetNode = (node: any): Node => {
+  const { properties, ref_id: refId } = node
+
+  return {
+    boost: properties.boost || 0,
+    children: [],
+    x: 0,
+    y: 0,
+    z: 0,
+    edge_count: node.edge_count || 0,
+    hidden: false,
+    colors: [],
+    date: properties.date,
+    description: '',
+    episode_title: properties.episode_title || '',
+    hosts: [],
+    guests: [],
+    id: '',
+    image_url: properties.image_url,
+    sender_pic: '',
+    sender_alias: '',
+    message_content: '',
+    keyword: false,
+    label: '',
+    source_link: properties.source_link || '',
+    link: properties.link || '',
+    name: node.name,
+    node_type: node.node_type,
+    ref_id: refId,
+    scale: 1,
+    show_title: properties.show_title || '',
+    text: properties.text,
+    timestamp: '',
+    topics: [],
+    type: properties.type || '',
+    weight: 0,
+    tweet_id: properties.tweet_id,
+    posted_by: undefined,
+    twitter_handle: properties.twitter_handle,
+    profile_picture: '',
+    verified: properties.verified,
+    unique_id: '',
+    properties: {},
+    media_url: '',
+  }
+}


### PR DESCRIPTION
### Problem:
- Create an adapter to use the following response format to generate the same UI as we currently have for tweets:

## Issue ticket number and link:
- **Ticket Number:** [ 1689 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1689 ]

### closes: #1689

### Evidence:
 - Please see the attached video as evidence.

https://www.loom.com/share/965b73cc1db748f2976aef2c29562c55

![image](https://github.com/stakwork/sphinx-nav-fiber/assets/87068339/ccf33c1a-3cc7-4982-a7ad-ee9ef9233645)

### Acceptance Criteria
- [x]  UI should match master using new response format