### PR TITLE
Fixed [Graph-Tooltip]: Tooltip `scroll bar` is overflow from the `top and bottom` of the tooltip

### DIFF
--- a/src/components/Universe/Graph/Cubes/Cube/components/Tooltip/index.tsx
+++ b/src/components/Universe/Graph/Cubes/Cube/components/Tooltip/index.tsx
@@ -20,6 +20,14 @@ const Wrapper = styled(Flex)(({ theme }) => ({
   [theme.breakpoints.down('sm')]: {
     padding: theme.spacing(1, 1.5),
   },
+  '&::-webkit-scrollbar': {
+    width: '3px',
+  },
+  '&::-webkit-scrollbar-track': {
+    borderRadius: '8px',
+    margin: '8px',
+    overflowY: 'hidden',
+  },
 }))
 
 const Divider = styled(Flex)`


### PR DESCRIPTION
### Problem:
- The tooltip `scroll bar` is overflowing from the top and bottom of the tooltip

## Issue ticket number and link:
- **Ticket Number:** [ 2025 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/2025 ]

### closes: #2025

### Evidence:
 - Please see the attached video  and Images as evidence.

https://www.loom.com/share/34f02a71ae3d45c1b2296701201d239a

![image](https://github.com/user-attachments/assets/efa86900-fb03-4cad-80a9-26f901f2257e)

![image](https://github.com/user-attachments/assets/b3d6ac03-f549-4abf-94af-6c3a632e7a0a)

### Acceptance Criteria
- [x] The tooltip's scroll bar must be fully contained within the tooltip's boundaries, without any overflow.