### PR TITLE
fix(text): more on this should be aligned with the icon on sidebar

### DIFF
--- a/src/components/App/SideBar/AiSummary/AiQuestions/index.tsx
+++ b/src/components/App/SideBar/AiSummary/AiQuestions/index.tsx
@@ -101,5 +101,5 @@ const SectionWrapper = styled(Flex)`
 `
 
 const SubTitle = styled.span`
-  margin-top: 2px;
+  margin-top: 1px;
 `

--- a/src/components/App/SideBar/AiSummary/AiQuestions/index.tsx
+++ b/src/components/App/SideBar/AiSummary/AiQuestions/index.tsx
@@ -28,7 +28,7 @@ const _AiQuestions = ({ questions }: Props) => {
         <div className="heading__icon">
           <StackIcon />
         </div>
-        <span>More on this</span>
+        <SubTitle>More on this</SubTitle>
       </Heading>
       <Flex>
         {questions.map((i) => (
@@ -98,4 +98,8 @@ const QuestionWrapper = styled(Flex)`
 
 const SectionWrapper = styled(Flex)`
   padding: 0 24px 24px 24px;
+`
+
+const SubTitle = styled.span`
+  margin-top: 2px;
 `


### PR DESCRIPTION
### Ticket №:  #1850

closes  #1850

### Problem:

'More on this' text is not aligned with icon on side bar

### Evidence:

![image](https://github.com/user-attachments/assets/72ffceaa-86b9-4e58-a595-dadabb06cd14)






