### PR TITLE
AI Chat - `ScrollBar` is Cutoff on Top Side in AI Sources

### DIFF
--- a/src/components/App/SideBar/SidebarSubView/index.tsx
+++ b/src/components/App/SideBar/SidebarSubView/index.tsx
@@ -85,7 +85,7 @@ const CloseButton = styled(Flex)`
 
 const ScrollWrapper = styled(Flex)`
   flex: 1 1 100%;
-  border-radius: 16px;
+  border-radius: 0 0 16px 16px;
   overflow: hidden;
 `
 


### PR DESCRIPTION
### Problem:
- In the AI Chat interface, the scrollbar in the AI Sources section is cut off on the top side and extra space at the first element.

## Issue ticket number and link:
- **Ticket Number:** [ 1914 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1914 ]

### closes: #1914

### Evidence:
 - Please see the attached Image as evidence.

`Top Side:`

![image](https://github.com/user-attachments/assets/ef1a874b-aa6a-48e8-ac1f-73f00b5f92f6)

`Bottom Side:`

![image](https://github.com/user-attachments/assets/986cdde2-a65b-4bca-9632-9364baaff08b)

