### PR TITLE
[Graph]:  Not Reset to Default Mode After Clicking Home/Logo Button Following Answer Generation

### DIFF
--- a/src/components/App/AppBar/index.tsx
+++ b/src/components/App/AppBar/index.tsx
@@ -1,18 +1,18 @@
+import { useNavigate } from 'react-router-dom'
 import styled from 'styled-components'
 import { Flex } from '~/components/common/Flex'
 import { Text } from '~/components/common/Text'
 import { Stats } from '~/components/Stats'
+import { useAiSummaryStore } from '~/stores/useAiSummaryStore'
 import { useAppStore } from '~/stores/useAppStore'
+import { useDataStore } from '~/stores/useDataStore'
 import { colors } from '~/utils/colors'
 import { media } from '~/utils/media'
-import { useAiSummaryStore } from '~/stores/useAiSummaryStore'
-import { useDataStore } from '~/stores/useDataStore'
-import { useNavigate } from 'react-router-dom'
 
 export const AppBar = () => {
   const appMetaData = useAppStore((s) => s.appMetaData)
   const { resetAiSummaryAnswer, setNewLoading } = useAiSummaryStore()
-  const { abortFetchData } = useDataStore((s) => s)
+  const { abortFetchData, resetGraph } = useDataStore((s) => s)
   const navigate = useNavigate()
 
   if (!appMetaData) {
@@ -22,6 +22,7 @@ export const AppBar = () => {
   const handleLogoClick = () => {
     setNewLoading(null)
     abortFetchData()
+    resetGraph()
     resetAiSummaryAnswer()
     navigate('/')
   }

--- a/src/stores/useDataStore/index.ts
+++ b/src/stores/useDataStore/index.ts
@@ -259,6 +259,7 @@ export const useDataStore = create<DataStore>()(
     resetGraph: () => {
       set({
         filters: defaultData.filters,
+        dataInitial: null,
         dataNew: null,
       })
 


### PR DESCRIPTION
### Problem:
- After the AI generates a result and displays a graph, clicking the `Home/Logo` and `Logo Text` button causes both the initial default graph and the AI-generated result graph to appear simultaneously, instead of resetting to the default graph view. 

closes: #2146

## Issue ticket number and link:
- **Ticket Number:** [ 2146 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/2146 ]

### Evidence:

https://www.loom.com/share/9723511e994b4f41abb38ed46f15fa69

### Acceptance Criteria
- [x] The graph should reset to its default mode whenever the `Home` button or the `Logo` and `Logo Text` is clicked after answer generation.