### PR TITLE
[Sidebar-Filter] - duplicate node types at sidebar filter pannel ( Better to add check at frontend side to avoid from duplicates 

### DIFF
--- a/src/components/App/SideBar/FilterSearch/index.tsx
+++ b/src/components/App/SideBar/FilterSearch/index.tsx
@@ -69,6 +69,10 @@ export const FilterSearch = ({ showAllSchemas, setShowAllSchemas, schemaAll, anc
     await fetchData(setBudget, setAbortRequests)
   }
 
+  const uniqueSchemas = (showAllSchemas ? schemaAll : schemaAll.slice(0, 4)).filter(
+    (schema, index, self) => index === self.findIndex((s) => s.type === schema.type),
+  )
+
   return (
     <SearchFilterPopover
       anchorEl={anchorEl}
@@ -93,7 +97,7 @@ export const FilterSearch = ({ showAllSchemas, setShowAllSchemas, schemaAll, anc
       </PopoverHeader>
       <PopoverBody>
         <SchemaTypeWrapper>
-          {(showAllSchemas ? schemaAll : schemaAll.slice(0, 4)).map((schema) => (
+          {uniqueSchemas.map((schema) => (
             <SchemaType
               key={schema.type}
               isSelected={selectedTypes.includes(schema.type as string)}


### PR DESCRIPTION
### Ticket №: #2226

closes #2226

### Problem:

Duplicate node types at sidebar filter panel

### Evidence:

![image](https://github.com/user-attachments/assets/0cab5f9d-8eed-4faf-aeb0-57067848cefb)


