### PR TITLE
[AI Chat]: Render `Entity` Highlight Only for the First Mention of a Node That Appears Multiple Times

### DIFF
--- a/src/components/App/SideBar/AiSummary/utils/AiSummaryHighlight/index.tsx
+++ b/src/components/App/SideBar/AiSummary/utils/AiSummaryHighlight/index.tsx
@@ -1,7 +1,7 @@
 import styled, { keyframes } from 'styled-components'
-import { colors } from '~/utils'
-import { ExtractedEntity } from '~/types'
 import { Tooltip } from '~/components/common/ToolTip'
+import { ExtractedEntity } from '~/types'
+import { colors } from '~/utils'
 
 // Define a keyframe animation for highlighting from top-left to bottom-right
 const highlightAnimation = keyframes`
@@ -63,12 +63,16 @@ export function highlightAiSummary(
     positionLeft = '50%'
   }
 
+  const highlightedEntities = new Set()
+
   return (
     <>
       {parts.map((part, index) => {
         const entity = entities.find((e) => e.entity.toLowerCase() === part.toLowerCase())
 
-        if (entity) {
+        if (entity && !highlightedEntities.has(entity.entity.toLowerCase())) {
+          highlightedEntities.add(entity.entity.toLowerCase())
+
           const uniqueKey = `${entity.entity}-${index}`
 
           return (


### PR DESCRIPTION
### Problem:
- Only the first mention of a node should be entity highlighted when it appears multiple times, but currently all mentions are highlighted.

![image](https://github.com/user-attachments/assets/165ff293-6452-428c-9e7d-78eb455775b7)

## Issue ticket number and link:
- **Ticket Number:** [ 2033 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/2033 ]

### closes: #2033

### Evidence:
 - Please see the attached video  and Image as evidence.

https://www.loom.com/share/6b7d2978df44420bb8618c25ef74c2bd

![image](https://github.com/user-attachments/assets/12b0e789-8761-4688-8b9e-fe143678fbe7)

![image](https://github.com/user-attachments/assets/990f42ef-d8d2-4fdc-81ff-ee1f4a54445e)

### Acceptance Criteria
- [x] Only the first occurrence of a node is entity highlighted when it appears multiple times.