### PR TITLE
Fixed[Chat Interface] - Executing search should not render `Trending Topics` or `Latest`

### DIFF
--- a/src/components/App/UniverseQuestion/index.tsx
+++ b/src/components/App/UniverseQuestion/index.tsx
@@ -21,6 +21,7 @@ export const UniverseQuestion = () => {
   const [setBudget] = useUserStore((s) => [s.setBudget])
   const setUniverseQuestionIsOpen = useAppStore((s) => s.setUniverseQuestionIsOpen)
   const resetAiSummaryAnswer = useAiSummaryStore((s) => s.resetAiSummaryAnswer)
+  const setCurrentSearch = useAppStore((s) => s.setCurrentSearch)
 
   useEffect(() => {
     const fetchSeedQuestions = async () => {
@@ -44,6 +45,7 @@ export const UniverseQuestion = () => {
     if (questionToSubmit) {
       resetAiSummaryAnswer()
       setUniverseQuestionIsOpen()
+      setCurrentSearch(questionToSubmit)
     }
 
     await fetchData(setBudget, setAbortRequests, questionToSubmit)


### PR DESCRIPTION
### Problem:
- When executing a search via the Chat Interface button (Blue button in bottom right), currently Trending Topics and Latest still remain in the sidebar:

closes: #1818

## Issue ticket number and link:
- **Ticket Number:** [ 1818 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1818 ]

### Evidence:

![image](https://github.com/user-attachments/assets/af0ee7fd-20bc-435a-bb52-b239d1fe49f1)

https://www.loom.com/share/d46dd18abf5846f1857b39271be744e2