### PR TITLE
Fixed(AI-Chat): Tooltip is Consistently `Blanking Out` During Answer Generation

### DIFF
--- a/src/components/App/SideBar/AiSummary/utils/AiSummaryHighlight/index.tsx
+++ b/src/components/App/SideBar/AiSummary/utils/AiSummaryHighlight/index.tsx
@@ -1,7 +1,7 @@
-import styled, { keyframes, css } from 'styled-components'
-import { colors } from '~/utils'
-import { ExtractedEntity } from '~/types'
+import styled, { css, keyframes } from 'styled-components'
 import { Tooltip } from '~/components/common/ToolTip'
+import { ExtractedEntity } from '~/types'
+import { colors } from '~/utils'
 
 // Define a keyframe animation for highlighting from top-left to bottom-right
 const highlightAnimation = keyframes`
@@ -61,7 +61,7 @@ export function highlightAiSummary(
         const entity = entities.find((e) => e.entity.toLowerCase() === part.toLowerCase())
 
         if (entity) {
-          const uniqueKey = `${entity.entity}-${part}-${Math.random().toString(36).substr(2, 9)}`
+          const uniqueKey = `${entity.entity}-${entities.indexOf(entity)}`
 
           return (
             <StyledTooltip key={uniqueKey} content={entity.description}>


### PR DESCRIPTION
### Problem:
- The tooltip is consistently blanking out during the process of answer generation.

closes: #

## Issue ticket number and link:
- **Ticket Number:** [  ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/ ]

### Evidence:


### Acceptance Criteria
- [x] Tooltip remains visible and displays correct information throughout answer generation without blanking out.