### PR TITLE
Fix [Cypress]:  Chromium Renderer crash by optimizing memory management

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -23,6 +23,8 @@ export default defineConfig({
       // with any changed environment variables
       return config
     },
+    experimentalMemoryManagement: true,
+    numTestsKeptInMemory: 0,
     viewportHeight: 900,
     viewportWidth: 1440,
     watchForFileChanges: false,


### PR DESCRIPTION
### Problem:

![image](https://github.com/user-attachments/assets/41ce8e67-2539-4e7d-b826-5baa50e54cf4)


