### PR TITLE
Fixed[Source Table]: Update `View Content` Tab name to `My Content` to match Figma design

### DIFF
--- a/src/components/SourcesTableModal/SourcesView/__tests__/index.tsx
+++ b/src/components/SourcesTableModal/SourcesView/__tests__/index.tsx
@@ -3,11 +3,11 @@ import '@testing-library/jest-dom'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
+import { isSphinx } from '~/utils/isSphinx'
 import { SourcesView } from '..'
+import { getNodeContent } from '../../../../network/fetchSourcesData'
 import { useFeatureFlagStore } from '../../../../stores/useFeatureFlagStore'
 import { useUserStore } from '../../../../stores/useUserStore'
-import { getNodeContent } from '../../../../network/fetchSourcesData'
-import { isSphinx } from '~/utils/isSphinx'
 
 jest.mock('~/utils/isSphinx', () => ({
   isSphinx: jest.fn(),
@@ -72,14 +72,14 @@ describe('Test SourceView', () => {
     expect(queryByText('Queued sources')).not.toBeInTheDocument()
   })
 
-  it('should render the "View Content" tab correctly', () => {
+  it('should render the "My Content" tab correctly', () => {
     isSphinxMock.mockReturnValue(true)
 
     render(<SourcesView />)
 
-    const viewContentTab = screen.getByRole('tab', { name: 'View Content' })
+    const myContentTab = screen.getByRole('tab', { name: 'My Content' })
 
-    expect(viewContentTab).toBeInTheDocument()
+    expect(myContentTab).toBeInTheDocument()
   })
 
   it('should only render Sphinx-related content for Sphinx users', () => {
@@ -138,8 +138,8 @@ describe('Test SourceView', () => {
     render(<SourcesView />)
 
     waitFor(async () => {
-      const viewContentTab = screen.getByRole('tab', { name: 'View Content' })
-      fireEvent.click(viewContentTab)
+      const myContentTab = screen.getByRole('tab', { name: 'My Content' })
+      fireEvent.click(myContentTab)
 
       const tweetRow = await screen.findByText('123456789')
       const articleRow = await screen.findByText('http://examplearticle.com')
@@ -160,8 +160,8 @@ describe('Test SourceView', () => {
     it('should render the correct node type for each row', async () => {
       render(<SourcesView />)
       waitFor(async () => {
-        const viewContentTab = screen.getByRole('tab', { name: 'View Content' })
-        fireEvent.click(viewContentTab)
+        const myContentTab = screen.getByRole('tab', { name: 'My Content' })
+        fireEvent.click(myContentTab)
 
         const tweetType = await screen.findByText('Tweet')
         const articleType = await screen.findByText('Article')
@@ -174,8 +174,8 @@ describe('Test SourceView', () => {
     it('should render the correct source for each row', async () => {
       render(<SourcesView />)
       waitFor(async () => {
-        const viewContentTab = screen.getByRole('tab', { name: 'View Content' })
-        fireEvent.click(viewContentTab)
+        const myContentTab = screen.getByRole('tab', { name: 'My Content' })
+        fireEvent.click(myContentTab)
 
         const tweetId = await screen.findByText('123456789')
         const articleLink = await screen.findByText('http://examplearticle.com')
@@ -188,8 +188,8 @@ describe('Test SourceView', () => {
     it('should render the correct date for each row', async () => {
       render(<SourcesView />)
       waitFor(async () => {
-        const viewContentTab = screen.getByRole('tab', { name: 'View Content' })
-        fireEvent.click(viewContentTab)
+        const myContentTab = screen.getByRole('tab', { name: 'My Content' })
+        fireEvent.click(myContentTab)
 
         const tweetDate = await screen.findByText('4/4/2021')
         const articleDate = await screen.findByText('5/4/2021')
@@ -202,8 +202,8 @@ describe('Test SourceView', () => {
     it('should render the correct status for each row', async () => {
       render(<SourcesView />)
       waitFor(async () => {
-        const viewContentTab = screen.getByRole('tab', { name: 'View Content' })
-        fireEvent.click(viewContentTab)
+        const myContentTab = screen.getByRole('tab', { name: 'My Content' })
+        fireEvent.click(myContentTab)
 
         const tweetStatus = await screen.findByText('complete')
         const articleStatus = await screen.findByText('pending')

--- a/src/components/SourcesTableModal/SourcesView/constants.ts
+++ b/src/components/SourcesTableModal/SourcesView/constants.ts
@@ -1,7 +1,7 @@
+import { IconButton } from '@mui/material'
+import styled from 'styled-components'
 import { RSS, TWITTER_HANDLE, YOUTUBE_CHANNEL } from '~/constants'
 import { ISourceMap } from './types'
-import styled from 'styled-components'
-import { IconButton } from '@mui/material'
 
 export const sourcesMapper: ISourceMap = {
   [RSS]: 'RSS link',
@@ -12,7 +12,7 @@ export const sourcesMapper: ISourceMap = {
 export const SOURCE_TABLE = 'Sources Table'
 export const QUEUED_SOURCES = 'Queued Sources'
 export const TOPICS = 'Topics'
-export const VIEW_CONTENT = 'View Content'
+export const MY_CONTENT = 'My Content'
 
 export const DATE = 'date'
 export const EDGE_COUNT = 'edge_count'

--- a/src/components/SourcesTableModal/SourcesView/index.tsx
+++ b/src/components/SourcesTableModal/SourcesView/index.tsx
@@ -11,7 +11,7 @@ import { isSphinx } from '~/utils/isSphinx'
 import { QueuedSources } from './QueuedSources'
 import { Sources } from './Sources'
 import { TopicSources } from './Topics'
-import { QUEUED_SOURCES, SOURCE_TABLE, TOPICS, VIEW_CONTENT } from './constants'
+import { MY_CONTENT, QUEUED_SOURCES, SOURCE_TABLE, TOPICS } from './constants'
 
 interface TabPanelProps {
   children?: React.ReactNode
@@ -20,7 +20,7 @@ interface TabPanelProps {
 }
 
 const tabsData = [
-  { label: VIEW_CONTENT, component: Content },
+  { label: MY_CONTENT, component: Content },
   { label: SOURCE_TABLE, component: Sources },
   { label: QUEUED_SOURCES, component: QueuedSources },
   { label: TOPICS, component: TopicSources },
@@ -68,7 +68,7 @@ export const SourcesView = () => {
       return isAdmin && queuedSourcesFeatureFlag
     }
 
-    if (label === VIEW_CONTENT) {
+    if (label === MY_CONTENT) {
       return sphinxEnabled
     }
 


### PR DESCRIPTION
### Problem:
- The Source Table " View Content" Tab needs to be renamed to `My Content` as per the Figma design.

closes: #2139

## Issue ticket number and link:
- **Ticket Number:** [ 2139 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/2139 ]

### Evidence:

![image](https://github.com/user-attachments/assets/4a26cf6a-19c7-4fe2-97c3-275b75d3e5ec)

### Acceptance Criteria:
- [x] Rename the `View Content` Tab in the Source Table to `My Content.`

### Unit Test:

![image](https://github.com/user-attachments/assets/bf8a0921-dc81-4cbb-b4dd-6adbfdd5adfd)
