### PR TITLE
Fixed [Ai Sources]: Sources title not bolded and padding is incorrect

### DIFF
--- a/src/components/App/SideBar/AiSummary/AiSources/index.tsx
+++ b/src/components/App/SideBar/AiSummary/AiSources/index.tsx
@@ -125,15 +125,20 @@ const Heading = styled(Flex)`
     .heading__count {
       font-weight: 400;
       color: ${colors.GRAY7};
-      margin-left: 16px;
+      margin-left: 12px;
+      line-height: 32px;
+      text-align: left;
       margin-bottom: 4px;
     }
 
     .tittle {
       margin-bottom: 4px;
       font-size: 14px;
-      font-weight: 400;
+      font-weight: 600;
       font-family: Barlow;
+      line-height: 32px;
+      text-align: left;
+      color: ${colors.white};
     }
   }
 `


### PR DESCRIPTION
### Problem:
- Bold sources title in AI chat feature and fix padding as per Figma.

closes: #2040

## Issue ticket number and link:
- **Ticket Number:** [ 2040 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/2040 ]

### Evidence:

![image](https://github.com/user-attachments/assets/1874cf7a-f8ec-4a9c-ad9e-5c1dab116e3a)

![image](https://github.com/user-attachments/assets/d065d092-6ece-4861-ab0f-e0fb622f4632)

![image](https://github.com/user-attachments/assets/36412f01-caff-449d-b23c-4ed77498fe7f)
