### PR TITLE
[Fixed]: Search Result Count Mismatch Due to Duplicate Content in Sidebar Options

### DIFF
--- a/src/components/App/SideBar/Latest/index.tsx
+++ b/src/components/App/SideBar/Latest/index.tsx
@@ -51,7 +51,7 @@ const _View = ({ isSearchResult }: Props) => {
           ) : null}
         </div>
       )}
-      <Relevance isSearchResult={isSearchResult} />
+      {!isSearchResult && <Relevance isSearchResult={isSearchResult} />}
     </Wrapper>
   )
 }


### PR DESCRIPTION
### Problem:
- Currently, the search result count and the results do not match because some options show duplicate content in the sidebar.

## Issue ticket number and link:
- **Ticket Number:** [ 1884 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1884 ]

### closes: #1884

### Evidence:
 - Please see the attached video  and Images as evidence.

https://www.loom.com/share/aac7d6fd794b4980be20a461dd547f76

![image](https://github.com/user-attachments/assets/fa71b6aa-e3fd-428e-894b-a55186e30bb4)

![image](https://github.com/user-attachments/assets/f7beaf6c-d939-45db-999b-68d31916820c)

![image](https://github.com/user-attachments/assets/7f11eb9b-6c89-434e-9a4f-1b46b3560047)

etc.