### PR TITLE
fix(changeNodeType ): PUT `/node` formatting change

### DIFF
--- a/src/components/ModalsContainer/ChangeNodeTypeModal/index.tsx
+++ b/src/components/ModalsContainer/ChangeNodeTypeModal/index.tsx
@@ -84,7 +84,7 @@ const handleSubmitForm = async (
     const refId = id || selectedNode?.ref_id
 
     if (refId) {
-      await changeNodeType(refId, body)
+      await changeNodeType(refId, { node_data: body })
     }
 
     // eslint-disable-next-line  @typescript-eslint/no-explicit-any

--- a/src/components/ModalsContainer/ChangeNodeTypeModal/index.tsx
+++ b/src/components/ModalsContainer/ChangeNodeTypeModal/index.tsx
@@ -41,21 +41,21 @@ const handleSubmitForm = async (
     }
   })
 
-  const properties: { [key: string]: unknown } = {}
+  const nodeData: { [key: string]: unknown } = {}
 
   Object.keys(selectedNode || {}).forEach((selectedNodeKey) => {
     const selectedNodeValue = selectedNode?.[selectedNodeKey as keyof NodeExtended]
 
     Object.entries(swappedValues).forEach(([key, value]) => {
       if (value === selectedNodeKey) {
-        properties[swappedValues[key]] = selectedNodeValue as string
+        nodeData[swappedValues[key]] = selectedNodeValue as string
       }
     })
   })
 
   Object.keys(requiredFieldsData).forEach((key) => {
     if (key !== 'nodeType') {
-      properties[key] = requiredFieldsData[key]
+      nodeData[key] = requiredFieldsData[key]
     }
   })
 
@@ -65,7 +65,7 @@ const handleSubmitForm = async (
 
   const body: { [index: string]: unknown } = {
     node_type: nodeType,
-    properties,
+    node_data: nodeData,
     properties_to_be_deleted: propertiesToBeDeleted,
     type_to_be_deleted: typeName ? [typeName] : [],
   }
@@ -84,7 +84,7 @@ const handleSubmitForm = async (
     const refId = id || selectedNode?.ref_id
 
     if (refId) {
-      await changeNodeType(refId, { node_data: body })
+      await changeNodeType(refId, body)
     }
 
     // eslint-disable-next-line  @typescript-eslint/no-explicit-any

--- a/src/components/ModalsContainer/EditNodeNameModal/Body/index.tsx
+++ b/src/components/ModalsContainer/EditNodeNameModal/Body/index.tsx
@@ -94,7 +94,7 @@ export const Body = () => {
     const updatedData = { [propName]: topicValue.trim(), image_url: imageUrl.trim() }
 
     try {
-      await putNodeData(node?.ref_id || '', updatedData)
+      await putNodeData(node?.ref_id || '', { node_data: updatedData })
 
       const { updateNode } = useDataStore.getState()
 

--- a/src/components/SourcesTableModal/SourcesView/Topics/EditTopicModal/index.tsx
+++ b/src/components/SourcesTableModal/SourcesView/Topics/EditTopicModal/index.tsx
@@ -49,7 +49,7 @@ export const EditTopicModal: FC<Props> = ({ topic, onClose }) => {
     setLoading(true)
 
     try {
-      await putNodeData(topic?.ref_id || '', { name })
+      await putNodeData(topic?.ref_id || '', { node_data: { name } })
 
       if (data) {
         const newData = { ...data }

--- a/src/components/SourcesTableModal/SourcesView/Topics/Table/TableRow.tsx
+++ b/src/components/SourcesTableModal/SourcesView/Topics/Table/TableRow.tsx
@@ -45,7 +45,7 @@ const TableRowComponent: FC<TTableRaw> = ({
     setLoading(true)
 
     try {
-      await putNodeData(refId, { is_muted: shouldMute })
+      await putNodeData(refId, { node_data: { is_muted: shouldMute } })
 
       useTopicsStore.setState({
         ids: ids.filter((i) => i !== refId),

--- a/src/components/SourcesTableModal/SourcesView/Topics/Table/index.tsx
+++ b/src/components/SourcesTableModal/SourcesView/Topics/Table/index.tsx
@@ -82,7 +82,7 @@ export const Table: React.FC<TopicTableProps> = ({
 
         if (value) {
           try {
-            await putNodeData(checkedId, { is_muted: !showMuted })
+            await putNodeData(checkedId, { node_data: { is_muted: !showMuted } })
 
             return checkedId
           } catch (error) {

--- a/src/components/SourcesTableModal/SourcesView/Topics/index.tsx
+++ b/src/components/SourcesTableModal/SourcesView/Topics/index.tsx
@@ -85,7 +85,7 @@ export const TopicSources = () => {
 
   const handleMute = async (refId: string, action: string) => {
     try {
-      await putNodeData(refId, { is_muted: action === 'mute' })
+      await putNodeData(refId, { node_data: { is_muted: action === 'mute' } })
       useTopicsStore.setState({ ids: ids.filter((i) => i !== refId), total: total - 1 })
     } catch (error) {
       console.warn(error)

--- a/src/network/fetchSourcesData/index.ts
+++ b/src/network/fetchSourcesData/index.ts
@@ -170,7 +170,7 @@ interface UpdateEdgeData {
 }
 
 export const changeNodeType = async (ref_id: string, data: ChangeNodeType) =>
-  api.put(`/node`, JSON.stringify({ ...data, ref_id }))
+  api.put(`/node`, JSON.stringify({ node_data: { ...data }, ref_id }))
 
 export const getFullTranscript = async (refId: string | undefined) => {
   const url = `/node/text/${refId}`

--- a/src/network/fetchSourcesData/index.ts
+++ b/src/network/fetchSourcesData/index.ts
@@ -170,7 +170,7 @@ interface UpdateEdgeData {
 }
 
 export const changeNodeType = async (ref_id: string, data: ChangeNodeType) =>
-  api.put(`/node`, JSON.stringify({ node_data: { ...data }, ref_id }))
+  api.put(`/node`, JSON.stringify({ ...data, ref_id }))
 
 export const getFullTranscript = async (refId: string | undefined) => {
   const url = `/node/text/${refId}`

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -53,10 +53,12 @@ export type RadarRequest = {
 }
 
 export type NodeRequest = {
-  is_muted?: boolean
-  topic?: string
-  name?: string
-  image_url?: string
+  node_data: {
+    name?: string
+    is_muted?: boolean
+    topic?: string
+    image_url?: string
+  }
 }
 
 export type Node = {


### PR DESCRIPTION
### Problem:
- Update everywhere we use PUT /node (source table (renaming), `changeNodeType` to use new formatting.

closes: #1765

## Issue ticket number and link:
- **Ticket Number:** [ 1765 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1765 ]

### Evidence:
 - Please see the attached video as evidence.

![image](https://github.com/stakwork/sphinx-nav-fiber/assets/171659890/358cd78f-fa31-496c-9fd0-6e72e80a5683)

### Acceptance Criteria
 { node_data: {property1: “example”} }