### PR TITLE
Background of Tooltip at graph not visible

### DIFF
--- a/src/components/Universe/Graph/Cubes/Cube/components/Tooltip/index.tsx
+++ b/src/components/Universe/Graph/Cubes/Cube/components/Tooltip/index.tsx
@@ -11,7 +11,7 @@ import { TwitData } from './Tweet'
 const Wrapper = styled(Flex)(({ theme }) => ({
   width: '300px',
   pointerEvents: 'auto',
-  background: colors.dashboardHeader,
+  background: colors.BG3,
   boxShadow: '0px 1px 6px rgba(0, 0, 0, 0.1)',
   color: colors.primaryText1,
   maxHeight: '400px',


### PR DESCRIPTION
### Ticket №: #2050


closes #2050


### Problem:

Tooltip background is not visible when we hover over the node in graph

### Evidence:

![image](https://github.com/user-attachments/assets/8928468f-d4c3-486c-9a1c-e81d1f9daaa3)

