### PR TITLE
Toggle section should be aligned

### DIFF
--- a/src/components/ModalsContainer/BlueprintModal/Body/Editor/MediaOptions/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Editor/MediaOptions/index.tsx
@@ -65,7 +65,9 @@ const StyledFlex = styled(Flex)`
 
 const StyledFormControlLabel = styled(FormControlLabel)`
   justify-content: space-between;
-  margin: 8px 0;
+  margin-left: 2px !important;
+  margin-top: 8px;
+  margin-bottom: 8px;
 `
 
 const StyledLabel = styled.span<{ active: boolean }>`


### PR DESCRIPTION
### Ticket №: #2107

closes #2107

### Problem:

At create new node type sidebar video, image and source link toggles are not aligned with other content of the sidebar

### Evidence:

![image](https://github.com/user-attachments/assets/93ab5422-a24d-4322-add4-591f74cfc33c)
