### PR TITLE
'More on this' should be aligned with the icon on side bar [ AI search ] 

### DIFF
--- a/src/components/App/SideBar/AiSummary/AiQuestions/index.tsx
+++ b/src/components/App/SideBar/AiSummary/AiQuestions/index.tsx
@@ -28,7 +28,7 @@ const _AiQuestions = ({ questions }: Props) => {
         <div className="heading__icon">
           <StackIcon />
         </div>
-        <span>More on this</span>
+        <span className="tittle">More on this</span>
       </Heading>
       <Flex>
         {questions.map((i) => (
@@ -67,6 +67,10 @@ const Heading = styled(Flex)`
       font-weight: 400;
       color: ${colors.GRAY7};
       margin-left: 16px;
+    }
+
+    .tittle {
+      margin-bottom: 2px;
     }
   }
 `

--- a/src/components/App/SideBar/AiSummary/AiQuestions/index.tsx
+++ b/src/components/App/SideBar/AiSummary/AiQuestions/index.tsx
@@ -28,7 +28,7 @@ const _AiQuestions = ({ questions }: Props) => {
         <div className="heading__icon">
           <StackIcon />
         </div>
-        <span className="tittle">More on this</span>
+        <HeadingTitle>More on this</HeadingTitle>
       </Heading>
       <Flex>
         {questions.map((i) => (
@@ -68,11 +68,11 @@ const Heading = styled(Flex)`
       color: ${colors.GRAY7};
       margin-left: 16px;
     }
-
-    .tittle {
-      margin-bottom: 2px;
-    }
   }
+`
+
+const HeadingTitle = styled.span`
+  margin-top: 1px;
 `
 
 const QuestionWrapper = styled(Flex)`


### PR DESCRIPTION
### Problem:
- `More on this` text is not aligned with icon on side bar

closes: #1830

## Issue ticket number and link:
- **Ticket Number:** [ 1830 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1830 ]

### Evidence:
 - Please see the attached Image as evidence.

![image](https://github.com/user-attachments/assets/b3c83c44-51b5-4c55-9fea-ae2557c7808d)

### Acceptance Criteria
- [x]  More on this text should be aligned with icon