### PR TITLE
`[AI Search]`:  Collapse Button `Overlaps` Search Text When Clicked

### DIFF
--- a/src/components/App/SideBar/index.tsx
+++ b/src/components/App/SideBar/index.tsx
@@ -204,19 +204,21 @@ const Content = forwardRef<HTMLDivElement, ContentProp>(({ subViewOpen }, ref) =
         </CollapseButton>
       )}
       <ScrollWrapper ref={componentRef}>
-        {!searchTerm && !hasAiChats && trendingTopicsFeatureFlag && (
-          <TrendingWrapper>
-            <Trending />
-          </TrendingWrapper>
-        )}
-        <Flex align="flex-start">
-          {hasAiChats ? (
+        {hasAiChats ? (
+          <Flex align="flex-start">
             <Flex p={24}>
               <Button onClick={handleCloseAi} startIcon={<ArrowBackIcon />}>
                 Home
               </Button>
             </Flex>
-          ) : null}
+          </Flex>
+        ) : null}
+        {!searchTerm && !hasAiChats && trendingTopicsFeatureFlag && (
+          <TrendingWrapper>
+            <Trending />
+          </TrendingWrapper>
+        )}
+        <Flex>
           {Object.keys(aiSummaryAnswers).map((i: string) => (
             <AiSummary key={i} question={i} response={aiSummaryAnswers[i]} />
           ))}


### PR DESCRIPTION
### Problem:
- When the collapse button is clicked, it `overlaps` with the search  Text.

closes: #1951

## Issue ticket number and link:
- **Ticket Number:** [ 1951 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1951 ]

### Evidence:

![image](https://github.com/user-attachments/assets/17a107ff-6b33-40fb-a6e7-ebb2bc40475a)

https://www.loom.com/share/6e9996ad5dfb4c9a9316cc96c13fa1e8

### Acceptance Criteria
- [x] The collapse button should not overlap with the search question text when clicked.