### PR TITLE
[AI Chat]: After AI answers, `follow-up question search bar` moves to the left side

### DIFF
--- a/src/components/App/SideBar/AiSearch/index.tsx
+++ b/src/components/App/SideBar/AiSearch/index.tsx
@@ -41,7 +41,7 @@ export const AiSearch = () => {
               handleSubmit()
             }}
           >
-            {!isLoading ? <SearchIcon /> : <ClipLoader color={colors.lightGray} data-testid="loader" size="20" />}
+            {!isLoading ? <SearchIcon /> : <StyledClipLoader color={colors.lightGray} data-testid="loader" size="20" />}
           </InputButton>
         </Search>
       </FormProvider>
@@ -62,7 +62,6 @@ const Search = styled(Flex).attrs({
   align: 'center',
 })`
   flex-grow: 1;
-  margin-right: 10px;
 `
 
 const InputButton = styled(Flex).attrs({
@@ -84,4 +83,8 @@ const InputButton = styled(Flex).attrs({
   ${AiSearchWrapper} input:focus + & {
     color: ${colors.primaryBlue};
   }
+`
+
+const StyledClipLoader = styled(ClipLoader)`
+  margin-right: 10px;
 `


### PR DESCRIPTION
### Problem:
- - The follow-up question search bar moves to the left side of the interface after the AI provides an answer.

closes: #2014

## Issue ticket number and link:
- **Ticket Number:** [ 2014 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/2014 ]

### Evidence:
 - Please see the attached video and images as evidence.
 
 https://www.loom.com/share/2241abb3d876469aa7f143fcc8a74ae1
 
 `During Generating answer:`
 
![image](https://github.com/user-attachments/assets/3d0070c0-3a60-4ea6-86b0-b73f37e8e3cd)
 
 `After Generating answer:`
 
![image](https://github.com/user-attachments/assets/de218d16-e8a4-42e6-8f2c-53630b5bda63)

### Acceptance Criteria
- [x] The follow-up question search bar should remain in its original position and not shift to the left side of the interface after the AI answers a question.