### PR TITLE
When we search a long text in AI search bar due to that text side bar UI damage ( text should be wrapped in side bar)

### DIFF
--- a/src/components/App/SideBar/AiSummary/index.tsx
+++ b/src/components/App/SideBar/AiSummary/index.tsx
@@ -23,6 +23,9 @@ const Title = styled(Text)`
   font-size: 20px;
   font-weight: 600;
   flex-grow: 1;
+  overflow-wrap: break-word;
+  white-space: normal;
+  word-break: break-word;
 `
 
 const TitleWrapper = styled(Flex).attrs({
@@ -30,6 +33,8 @@ const TitleWrapper = styled(Flex).attrs({
   alignItems: 'center',
 })`
   padding: 24px 10px 24px 24px;
+  flex-shrink: 1;
+  overflow: hidden;
 `
 
 export const AiSummary = ({ question, response }: Props) => {


### PR DESCRIPTION
### Ticket №: #1911

closes #1911

### Problem:

When we search a lengthy string in AI search bar that text is damage the side bar View

### Evidence:

https://www.loom.com/share/3435143efff04668b6e1311bc3bff0a1?sid=7d58cbd6-f59c-4466-b828-6af5c15b6446
