### PR TITLE
[AI Chat]: `Listen` Button Behavior: Only One Button Plays at a Time

### DIFF
--- a/src/components/App/SideBar/AiSummary/index.tsx
+++ b/src/components/App/SideBar/AiSummary/index.tsx
@@ -47,7 +47,6 @@ export const AiSummary = ({ question, response, refId }: Props) => {
   const [collapsed, setCollapsed] = useState(false)
   const { setAiSummaryAnswer } = useAiSummaryStore((s) => s)
   const audioRef = useRef<HTMLAudioElement | null>(null)
-  const [isPlaying, setIsPlaying] = useState(false)
   const { currentPlayingAudio, setCurrentPlayingAudio } = useAppStore((s) => s)
 
   useEffect(() => {
@@ -60,7 +59,6 @@ export const AiSummary = ({ question, response, refId }: Props) => {
     const audioElement = audioRef.current
 
     const onAudioPlaybackComplete = () => {
-      setIsPlaying(false)
       setCurrentPlayingAudio(null)
     }
 
@@ -87,27 +85,23 @@ export const AiSummary = ({ question, response, refId }: Props) => {
 
   const handleToggleAudio = () => {
     if (audioRef.current) {
-      if (isPlaying) {
-        audioRef.current.pause()
-      } else {
+      if (audioRef.current.paused) {
         audioRef.current.play()
+        setCurrentPlayingAudio(audioRef)
+      } else {
+        audioRef.current.pause()
+        setCurrentPlayingAudio(null)
       }
-
-      setIsPlaying(!isPlaying)
     }
   }
 
   const togglePlay = () => {
-    const isBackgroundAudioPlaying = !currentPlayingAudio?.current?.paused
-
-    if (isBackgroundAudioPlaying) {
-      currentPlayingAudio?.current?.pause()
+    if (currentPlayingAudio?.current && currentPlayingAudio.current !== audioRef.current) {
+      currentPlayingAudio.current.pause()
       setCurrentPlayingAudio(null)
     }
 
-    if (currentPlayingAudio?.current?.src !== response.audio_en || !isBackgroundAudioPlaying) {
-      handleToggleAudio()
-    }
+    handleToggleAudio()
   }
 
   return (
@@ -115,7 +109,13 @@ export const AiSummary = ({ question, response, refId }: Props) => {
       <TitleWrapper>
         <Title ref={ref}>{question}</Title>
         {response.audio_en && (
-          <AudioButton onClick={togglePlay}>{isPlaying ? <AiPauseIcon /> : <AiPlayIcon />}</AudioButton>
+          <AudioButton onClick={togglePlay}>
+            {currentPlayingAudio?.current === audioRef.current && !audioRef.current?.paused ? (
+              <AiPauseIcon />
+            ) : (
+              <AiPlayIcon />
+            )}
+          </AudioButton>
         )}
         <CollapseButton onClick={toggleCollapse}>{collapsed ? <ChevronDownIcon /> : <ChevronUpIcon />}</CollapseButton>
       </TitleWrapper>


### PR DESCRIPTION
### Problem:
- When using the "Listen" button feature in the AI chat, only one audio can be played at a time. When a new "Listen" button is pressed, any currently playing audio stops.

## Issue ticket number and link:
- **Ticket Number:** [ 2019 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/2019 ]

### closes: #2019

### Evidence:
 - Please see the attached video  and Images as evidence.

https://www.loom.com/share/34b243ae9c9744b684349b210b5a80cb

### Acceptance Criteria
- [x] Multiple audio tracks should not be able to play simultaneously, or provide a clear indication that playing a new track will stop the current one.