### PR TITLE
Fixed [Blueprint] : `Not Selected` Labels Displayed  In `Indexes` When Adding Multiple Attributes fields

### DIFF
--- a/src/components/ModalsContainer/BlueprintModal/Body/Editor/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Editor/index.tsx
@@ -255,7 +255,7 @@ export const Editor = ({
   const attributesValue = watch('attributes')
 
   const attributes: Attribute[] = useMemo(
-    () => (isAttributeArray(attributesValue) ? attributesValue : []),
+    () => (isAttributeArray(attributesValue) ? attributesValue.filter((attr) => attr.key.trim() !== '') : []),
     [attributesValue],
   )
 


### PR DESCRIPTION
### Problem:
- When adding multiple attribute fields, `Not Selected` labels appear in the `Indexes` for unfilled fields.

![image](https://github.com/user-attachments/assets/8bf5b753-a233-4151-b897-cb3945b1b2ad)


## Issue ticket number and link:
- **Ticket Number:** [ 2123 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/2123 ]

closes: #2123

### Evidence:

https://www.loom.com/share/eeeb12ed20fb4825b842c2e151f9fc2b

![image](https://github.com/user-attachments/assets/27afd8c5-d3a0-4922-965a-dc2477fe9a0f)

### Acceptance Criteria
- [x] Only filled attribute fields are shown in the `Indexes` section