### PR TITLE
Fixed[AI Chat]: Highlighted Text Background Does Not Turn Transparent Blue After Click

### DIFF
--- a/src/components/App/SideBar/AiSummary/utils/AiSummaryHighlight/index.tsx
+++ b/src/components/App/SideBar/AiSummary/utils/AiSummaryHighlight/index.tsx
@@ -1,7 +1,7 @@
 import styled, { keyframes } from 'styled-components'
-import { colors } from '~/utils'
-import { ExtractedEntity } from '~/types'
 import { Tooltip } from '~/components/common/ToolTip'
+import { ExtractedEntity } from '~/types'
+import { colors } from '~/utils'
 
 // Define a keyframe animation for highlighting from top-left to bottom-right
 const highlightAnimation = keyframes`
@@ -29,6 +29,12 @@ const Highlight = styled.span<{ animate: boolean }>`
     text-decoration: underline;
     cursor: pointer;
     animation: none;
+  }
+
+  &:active {
+    background-color: ${colors.AI_HIGHLIGHT};
+    border-radius: 4px;
+    text-decoration: none;
   }
 `
 

--- a/src/utils/colors/index.tsx
+++ b/src/utils/colors/index.tsx
@@ -98,6 +98,7 @@ export const colors = {
   SEEDQUESTION: 'rgba(47, 58, 89, 1)',
   SEEDQUESTION_HOVER: 'rgba(38, 42, 58, 1)',
   COLLAPSE_BUTTON: 'rgba(48, 51, 66, 1)',
+  AI_HIGHLIGHT: 'rgba(0, 123, 255, 0.1)',
 } as const
 
 export type ColorName = keyof typeof colors


### PR DESCRIPTION
### Problem:
- Clicking to highlight text does not change the background to the expected transparent blue, as specified in the Figma design.

**Figma Design:**

https://www.figma.com/design/YuEbi4x32Mm8ZQJdnrs4uc/Second-Brain-Final-Designs?node-id=8664-35066&t=yupg8RsPFpoKO4IR-4

![image](https://github.com/user-attachments/assets/f18b4f0e-9ecf-4f28-96f3-62e648671209)

closes: #2081

## Issue ticket number and link:
- **Ticket Number:** [ 2081 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/2081 ]

### Evidence:

https://www.loom.com/share/24e9847666754b0eb5d022b29dfc3243

### Acceptance Criteria
- [x]  Highlighted text background changes to the specified transparent blue after click, matching the Figma design.
