### PR TITLE
Chat Icon Click Doesn't Close Sidebar or AI Search Bar as per Figma Design

### DIFF
--- a/src/components/App/ActionsToolbar/UniverseQuestionControl/index.tsx
+++ b/src/components/App/ActionsToolbar/UniverseQuestionControl/index.tsx
@@ -5,13 +5,23 @@ import { useAppStore } from '~/stores/useAppStore'
 import { colors } from '~/utils'
 
 export const UniverseQuestionControl = () => {
-  const setUniverseQuestionIsOpen = useAppStore((s) => s.setUniverseQuestionIsOpen)
+  const { setUniverseQuestionIsOpen, setSidebarOpen, setShowCollapseButton } = useAppStore((s) => ({
+    setUniverseQuestionIsOpen: s.setUniverseQuestionIsOpen,
+    setSidebarOpen: s.setSidebarOpen,
+    setShowCollapseButton: s.setShowCollapseButton,
+  }))
+
+  const handleOpenChatModal = () => {
+    setUniverseQuestionIsOpen()
+    setSidebarOpen(false)
+    setShowCollapseButton(false)
+  }
 
   return (
     <StyledButton
       color="secondary"
       href=""
-      onClick={() => setUniverseQuestionIsOpen()}
+      onClick={handleOpenChatModal}
       size="medium"
       startIcon={<MenuIcon />}
       variant="contained"

--- a/src/components/App/SideBar/Tab/index.tsx
+++ b/src/components/App/SideBar/Tab/index.tsx
@@ -5,16 +5,23 @@ import { useAppStore } from '~/stores/useAppStore'
 import { colors } from '~/utils/colors'
 
 export const Tab = () => {
-  const setSidebarOpen = useAppStore((s) => s.setSidebarOpen)
+  const { sidebarIsOpen, showCollapseButton } = useAppStore((s) => ({
+    sidebarIsOpen: s.setSidebarOpen,
+    showCollapseButton: s.showCollapseButton,
+  }))
 
   return (
-    <ExpandButton
-      onClick={() => {
-        setSidebarOpen(true)
-      }}
-    >
-      <ChevronRightIcon />
-    </ExpandButton>
+    <>
+      {showCollapseButton && (
+        <ExpandButton
+          onClick={() => {
+            sidebarIsOpen(true)
+          }}
+        >
+          <ChevronRightIcon />
+        </ExpandButton>
+      )}
+    </>
   )
 }
 

--- a/src/components/App/UniverseQuestion/index.tsx
+++ b/src/components/App/UniverseQuestion/index.tsx
@@ -17,13 +17,21 @@ export const UniverseQuestion = () => {
   const [question, setQuestion] = useState('')
   const { fetchData, setAbortRequests, seedQuestions } = useDataStore((s) => s)
   const [setBudget] = useUserStore((s) => [s.setBudget])
-  const setUniverseQuestionIsOpen = useAppStore((s) => s.setUniverseQuestionIsOpen)
+
+  const { setUniverseQuestionIsOpen, setSidebarOpen, setShowCollapseButton } = useAppStore((s) => ({
+    setUniverseQuestionIsOpen: s.setUniverseQuestionIsOpen,
+    setSidebarOpen: s.setSidebarOpen,
+    setShowCollapseButton: s.setShowCollapseButton,
+  }))
+
   const resetAiSummaryAnswer = useAiSummaryStore((s) => s.resetAiSummaryAnswer)
 
   const handleSubmitQuestion = async (questionToSubmit: string) => {
     if (questionToSubmit) {
       resetAiSummaryAnswer()
       setUniverseQuestionIsOpen()
+      setSidebarOpen(true)
+      setShowCollapseButton(true)
     }
 
     await fetchData(setBudget, setAbortRequests, questionToSubmit)
@@ -41,6 +49,12 @@ export const UniverseQuestion = () => {
   const handleSeedQuestionClick = async (seedQuestion: string) => {
     setQuestion(seedQuestion)
     await handleSubmitQuestion(seedQuestion)
+  }
+
+  const handleUniverseQuestionIsOpen = () => {
+    setUniverseQuestionIsOpen()
+    setSidebarOpen(true)
+    setShowCollapseButton(true)
   }
 
   const shuffleArray = (inputArray: string[]) => {
@@ -95,7 +109,7 @@ export const UniverseQuestion = () => {
           ))}
         </SeedQuestionsWrapper>
       )}
-      <CloseButton onClick={setUniverseQuestionIsOpen} startIcon={<ExploreIcon />}>
+      <CloseButton onClick={handleUniverseQuestionIsOpen} startIcon={<ExploreIcon />}>
         Explore Graph
       </CloseButton>
     </Wrapper>

--- a/src/stores/useAppStore/index.ts
+++ b/src/stores/useAppStore/index.ts
@@ -16,6 +16,7 @@ export type AppStore = {
   relevanceIsSelected: boolean
   currentPlayingAudio: React.MutableRefObject<HTMLAudioElement | null> | null
   appMetaData: TAboutParams | null
+  showCollapseButton: boolean
   clearSearch: () => void
   setCurrentSearch: (_: string) => void
   setSearchFormValue: (_: string) => void
@@ -27,6 +28,7 @@ export type AppStore = {
   setAppMetaData: (val: TAboutParams) => void
   setUniverseQuestionIsOpen: () => void
   setCurrentPlayingAudio: (_: React.MutableRefObject<HTMLAudioElement | null> | null) => void
+  setShowCollapseButton: (_: boolean) => void
 }
 
 const defaultData = {
@@ -42,6 +44,7 @@ const defaultData = {
   transcriptIsOpen: false,
   appMetaData: null,
   currentPlayingAudio: null,
+  showCollapseButton: true,
 }
 
 export const useAppStore = create<AppStore>((set, get) => ({
@@ -64,4 +67,5 @@ export const useAppStore = create<AppStore>((set, get) => ({
   setTranscriptOpen: (transcriptIsOpen) => set({ transcriptIsOpen }),
   setUniverseQuestionIsOpen: () => set({ universeQuestionIsOpen: !get().universeQuestionIsOpen }),
   setAppMetaData: (appMetaData) => set({ appMetaData }),
+  setShowCollapseButton: (showCollapseButton) => set({ showCollapseButton }),
 }))


### PR DESCRIPTION
### Problem:
- when I click the chat icon, the search bar remains open. However, according to the Figma design, when the chat icon is clicked, the sidebar should be closed, and when the AI search is closed, the sidebar should be open.

## Issue ticket number and link:
- **Ticket Number:** [ 1883 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1883 ]

### closes: #1883

### Evidence:
 - Please see the attached video as evidence.

https://www.loom.com/share/d26444d6677641fe801545e62b27b54f
