### PR TITLE
Fixed[Blueprint]: Untoggling a Media Attribute Should Send DELETE in PUT /schema Request

### DIFF
--- a/src/components/ModalsContainer/BlueprintModal/Body/Editor/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Editor/index.tsx
@@ -69,6 +69,7 @@ const handleSubmitForm = async (
   isUpdate = false,
   deletedAttributes: string[],
   mediaOptions: { videoAudio: boolean; image: boolean; sourceLink: boolean },
+  initialMediaOptions: { videoAudio: boolean; image: boolean; sourceLink: boolean },
 ): Promise<string | undefined> => {
   try {
     // eslint-disable-next-line camelcase
@@ -93,14 +94,20 @@ const handleSubmitForm = async (
 
     if (mediaOptions.videoAudio) {
       requestData.media_url = ''
+    } else if (initialMediaOptions.videoAudio) {
+      requestData.media_url = 'delete'
     }
 
     if (mediaOptions.image) {
       requestData.image_url = ''
+    } else if (initialMediaOptions.image) {
+      requestData.image_url = 'delete'
     }
 
     if (mediaOptions.sourceLink) {
       requestData.source_link = ''
+    } else if (initialMediaOptions.sourceLink) {
+      requestData.source_link = 'delete'
     }
 
     let res: { status: string; ref_id: string }
@@ -352,6 +359,11 @@ export const Editor = ({
         !!selectedSchema,
         deletedAttributes,
         mediaOptions,
+        {
+          videoAudio: !!selectedSchema?.media_url,
+          image: !!selectedSchema?.image_url,
+          sourceLink: !!selectedSchema?.source_link,
+        },
       )
 
       onSchemaCreate({ type: data.type, parent: parent || '', ref_id: selectedSchema?.ref_id || res || 'new' })


### PR DESCRIPTION
### Problem:
- If a previously toggled media attribute is untoggled when editing a node, we should send `delete` in the PUT /schema request.

closes: #2121

## Issue ticket number and link:
- **Ticket Number:** [ 2121 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/2121 ]

### Evidence:

https://www.loom.com/share/0259aa274e204742b673bfdc96c12ee3

![image](https://github.com/user-attachments/assets/7e163848-333d-4318-ba73-2230cb47a2ff)
