### PR TITLE
[Graph]: `GraphClear` and `CameraRecenterControl` Buttons Overlap Each Other

### DIFF
--- a/src/components/App/ActionsToolbar/GraphClear/index.tsx
+++ b/src/components/App/ActionsToolbar/GraphClear/index.tsx
@@ -1,15 +1,20 @@
 import { Button } from '@mui/material'
 import styled from 'styled-components'
+import { Tooltip } from '~/components/common/ToolTip'
 import ClearIcon from '~/components/Icons/ClearIcon'
 import { useDataStore } from '~/stores/useDataStore'
 
 export const GraphClear = () => {
   const { resetData } = useDataStore((s) => s)
 
-  return <CameraCenterButton href="" onClick={() => resetData()} size="medium" startIcon={<ClearIcon />} />
+  return (
+    <Tooltip content="Clear Graph" fontSize="13px" position="left">
+      <ClearButton href="" onClick={() => resetData()} size="medium" startIcon={<ClearIcon />} />
+    </Tooltip>
+  )
 }
 
-const CameraCenterButton = styled(Button)`
+const ClearButton = styled(Button)`
   && {
     padding: 0;
     width: 32px;

--- a/src/components/App/ActionsToolbar/index.tsx
+++ b/src/components/App/ActionsToolbar/index.tsx
@@ -17,8 +17,10 @@ export const ActionsToolbar = () => {
 
   return (
     <Wrapper align="flex-end" id="actions-toolbar">
-      {!isLoading && !universeQuestionIsOpen && isAdmin && <GraphClear />}
-      {!isLoading && !universeQuestionIsOpen && <CameraRecenterControl />}
+      <ButtonWrapper>
+        {!isLoading && !universeQuestionIsOpen && isAdmin && <GraphClear />}
+        {!isLoading && !universeQuestionIsOpen && <CameraRecenterControl />}
+      </ButtonWrapper>
       <Flex align="center" direction="row" mt={16}>
         {!isLoading && !universeQuestionIsOpen && <GraphViewControl />}
       </Flex>
@@ -32,4 +34,10 @@ const Wrapper = styled(Flex)`
   right: 20px;
   bottom: 20px;
   pointer-events: all;
+`
+
+const ButtonWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 `

--- a/src/components/common/ToolTip/index.tsx
+++ b/src/components/common/ToolTip/index.tsx
@@ -47,9 +47,16 @@ const TooltipText = styled.div<{
   padding: ${({ padding }) => padding || '5px 8px'};
   position: absolute;
   z-index: 1;
-  ${({ position }) => (position === 'top' ? 'bottom: 100%;' : 'top: 100%;')}
-  left: ${({ mrLeft }) => mrLeft || '50%'};
-  transform: translateX(-50%);
+  ${({ position }) => {
+    switch (position) {
+      case 'top':
+        return 'bottom: 100%; left: 50%; transform: translateX(-50%);'
+      case 'left':
+        return 'right: calc(100% + 6px); top: 50%; transform: translateY(-50%);'
+      default:
+        return 'top: 100%; left: 50%; transform: translateX(-50%);'
+    }
+  }}
   margin-top: ${({ margin }) => margin || '0px'};
   opacity: 0;
   transition: opacity 0.3s;


### PR DESCRIPTION
### Problem:
- The `GraphClear` and `CameraRecenterControl` buttons overlap each other, making it difficult to interact with either button and add `tooltip`.

closes: #1906

## Issue ticket number and link:
- **Ticket Number:** [ 1906 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/1906 ]

### Evidence:
 - Please see the attached video and images as evidence.
 
https://www.loom.com/share/483d3445233142f98797217753784c86

![image](https://github.com/user-attachments/assets/777c6570-d2a4-408e-9f69-fbc8ab4ce29e)

![image](https://github.com/user-attachments/assets/3084e0ac-6b74-40d3-84b7-ff2bfaddb7e4)

### Acceptance Criteria
- [x] The buttons should be positioned correctly, with no overlap.
- [x] Both buttons should be easily clickable and functional.
- [x] Add Tooltip
