### PR TITLE
 Fixed(BluePrint): Resolve Scrolling Issues for New Node Type Creation

### DIFF
--- a/src/components/ModalsContainer/BlueprintModal/Body/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/index.tsx
@@ -260,6 +260,18 @@ const InnerEditorWrapper = styled.div`
   overflow-y: auto;
   padding: 16px;
   max-height: calc(90vh - 20px);
+
+  @media (max-width: 1440px) {
+    max-height: calc(85vh - 20px);
+  }
+
+  @media (max-width: 1024px) {
+    max-height: calc(65vh - 20px);
+  }
+
+  @media (max-width: 924px) {
+    max-height: calc(65vh - 20px);
+  }
 `
 
 const Container = styled(Flex)`


### PR DESCRIPTION
### Problem:
- The Blueprint Modal in the Ontology section was not fully responsive, causing scrolling issues when trying to create a new node type on smaller screens.

closes: #2105

## Issue ticket number and link:
- **Ticket Number:** [ 2105 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/2105 ]

### Evidence:

https://www.loom.com/share/6fc042d0a71e49828116b19e0eb1ddcc

### Acceptance Criteria
- [x] Update the Blueprint Modal to be fully responsive across different screen sizes
- [x] Ensure that users can scroll down to create new node types on smaller screens
- [x] Maintain the existing layout and functionality for larger screens
- [x] Verify that the changes do not introduce new layout issues in other parts of the modal