### PR TITLE
`TLDR` Background Allows Clicks Behind `Modals` and `Stats Bar`

### DIFF
--- a/src/components/App/AppBar/index.tsx
+++ b/src/components/App/AppBar/index.tsx
@@ -42,7 +42,7 @@ const Header = styled(Flex).attrs({
   left: 64px;
   right: 32px;
   transition: opacity 1s;
-  z-index: 99;
+  z-index: 1;
   padding: 20px 23px;
 `
 

--- a/src/components/App/MainToolbar/index.tsx
+++ b/src/components/App/MainToolbar/index.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router-dom'
 import styled from 'styled-components'
 import AddContentIcon from '~/components/Icons/AddContentIcon'
 import AddSourceIcon from '~/components/Icons/AddSourceIcon'
@@ -12,7 +13,6 @@ import { useModal } from '~/stores/useModalStore'
 import { useUserStore } from '~/stores/useUserStore'
 import { colors } from '~/utils/colors'
 import { isSphinx } from '~/utils/isSphinx'
-import { useNavigate } from 'react-router-dom'
 
 export const MainToolbar = () => {
   const { open: openSourcesModal } = useModal('sourcesTable')
@@ -86,7 +86,7 @@ const Wrapper = styled(Flex).attrs({
   justify: 'flex-start',
 })`
   flex: 0 0 64px;
-  z-index: 31;
+  z-index: 1;
   transition: opacity 1s;
   background: ${colors.BG2};
   position: relative;


### PR DESCRIPTION
### Problem:
- When the TLDR modal is open, the background is clickable, allowing interactions with elements behind the modal or stats bar.

closes: #1930

## Issue ticket number and link:
- **Ticket Number:** [ 1930 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1930 ]

### Evidence:

https://www.loom.com/share/75dd2d8bd2c245c5860a63e0c57db7b4

![image](https://github.com/user-attachments/assets/9136c882-a8d6-47ee-8d84-ab2185f1da68)
