### PR TITLE
Fix[FilterSearch]: Bottom Slider Issue When Maxing Filter 

### DIFF
--- a/src/components/App/SideBar/FilterSearch/index.tsx
+++ b/src/components/App/SideBar/FilterSearch/index.tsx
@@ -352,6 +352,7 @@ export const VolumeControl = styled(Flex)`
       background-color: ${colors.black};
     }
     .MuiSlider-thumb {
+      overflow-x: hidden;
       width: 20px;
       height: 20px;
       background-color: ${colors.white};


### PR DESCRIPTION
### Problem:
- Maxing the `source nodes` or `max results` shouldn't cause the bottom slider to appear:

## Issue ticket number and link:
- **Ticket Number:** [ 2163 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/2163 ]

### closes: #2163

### Evidence:

![image](https://github.com/user-attachments/assets/046f8fac-7580-41d3-8fdb-5e3bfe1e7e6c)
