### PR TITLE
Fixed: AI Chat - Clicking Logo After AI Search Does Not Route to Home Page

### DIFF
--- a/src/components/App/MainToolbar/index.tsx
+++ b/src/components/App/MainToolbar/index.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router-dom'
 import styled from 'styled-components'
 import AddContentIcon from '~/components/Icons/AddContentIcon'
 import AddSourceIcon from '~/components/Icons/AddSourceIcon'
@@ -7,12 +8,12 @@ import SettingsIcon from '~/components/Icons/SettingsIcon'
 import SourcesTableIcon from '~/components/Icons/SourcesTableIcon'
 import { Flex } from '~/components/common/Flex'
 import { Text } from '~/components/common/Text'
+import { useAiSummaryStore } from '~/stores/useAiSummaryStore'
 import { useFeatureFlagStore } from '~/stores/useFeatureFlagStore'
 import { useModal } from '~/stores/useModalStore'
 import { useUserStore } from '~/stores/useUserStore'
 import { colors } from '~/utils/colors'
 import { isSphinx } from '~/utils/isSphinx'
-import { useNavigate } from 'react-router-dom'
 
 export const MainToolbar = () => {
   const { open: openSourcesModal } = useModal('sourcesTable')
@@ -23,15 +24,21 @@ export const MainToolbar = () => {
   const { open: openFeedbackModal } = useModal('feedback')
   const navigate = useNavigate()
 
+  const { resetAiSummaryAnswer } = useAiSummaryStore()
   const customSchemaFeatureFlag = useFeatureFlagStore((s) => s.customSchemaFeatureFlag)
   const userFeedbackFeatureFlag = useFeatureFlagStore((s) => s.userFeedbackFeatureFlag)
 
   const [isAdmin] = useUserStore((s) => [s.isAdmin])
   const sphinxEnabled = isSphinx()
 
+  const handleLogoClick = () => {
+    resetAiSummaryAnswer()
+    navigate('/')
+  }
+
   return (
     <Wrapper>
-      <LogoButton onClick={() => navigate('/')}>
+      <LogoButton onClick={handleLogoClick}>
         <img alt="Second brain" src="logo.svg" />
       </LogoButton>
       {isAdmin ? (


### PR DESCRIPTION
### Problem:
- After performing an AI search in the AI Chat interface, clicking the logo does not navigate back to the Home page as expected.

closes: #1895

## Issue ticket number and link:
- **Ticket Number:** [ 1895 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1895 ]

### Evidence:

https://www.loom.com/share/eb8a1a617f9d42aaa141c180215c3598
