### PR TITLE
fix(ai-search): tooltip Cut off near the top

### DIFF
--- a/src/components/App/SideBar/AiSummary/utils/AiSummaryHighlight/index.tsx
+++ b/src/components/App/SideBar/AiSummary/utils/AiSummaryHighlight/index.tsx
@@ -75,7 +75,7 @@ const StyledTooltip = styled(({ className, ...props }) => (
     fontSize="12px"
     fontWeight="500"
     minWidth="160px"
-    padding="10px"
+    padding="5px"
     position="top"
     textAlign="start"
     whiteSpace="normal"


### PR DESCRIPTION
### Problem:
- Tooltip Cut off near the top

## Issue ticket number and link:
- **Ticket Number:** [ 1874 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1874 ]

### closes: #1874

### Evidence:
 - Please see the attached video as evidence.

![image](https://github.com/user-attachments/assets/0021bb46-976e-4c38-85ed-bff65605d11d)

https://www.loom.com/share/139008aefc1748e5afe4756a352ec56e