### PR TITLE
Tapping on Trending topics or Learn more should use tldr_topic

### DIFF
--- a/src/components/App/SideBar/Trending/BriefDescriptionModal/index.tsx
+++ b/src/components/App/SideBar/Trending/BriefDescriptionModal/index.tsx
@@ -34,7 +34,7 @@ export const BriefDescription: FC<Props> = ({ trend, onClose }) => {
 
   const handleLearnMore = async () => {
     handleClose()
-    await fetchData(setBudget, setAbortRequests, trend.name)
+    await fetchData(setBudget, setAbortRequests, trend.tldr_topic ?? trend.name)
   }
 
   const handleClose = useCallback(() => {

--- a/src/components/App/SideBar/Trending/index.tsx
+++ b/src/components/App/SideBar/Trending/index.tsx
@@ -205,7 +205,7 @@ export const Trending = () => {
                 className="list-item"
                 direction="row"
                 justify="space-between"
-                onClick={() => selectTrending(i.name)}
+                onClick={() => selectTrending(i.tldr_topic ?? i.name)}
               >
                 <Paragraph>
                   <IconWrapper>


### PR DESCRIPTION
### Ticket №: #2054

closes #2054

### Problem:

Tapping on a trending topic or the TLDR and tapping Learn more should execute tldr_topic FIRST and if unavailable use name

### Evidence:

https://www.loom.com/share/ba8b3321f6aa4e40b1a75f3e1b2801b6?sid=798a46c0-d81a-496f-9321-04a482a04598
