### PR TITLE
[AI Chat] - Update logic on matching webSocket request to query

### DIFF
--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -72,7 +72,7 @@ export const App = () => {
 
   const { fetchData, setCategoryFilter, setAbortRequests, addNewNode, filters } = useDataStore((s) => s)
 
-  const { setAiSummaryAnswer, getKeyExist } = useAiSummaryStore((s) => s)
+  const { setAiSummaryAnswer, getKeyExist, aiRefId } = useAiSummaryStore((s) => s)
 
   const setSelectedNode = useUpdateSelectedNode()
 
@@ -128,32 +128,32 @@ export const App = () => {
 
   const handleAiSummaryAnswer = useCallback(
     (data: AiSummaryAnswerResponse) => {
-      if (data.question && getKeyExist(data.question)) {
-        setAiSummaryAnswer(data.question, { answer: data.answer, answerLoading: false })
+      if (data.question && getKeyExist(aiRefId)) {
+        setAiSummaryAnswer(aiRefId, { answer: data.answer, answerLoading: false })
       }
     },
-    [setAiSummaryAnswer, getKeyExist],
+    [setAiSummaryAnswer, getKeyExist, aiRefId],
   )
 
   const handleAiRelevantQuestions = useCallback(
     (data: AiSummaryQuestionsResponse) => {
-      if (data.question && getKeyExist(data.question)) {
-        setAiSummaryAnswer(data.question, {
+      if (data.question && getKeyExist(aiRefId)) {
+        setAiSummaryAnswer(aiRefId, {
           questions: data.relevant_questions.map((i) => i.question),
           questionsLoading: false,
         })
       }
     },
-    [setAiSummaryAnswer, getKeyExist],
+    [setAiSummaryAnswer, getKeyExist, aiRefId],
   )
 
   const handleAiSources = useCallback(
     (data: AiSummarySourcesResponse) => {
-      if (data.question && getKeyExist(data.question)) {
-        setAiSummaryAnswer(data.question, { sources: data.sources.map((i) => i.ref_id), sourcesLoading: false })
+      if (data.question && getKeyExist(aiRefId)) {
+        setAiSummaryAnswer(aiRefId, { sources: data.sources.map((i) => i.ref_id), sourcesLoading: false })
       }
     },
-    [setAiSummaryAnswer, getKeyExist],
+    [setAiSummaryAnswer, getKeyExist, aiRefId],
   )
 
   const handleNewNodeCreated = useCallback(
@@ -167,11 +167,11 @@ export const App = () => {
 
   const handleExtractedEntities = useCallback(
     (data: ExtractedEntitiesResponse) => {
-      if (data.question && getKeyExist(data.question)) {
-        setAiSummaryAnswer(data.question, { answerLoading: false, entities: data.entities })
+      if (data.question && getKeyExist(aiRefId)) {
+        setAiSummaryAnswer(aiRefId, { answerLoading: false, entities: data.entities })
       }
     },
-    [setAiSummaryAnswer, getKeyExist],
+    [setAiSummaryAnswer, getKeyExist, aiRefId],
   )
 
   // setup socket


### PR DESCRIPTION
### Problem:
- Currently, we match the 4 websocket request with the user input e.g "who is satoshi?".
- Update logic to match answer, entities, relevant_questions and sources to use ref_id from query_data from the latest /graph/search request response the user used to render each component.

closes: #1958

## Issue ticket number and link:
- **Ticket Number:** [ 1958 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1958 ]

### Acceptance Criteria
- [x]  Using query_data ref_id should render the components