### PR TITLE
Source and node slider update

### DIFF
--- a/src/components/App/SideBar/FilterSearch/MaxResults/index.tsx
+++ b/src/components/App/SideBar/FilterSearch/MaxResults/index.tsx
@@ -1,5 +1,7 @@
 import { Slider } from '@mui/material'
 import { HeadingWrapper, PopoverBody, SourceNodesStepWrapper, SubHeading, VolumeControl } from '../index'
+import styled from 'styled-components'
+import { colors } from '~/utils'
 
 type MaxResultsProps = {
   maxResults: number
@@ -21,22 +23,29 @@ export const MaxResults = ({ maxResults, setMaxResults }: MaxResultsProps) => {
       </HeadingWrapper>
       <PopoverBody>
         <SourceNodesStepWrapper>
-          <span>1</span>
-          <span>{maxResults}</span>
+          <span>0</span>
+          <span>300</span>
         </SourceNodesStepWrapper>
         <VolumeControl direction="row">
-          <Slider
+          <CustomSlider
             className="volume-slider"
             data-testid="max-results-slider"
             max={300}
-            min={1}
+            min={0}
             onChange={MaxResultsChangeHandler}
             size="medium"
             step={1}
             value={maxResults}
+            valueLabelDisplay="on"
           />
         </VolumeControl>
       </PopoverBody>
     </>
   )
 }
+
+const CustomSlider = styled(Slider)({
+  '& .MuiSlider-valueLabel': {
+    backgroundColor: `${colors.primaryBlue}`
+  },
+})

--- a/src/components/App/SideBar/FilterSearch/SourceNodes/index.tsx
+++ b/src/components/App/SideBar/FilterSearch/SourceNodes/index.tsx
@@ -1,4 +1,6 @@
 import { Slider } from '@mui/material'
+import styled from 'styled-components'
+import { colors } from '~/utils/colors'
 import { HeadingWrapper, PopoverBody, SourceNodesStepWrapper, SubHeading, VolumeControl } from '../index'
 
 type SourceNodesProps = {
@@ -21,22 +23,29 @@ export const SourceNodes = ({ sourceNodes, setSourceNodes }: SourceNodesProps) =
       </HeadingWrapper>
       <PopoverBody>
         <SourceNodesStepWrapper>
-          <span>1</span>
-          <span>{sourceNodes}</span>
+          <span>0</span>
+          <span>100</span>
         </SourceNodesStepWrapper>
         <VolumeControl direction="row">
-          <Slider
+          <CustomSlider
             className="volume-slider"
             data-testid="source-nodes-slider"
             max={100}
-            min={1}
+            min={0}
             onChange={SourceNodesChangeHandler}
             size="medium"
             step={1}
             value={sourceNodes}
+            valueLabelDisplay="on"
           />
         </VolumeControl>
       </PopoverBody>
     </>
   )
 }
+
+const CustomSlider = styled(Slider)({
+  '& .MuiSlider-valueLabel': {
+    backgroundColor: `${colors.primaryBlue}`,
+  },
+})


### PR DESCRIPTION
### Ticket №: #2162

closes #2162

### Problem: 

Allow user to select minimum value of 0 for source nodes and max results (Current Min = 1)
The right hand side should not change, it should show the limit
Source nodes: right hand side fixed at 100
Max Results: right hand side fixed at 300

### Evidence: 



![image](https://github.com/user-attachments/assets/7e1dc3d3-2cb5-4fb9-9b41-7ca4fc633a6d)



