### PR TITLE
[Ai Chat]: Generated AI Answer `Overflowing` Sidebar

### DIFF
--- a/src/components/App/SideBar/AiSummary/AiAnswer/index.tsx
+++ b/src/components/App/SideBar/AiSummary/AiAnswer/index.tsx
@@ -19,6 +19,9 @@ const Wrapper = styled(Flex).attrs({
 })`
   padding: 0 1.5rem 1.5rem;
   gap: 1rem;
+  overflow-wrap: break-word;
+  white-space: normal;
+  word-break: break-word;
 `
 
 const SummaryText = styled(Text)`


### PR DESCRIPTION
### Problem:
- The generated answer extends beyond the main content area and overlaps into the sidebar, causing layout issues.

closes: #2057

## Issue ticket number and link:
- **Ticket Number:** [ 2057 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/2057 ]

### Evidence:
 - Please see the attached video and images as evidence.
 
 https://www.loom.com/share/ef98cb87ad914b09b33a8051f4f8dba6

![image](https://github.com/user-attachments/assets/d63b1d68-4308-45c3-8229-94d7e692dcdd)

### Acceptance Criteria
- [x]  The AI-generated answer should be contained within the main content area without overlapping or affecting the sidebar.