### PR TITLE
Spacing before and after the highlight

### DIFF
--- a/src/components/App/SideBar/AiSummary/utils/AiSummaryHighlight/index.tsx
+++ b/src/components/App/SideBar/AiSummary/utils/AiSummaryHighlight/index.tsx
@@ -51,7 +51,7 @@ function escapeRegExp(string: string) {
 }
 
 const Highlight = styled.span`
-  padding: 2px;
+  padding: 0;
   margin: 0;
   color: ${colors.SECONDARY_BLUE};
 


### PR DESCRIPTION
### Problem:
- There seems to be padding or spacign before and after the highlighted word. There should but be 1 space as usual

closes: #1837

## Issue ticket number and link:
- **Ticket Number:** [ 1837 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1837 ]

### Evidence:

![image](https://github.com/user-attachments/assets/5b28e6f5-fc7d-4c14-979e-1b03cea9d5ba)
