### PR TITLE
[AddItemFlow]: Input Field Text Color Not `Readable`

### DIFF
--- a/src/components/AddItemModal/SetAttributesStep/index.tsx
+++ b/src/components/AddItemModal/SetAttributesStep/index.tsx
@@ -173,9 +173,4 @@ const StyledWrapper = styled(Flex)`
 const TextFieldWrapper = styled(Flex)`
   display: flex;
   gap: 10px;
-
-  #item-name {
-    color: ${colors.GRAY7};
-    -webkit-text-fill-color: ${colors.GRAY7};
-  }
 `


### PR DESCRIPTION
### Problem:
- The text color in the input field is not readable, making it difficult for users to see what they are typing. This issue affects user experience and accessibility.

closes: #1905

## Issue ticket number and link:
- **Ticket Number:** [ 1905 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1905]

### Evidence:
 - Please see the attached video as evidence.

https://www.loom.com/share/b4774c79650245f980b9cdf613e7754d

![image](https://github.com/user-attachments/assets/acd4d712-2880-4d55-b9de-9250473a1bf2)

### Acceptance Criteria
- [x]  The text color in the input field should be white to ensure readability.