### PR TITLE
Confirm and Delete Buttons Disappear in "Create Node" and "Edit Node" in BluePrint Modal 

### DIFF
--- a/src/components/ModalsContainer/BlueprintModal/Body/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/index.tsx
@@ -259,6 +259,7 @@ const InnerEditorWrapper = styled.div`
   height: 100%;
   overflow-y: auto;
   padding: 16px;
+  max-height: calc(90vh - 20px);
 `
 
 const Container = styled(Flex)`


### PR DESCRIPTION
### Problem:
- In the BluePrint graph, both the "Confirm" and "Delete" buttons are not visible in the following scenarios:
   - When creating a new node.
    - When editing an existing node.

closes: #2099

## Issue ticket number and link:
- **Ticket Number:** [ 2099 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/2099 ]

### Evidence:

https://www.loom.com/share/b920367233e340c59bfdedaa0a6bfe32

![image](https://github.com/user-attachments/assets/a3a1add6-db3d-4138-a3bc-8c2bfbe654e0)

![image](https://github.com/user-attachments/assets/530ce714-11b9-4016-b789-8822d3e91beb)

### Acceptance Criteria
- [x] "Confirm" and "Delete" buttons must be visible and functional in both "Create Node" and "Edit Node" scenarios in the BluePrint graph.