### PR TITLE
Fixed(ai-summary):  `AI Answer Resets` on Collapse Toggle in `AiSummary`

### DIFF
--- a/src/components/App/SideBar/AiSummary/AiAnswer/index.tsx
+++ b/src/components/App/SideBar/AiSummary/AiAnswer/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 import styled from 'styled-components'
 import { highlightAiSummary } from '~/components/App/SideBar/AiSummary/utils/AiSummaryHighlight'
 import { Flex } from '~/components/common/Flex'
@@ -10,6 +10,8 @@ type Props = {
   answer: string
   hasBeenRendered: boolean
   handleLoaded: () => void
+  displayedText: string
+  setDisplayedText: (text: string) => void
 }
 
 const Wrapper = styled(Flex).attrs({
@@ -25,10 +27,9 @@ const SummaryText = styled(Text)`
   line-height: 19.6px;
 `
 
-export const AiAnswer = ({ answer, handleLoaded, hasBeenRendered }: Props) => {
+export const AiAnswer = ({ answer, handleLoaded, hasBeenRendered, displayedText, setDisplayedText }: Props) => {
   const { fetchData, setAbortRequests } = useDataStore((s) => s)
   const { setBudget } = useUserStore((s) => s)
-  const [displayedText, setDisplayedText] = useState('')
   const filteredNodes = useFilteredNodes()
 
   useEffect(() => {
@@ -48,7 +49,7 @@ export const AiAnswer = ({ answer, handleLoaded, hasBeenRendered }: Props) => {
     }
 
     handleLoaded()
-  }, [answer, displayedText, handleLoaded, hasBeenRendered])
+  }, [answer, displayedText, handleLoaded, hasBeenRendered, setDisplayedText])
 
   useEffect(() => {
     if (displayedText) {
@@ -58,7 +59,7 @@ export const AiAnswer = ({ answer, handleLoaded, hasBeenRendered }: Props) => {
     if (hasBeenRendered) {
       setDisplayedText(answer)
     }
-  }, [answer, displayedText, hasBeenRendered])
+  }, [answer, displayedText, hasBeenRendered, setDisplayedText])
 
   const handleSubmit = (search: string) => {
     fetchData(setBudget, setAbortRequests, search)

--- a/src/components/App/SideBar/AiSummary/index.tsx
+++ b/src/components/App/SideBar/AiSummary/index.tsx
@@ -36,6 +36,7 @@ export const AiSummary = ({ question, response }: Props) => {
   const ref = useRef<HTMLDivElement>(null)
   const [collapsed, setCollapsed] = useState(false)
   const { setAiSummaryAnswer } = useAiSummaryStore((s) => s)
+  const [displayedText, setDisplayedText] = useState('')
 
   useEffect(() => {
     if (ref.current) {
@@ -66,8 +67,10 @@ export const AiSummary = ({ question, response }: Props) => {
           ) : (
             <AiAnswer
               answer={response.answer || ''}
+              displayedText={displayedText}
               handleLoaded={() => handleLoaded()}
               hasBeenRendered={!!response?.hasBeenRendered}
+              setDisplayedText={setDisplayedText}
             />
           )}
           {response.questionsLoading ? (


### PR DESCRIPTION
### Problem:
- The AI answer resets and starts displaying from the beginning each time the collapse button is toggled.

closes: #1856

## Issue ticket number and link:
- **Ticket Number:** [ 1856 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1856 ]

### Evidence:
 - Please see the attached video as evidence.

https://www.loom.com/share/8b973e1653524ef39169f913ef9b9b49

### Acceptance Criteria
- [x]   The AI answer should retain its displayed state and not reset when the collapse button is toggled.