### PR TITLE
Load More button should not be visible on sidebar if there is no any node types

### DIFF
--- a/src/components/App/SideBar/Relevance/index.tsx
+++ b/src/components/App/SideBar/Relevance/index.tsx
@@ -21,7 +21,7 @@ type Props = {
 const _Relevance = ({ isSearchResult }: Props) => {
   const scrollViewRef = useRef<HTMLDivElement | null>(null)
 
-  const pageSize = !isSearchResult ? 100 : 80
+  const pageSize = !isSearchResult ? 10 : 80
 
   const { setSelectedTimestamp, nextPage } = useDataStore((s) => s)
   const setSelectedNode = useUpdateSelectedNode()
@@ -125,12 +125,11 @@ const _Relevance = ({ isSearchResult }: Props) => {
         })}
 
         <LoadMoreWrapper align="center" background="BG1" direction="row" justify="center">
-          {hasNext ||
-            (true && (
-              <Button key={buttonKey} onClick={handleLoadMoreClick} size="medium">
-                Load More
-              </Button>
-            ))}
+          {hasNext && (
+            <Button key={buttonKey} onClick={handleLoadMoreClick} size="medium">
+              Load More
+            </Button>
+          )}
         </LoadMoreWrapper>
       </ScrollView>
     </>


### PR DESCRIPTION
### Ticket №: #1774

closes: #1774

### Problem:

Load More button is visible on sidebar as there is no any node type

### Evidence:

https://www.loom.com/share/0cc3b476aa3d44d28d7084f78496fef1?sid=4b5f5bb2-3d3f-4309-bb27-62ba02b997dd

