### PR TITLE
Fixed(ai-r): Misaligned Collapse Button and Incorrect Follow-Up Search Icon Color

### DIFF
--- a/src/components/App/SideBar/AiSearch/index.tsx
+++ b/src/components/App/SideBar/AiSearch/index.tsx
@@ -67,4 +67,8 @@ const InputButton = styled(Flex).attrs({
   &:hover {
     /* background-color: ${colors.gray200}; */
   }
+
+  ${AiSearchWrapper} input:focus + & {
+    color: ${colors.primaryBlue};
+  }
 `

--- a/src/components/App/SideBar/AiSummary/index.tsx
+++ b/src/components/App/SideBar/AiSummary/index.tsx
@@ -96,13 +96,14 @@ const CollapseButton = styled(Button)`
     cursor: pointer;
     flex-shrink: 0;
     padding: 0px;
-    width: 29px;
+    width: 27px;
     height: 26px;
     min-width: 26px;
     border-radius: 6px;
     display: flex;
     align-items: center;
     justify-content: center;
+    margin-top: 1px;
   }
 
   svg {


### PR DESCRIPTION
### Problem:
- The collapse button is not aligned with the question, and the follow-up search icon is not blue as specified.

## Issue ticket number and link:
- **Ticket Number:** [ 1893 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1893 ]

### closes: #1893

### Evidence:
 - Please see the attached video  and Images as evidence.
 
 https://www.loom.com/share/a215d19542514ff796c47cfaa8292345
 
 
![image](https://github.com/user-attachments/assets/5d35b781-4d10-4962-b0c7-f4ab77b3c129)
