### PR TITLE
Fixed(AI-Search): Padding Between Question and Collapse Button

### DIFF
--- a/src/components/App/SideBar/AiSummary/index.tsx
+++ b/src/components/App/SideBar/AiSummary/index.tsx
@@ -26,6 +26,7 @@ const Title = styled(Text)`
   overflow-wrap: break-word;
   white-space: normal;
   word-break: break-word;
+  margin-right: 10px;
 `
 
 const TitleWrapper = styled(Flex).attrs({


### PR DESCRIPTION
### Problem:
- Add some space between the query and toggle. The question should wrap earlier:

closes: #1978

## Issue ticket number and link:
- **Ticket Number:** [ 1978 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1978 ]

### Evidence:

![image](https://github.com/user-attachments/assets/261e43ef-96a7-4e3c-ad09-af98769fc3fe)
