### PR TITLE
At Create Type and Edit Type sidebar when we click on Confirm Button then loading start but buttons not turned to grayed disable

### DIFF
--- a/src/components/ModalsContainer/BlueprintModal/Body/Editor/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Editor/index.tsx
@@ -542,7 +542,7 @@ export const Editor = ({
 
               <CustomButton
                 color="secondary"
-                disabled={submitDisabled}
+                disabled={submitDisabled || loading}
                 onClick={onSubmit}
                 size="large"
                 variant="contained"


### PR DESCRIPTION
### Ticket №: #2160

closes #2160

### Problem:

At Create Type and Edit Type sidebar when we click on Confirm Button then loading start but buttons not turned to grayed disable

### Evidence:

https://www.loom.com/share/f2ac9b4078cc4164a2d1fb704d817ddf?sid=33ca2f1d-5e87-47ea-93f9-509586861fce




