### PR TITLE
tests: increase timeout to 30 second

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -64,6 +64,6 @@ Cypress.Commands.add('initialSetup', (username, budget) => {
 
   cy.wait(20000)
   cy.wait(['@loadLatest'])
-  cy.get('[data-testid="explore-graph-btn"]').click()
+  cy.get('[data-testid="explore-graph-btn"]', { timeout: 30000 }).should('be.visible').click()
   cy.wait(['@loadAbout', '@loadStats', '@getTrends'])
 })


### PR DESCRIPTION
I want to try and increase this timeout to 30 seconds to see if it will help solve the jarvis backend issues we've been seeing