### PR TITLE
cypress: added wait for @latest because graph will not load otherwise

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -63,8 +63,7 @@ Cypress.Commands.add('initialSetup', (username, budget) => {
   })
 
   cy.wait(20000)
-
+  cy.wait(['@loadLatest'])
   cy.get('[data-testid="explore-graph-btn"]').click()
-
   cy.wait(['@loadAbout', '@loadStats', '@getTrends'])
 })


### PR DESCRIPTION
### Ticket №:

none

### Problem:
On Jarvis backend we are getting failures for curration and I suspect it is because we are not waiting for the latest call
### Solution:

what was the solution?

### Changes:

I just added a cypress wait for

`https://knowledge-graph-test.sphinx.chat/api/prediction/graph/search?skip=0&limit=300&depth=2&sort_by=date_added_to_graph&include_properties=true&top_node_count=50&includeContent=true&ai_summary=false&free=true&sig=&msg=`

### Testing:

I noticed if I tried to load the graph but block this endpoint
`https://knowledge-graph-test.sphinx.chat/api/prediction/graph/search?skip=0&limit=300&depth=2&sort_by=date_added_to_graph&include_properties=true&top_node_count=50&includeContent=true&ai_summary=false&free=true&sig=&msg=`

It wont load so I suspect that this is causing intermittent failures on jarvis-backend because it is taking long to load

### Notes:
none