### PR TITLE
The Node type property on sidebar subview should not be visible if there is no value of that property

### DIFF
--- a/src/components/App/SideBar/SelectedNodeView/Default/index.tsx
+++ b/src/components/App/SideBar/SelectedNodeView/Default/index.tsx
@@ -54,6 +54,10 @@ type Props = { label: string; value: unknown }
 const NodeDetail = ({ label, value }: Props) => {
   const isLong = (value as string).length > 140
 
+  if (!value) {
+    return null
+  }
+
   return (
     <>
       <StyledDetail className={clsx('node-detail', { 'node-detail__long': isLong })}>

--- a/src/components/App/SideBar/SidebarSubView/MediaPlayer/ToolBar/__tests__/index.tsx
+++ b/src/components/App/SideBar/SidebarSubView/MediaPlayer/ToolBar/__tests__/index.tsx
@@ -11,7 +11,7 @@ describe('MediaPlayer in Fullscreen', () => {
         duration={120}
         handleProgressChange={jest.fn()}
         handleVolumeChange={jest.fn()}
-        isFullScreen={true}
+        isFullScreen
         isPlaying={false}
         onFullScreenClick={jest.fn()}
         playingTime={0}

--- a/src/components/App/SideBar/SidebarSubView/MediaPlayer/ToolBar/__tests__/index.tsx
+++ b/src/components/App/SideBar/SidebarSubView/MediaPlayer/ToolBar/__tests__/index.tsx
@@ -11,7 +11,7 @@ describe('MediaPlayer in Fullscreen', () => {
         duration={120}
         handleProgressChange={jest.fn()}
         handleVolumeChange={jest.fn()}
-        isFullScreen
+        isFullScreen={true}
         isPlaying={false}
         onFullScreenClick={jest.fn()}
         playingTime={0}


### PR DESCRIPTION

### Ticket №: #1773

closes #1773

### Problem:

currently if there is not value of property it is visible on Sidebar SubView

### Evidence:

![image](https://github.com/stakwork/sphinx-nav-fiber/assets/98140673/4db691a8-28e5-4350-b752-0164a25362ed)



