### PR TITLE
Fixed [BluePrint]: `Create Type` Modal `Confirm` Button Enabled Without Selecting `Parent`

### DIFF
--- a/src/components/ModalsContainer/BlueprintModal/Body/Editor/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Editor/index.tsx
@@ -367,11 +367,12 @@ export const Editor = ({
         isMatch
 
       const isValidType = !!values.type?.trim()
+      const isValidParent = !!values.parent?.trim()
 
       setSubmitDisabled(
         selectedSchema
           ? loading || !isChanged || !isValidType || displayParentError
-          : loading || displayParentError || !isValidType,
+          : loading || displayParentError || !isValidType || !isValidParent,
       )
     })
 


### PR DESCRIPTION
### Problem:
- The `Create Type` modal confirm button is enabled even when no Parent is selected, which allows submission without the necessary input.

closes: #2133

## Issue ticket number and link:
- **Ticket Number:** [ 2133 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/2133 ]

### Evidence:

![image](https://github.com/user-attachments/assets/7f7a73d4-edbe-408e-a110-c7cf0593cf56)

https://www.loom.com/share/f39f47346b504b12b1f54f17d97a51a9

### Acceptance Criteria
- [x]  The `Create Type` modal confirm button should be disabled until a Parent is selected, and enabled only when a valid Parent is chosen.