### PR TITLE
Spacing between graph {graph_title} and secondbrain

### DIFF
--- a/src/components/App/AppBar/index.tsx
+++ b/src/components/App/AppBar/index.tsx
@@ -71,5 +71,6 @@ const TitleWrapper = styled.div`
     font-weight: 400;
     line-height: 16px;
     letter-spacing: 0.22px;
+    margin-left: 8px;
   }
 `


### PR DESCRIPTION
### Problem:
- Add 1 space between the graph title and secondbrain

closes: #1821

## Issue ticket number and link:
- **Ticket Number:** [ 1821 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1821 ]

### Evidence:
 - Please see the attached Image as evidence.

![image](https://github.com/user-attachments/assets/e43ac9e9-f92b-4008-a392-46b700b33f6d)
