### PR TITLE
[BluePrint] - Parent , source and destination node types in dropdown should be unique ( for safety we should put check on frontend side too )

### DIFF
--- a/src/components/ModalsContainer/BlueprintModal/Body/AddEdgeNode/Title/ToNode/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/AddEdgeNode/Title/ToNode/index.tsx
@@ -49,13 +49,14 @@ export const ToNode: FC<Props> = ({ onSelect, dataTestId, edgeLink, hideSelectAl
         const schemaOptions = data.schemas
           .filter((schema) => !schema.is_deleted && schema.type)
           .map((schema) =>
-            schema?.type === 'thing'
+            schema.type === 'thing'
               ? { label: 'No Parent', value: schema.type }
               : {
                   label: capitalizeFirstLetter(schema.type),
                   value: schema.type,
                 },
           )
+          .filter((option, index, self) => index === self.findIndex((o) => o.value === option.value))
 
         const allOption = { label: 'Select all', value: 'all' }
 

--- a/src/components/ModalsContainer/BlueprintModal/Body/Editor/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Editor/index.tsx
@@ -147,11 +147,13 @@ const fetchAndSetOptions = async (
       (schema) => !schema.is_deleted && schema.type && (!filterFunc || filterFunc(schema)),
     )
 
-    const options = filteredSchemas.map((schema) =>
-      schema.type === 'thing'
-        ? { label: 'No Parent', value: schema.type }
-        : { label: capitalizeFirstLetter(schema.type), value: schema.type },
-    )
+    const options = filteredSchemas
+      .map((schema) =>
+        schema.type === 'thing'
+          ? { label: 'No Parent', value: schema.type }
+          : { label: capitalizeFirstLetter(schema.type), value: schema.type },
+      )
+      .filter((option, index, self) => index === self.findIndex((o) => o.value === option.value))
 
     setOptions(options)
   } catch (error) {


### PR DESCRIPTION
### Ticket №: #2194

closes #2194

### Problem:

Parent , source and destination node types in dropdown showing multiple times that should be only once

### Evidence:

https://www.loom.com/share/b5071adec042491584fe8f4ea93d7900?sid=b6280511-335a-4927-937a-5bf31b817257



