### PR TITLE
Add Content should not allow link without extension needs to update the regex

### DIFF
--- a/src/components/AddContentModal/SourceStep/utils/index.ts
+++ b/src/components/AddContentModal/SourceStep/utils/index.ts
@@ -22,4 +22,22 @@ export const sourceUrlRegex = new RegExp(
   'i',
 )
 
-export const validateSourceURL = (input: string) => sourceUrlRegex.test(input)
+export const validateSourceURL = (input: string) => {
+  const match = input?.match(sourceUrlRegex)
+
+  if (match) {
+    // Extract domain from input
+    const url = new URL(input)
+    const domain = url.hostname
+
+    if (domain?.startsWith('www.')) {
+      // Check for two dots if 'www.' is present
+      return (domain?.match(/\./g) || []).length >= 2
+    }
+    // Check for one dot if 'www.' is not present
+
+    return (domain?.match(/\./g) || []).length >= 1
+  }
+
+  return false
+}

--- a/src/components/common/TextInput/index.tsx
+++ b/src/components/common/TextInput/index.tsx
@@ -247,7 +247,7 @@ export const TextInput = ({
             <Flex align="center" direction="row" shrink={1}>
               <MdError fontSize={18} />
               <Flex pl={4} shrink={1}>
-                {error.message}
+                {error.message !== '' ? error.message : 'Please enter a valid URL'}
               </Flex>
             </Flex>
           </Text>


### PR DESCRIPTION

### Ticket №: #1707

closes #1707

### Problem:

when we type https://www.youtube/ this is going to be acceptable without extension

### Evidence:

https://www.loom.com/share/29c5c8b35a4a4b0e852673aec38289f4?sid=65b1b26c-b18d-4fa7-87ef-bb45cf564cde

