### PR TITLE
When the Add Edge sidebar already open and then if we select a particular edge name then the source and destination are not auto selected

### DIFF
--- a/src/components/ModalsContainer/BlueprintModal/Body/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/index.tsx
@@ -194,9 +194,18 @@ export const Body = ({ Close }: BodyProps) => {
                 links={filteredLinks}
                 onEdgeClick={(refId, edgeType, source, target) => {
                   setEdgeData({ refId, edgeType, source, target })
-                  setIsAddEdgeNode(true)
-                  setIsCreateNew(false)
-                  setSelectedSchemaId('')
+
+                  if (!isAddEdgeNode) {
+                    setIsAddEdgeNode(true)
+                    setIsCreateNew(false)
+                    setSelectedSchemaId('')
+                  } else {
+                    setIsAddEdgeNode(false)
+
+                    setTimeout(() => {
+                      setIsAddEdgeNode(true)
+                    }, 200)
+                  }
                 }}
                 schemasWithPositions={schemasWithChildren}
                 selectedSchemaId={selectedSchemaId}


### PR DESCRIPTION
### Ticket №: #2149

closes #2149

### Problem:

When the Add Edge sidebar already open and then if we select a particular edge name then the source and destination are not auto selected

### Evidence:

https://www.loom.com/share/f9a935fae4e74f0098549274e148d6c4?sid=f078c5b3-a0c6-4ecd-8acc-a7a636ca918c
