### PR TITLE
Fixed: Highlight Damage to `SidebarSubView` UI in `[Tweet]`

### DIFF
--- a/src/components/App/SideBar/TwitData/index.tsx
+++ b/src/components/App/SideBar/TwitData/index.tsx
@@ -123,6 +123,10 @@ const TwitText = styled(Flex)`
   line-height: 130%;
   letter-spacing: -0.39px;
   margin: 8px 0;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  white-space: normal;
 `
 
 const StyledDivider = styled(Divider)`


### PR DESCRIPTION
### Problem:
- In the Tweet section, the `SidebarSubView` UI appears damaged when text is highlighted.

## Issue ticket number and link:
- **Ticket Number:** [ 1921 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1921 ]

### closes: #1921

### Evidence:
 - Please see the attached Image as evidence.
