### PR TITLE
Hide Audio EN Section: Audio Already Displayed with Text Section

### DIFF
--- a/src/components/App/SideBar/SelectedNodeView/Default/index.tsx
+++ b/src/components/App/SideBar/SelectedNodeView/Default/index.tsx
@@ -118,7 +118,7 @@ const NodeDetail = ({ label, value, hasAudio, isPlaying, togglePlay }: Props) =>
   const isLong = (value as string).length > 140
   const searchTerm = useAppStore((s) => s.currentSearch)
 
-  if (!value) {
+  if (!value || label === 'Audio EN') {
     return null
   }
 


### PR DESCRIPTION
### Problem:
- The Audio EN section is visible even though the audio is already displayed with the text section.

closes: #2103

## Issue ticket number and link:
- **Ticket Number:** [ 2103 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/2103 ]

### Evidence:

![image](https://github.com/user-attachments/assets/c1706994-135e-42c0-880c-ad56da329d70)

### Acceptance Criteria
- [x]  Audio EN section should be hidden when audio is displayed with the text.