### PR TITLE
[AI Chat]: Active AI Question Does Not Turn Blue as per Figma Design

### DIFF
--- a/src/components/App/SideBar/AiSummary/AiQuestions/index.tsx
+++ b/src/components/App/SideBar/AiSummary/AiQuestions/index.tsx
@@ -117,6 +117,13 @@ const QuestionWrapper = styled(Flex)`
     }
   }
 
+  &:active {
+    color: ${colors.SECONDARY_BLUE};
+    .icon {
+      color: ${colors.SECONDARY_BLUE};
+    }
+  }
+
   .icon {
     font-size: 20px;
     color: ${colors.GRAY7};


### PR DESCRIPTION
### Problem:
- When the AI question is active (i.e., when you click on it), the expected behavior according to the Figma design is for the color to change to blue. However, this color change does not occur, and the AI question remains in its original color, which does not match the design specifications.

closes: #2048

## Issue ticket number and link:
- **Ticket Number:** [ 2048 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/2048 ]

### Evidence:


### Acceptance Criteria
- [x] The active AI question should change to blue, as outlined in the Figma design.
