### PR TITLE
vite: removed logs that were not needed in cypress tests

### DIFF
--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -1,2 +1,22 @@
 export * from './constants'
 export * from './utils'
+
+// cypress/support/index.js
+
+// Override console.log to filter out specific messages
+const originalLog = console.log
+console.log = function (message) {
+  if (!message.includes('[vite] page reload')) {
+    originalLog.apply(console, arguments)
+  }
+}
+
+// Handle Cypress events to filter out specific log messages
+Cypress.on('window:before:load', (win) => {
+  win.console.log = function () {
+    if (arguments[0] && arguments[0].includes && arguments[0].includes('[vite] page reload')) {
+      return // Suppress `[vite] page reload` messages
+    }
+    originalLog.apply(console, arguments)
+  }
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,6 +23,7 @@ const commonConfigOptions = ({ mode }: { mode: Mode }): UserConfigExport => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     plugins: [react(), viteTsconfigPaths(), svgrPlugin(), eslint(), builtins({ crypto: false })],
+    server: { debug: false },
     define: {
       APP_VERSION: JSON.stringify(process.env.npm_package_version),
     },


### PR DESCRIPTION
This makes it so that in the cypress tests logs we dont have a bunch that look like 

```
3:38:12 PM [vite] page reload coverage/src/utils/auth/__tests__/index.html
3:38:12 PM [vite] page reload coverage/src/utils/auth/__tests__/index.ts.html
3:38:12 PM [vite] page reload coverage/src/utils/boost/index.html
3:38:12 PM [vite] page reload coverage/src/utils/boost/index.tsx.html
3:38:12 PM [vite] page reload coverage/src/utils/capitalize/index.html
3:38:12 PM [vite] page reload coverage/src/utils/capitalize/index.tsx.html
3:38:12 PM [vite] page reload coverage/src/utils/colors/index.html
```