### PR TITLE
[Graph]: `Node` Text `Overflowing` the Box

### DIFF
--- a/src/components/Universe/Graph/Cubes/RelevanceBadges/styles.ts
+++ b/src/components/Universe/Graph/Cubes/RelevanceBadges/styles.ts
@@ -87,7 +87,7 @@ export const TagWrapper = styled(Flex)`
   font-style: normal;
   font-weight: 700;
   text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
-  max-width: 100px;
+  max-width: auto;
   max-height: 100px;
   white-space: normal;
   font-size: 16px;


### PR DESCRIPTION
### Problem:
- The node text overflows the box, causing layout issues.

closes: #2224

## Issue ticket number and link:
- **Ticket Number:** [ 2224 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/2224 ]

### Evidence:

https://www.loom.com/share/f397463059e84cdbadaa6447e742c770

![image](https://github.com/user-attachments/assets/68c7b62c-91f6-4c4b-a086-d4aae4a7af42)

![image](https://github.com/user-attachments/assets/c4014a58-77e6-4007-bf4b-0456d0d5b4df)

![image](https://github.com/user-attachments/assets/5098e3c2-4fe0-4f0c-a4f2-9db5abe7d1f1)

![image](https://github.com/user-attachments/assets/41d0fee8-050a-40e2-a83e-eb47237e6bc1)

`etc.`

### Acceptance Criteria
- [x] Node text should wrap or truncate properly within the box.