### PR TITLE
The label and placeholder value of "Image_url" should be "Image Url" instead, just like "Node Name"

### DIFF
--- a/src/components/ModalsContainer/EditNodeNameModal/Title/index.tsx
+++ b/src/components/ModalsContainer/EditNodeNameModal/Title/index.tsx
@@ -68,13 +68,13 @@ export const TitleEditor = () => {
             marginBottom: 8,
           }}
         >
-          image_url
+          Image Url
         </LabelText>
         <TextInput
           id="cy-image_url"
           maxLength={500}
           name="image_url"
-          placeholder="image_url"
+          placeholder="Image url"
           rules={{
             pattern: {
               message: 'Please enter a valid URL',


### PR DESCRIPTION
### Ticket №:

closes https://github.com/stakwork/sphinx-nav-fiber/issues/1794

### Evidence:

<img width="959" alt="image" src="https://github.com/user-attachments/assets/06621e7c-8e4f-4a15-8f24-8d30f6eb5713">

