### PR TITLE
Add Seed Questions to Search Interface

### DIFF
--- a/src/network/fetchSourcesData/index.ts
+++ b/src/network/fetchSourcesData/index.ts
@@ -23,6 +23,7 @@ export type TAboutParams = {
   description?: string
   mission_statement?: string
   search_term?: string
+  seed_questions?: string[]
 }
 
 export type TStatParams = {


### PR DESCRIPTION
### Problem:
- Render 4 questions below the search bar in new chat interface (bottom right, triggered by the Blue Button):

closes: #1797

## Issue ticket number and link:
- **Ticket Number:** [ 1797 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1797]

### Evidence:
 - Please see the attached video as evidence.

https://www.loom.com/share/de0b17016a5a4df69fcf5b71342a9955

![image](https://github.com/stakwork/sphinx-nav-fiber/assets/171659890/b3ea98a3-3b65-433d-8ed6-25ac439253b9)

### Acceptance Criteria
- Render questions IF seed_questions is returned in About GET request
- onClick in the new interface, should automatically trigger search with ai summary flow