### PR TITLE
Fixed: [AI-Chat]: Tapping `New Chat` Button Input Field Should Auto-Focus

### DIFF
--- a/src/components/App/UniverseQuestion/index.tsx
+++ b/src/components/App/UniverseQuestion/index.tsx
@@ -1,9 +1,9 @@
+import { useEffect, useRef, useState } from 'react'
 import styled from 'styled-components'
 import { Flex } from '~/components/common/Flex'
 
 import { TextareaAutosize } from '@mui/base'
 import { Button } from '@mui/material'
-import { useEffect, useState } from 'react'
 import ArrowForwardIcon from '~/components/Icons/ArrowForwardIcon'
 import ExploreIcon from '~/components/Icons/ExploreIcon'
 import HelpIcon from '~/components/Icons/HelpIcon'
@@ -15,6 +15,7 @@ import { colors } from '~/utils/colors'
 
 export const UniverseQuestion = () => {
   const [question, setQuestion] = useState('')
+  const textAreaRef = useRef<HTMLTextAreaElement>(null)
   const { fetchData, setAbortRequests, seedQuestions } = useDataStore((s) => s)
   const [setBudget] = useUserStore((s) => [s.setBudget])
 
@@ -32,6 +33,12 @@ export const UniverseQuestion = () => {
       setDisplayedSeedQuestions(shuffleArray(seedQuestions).slice(0, 4))
     }
   }, [seedQuestions])
+
+  useEffect(() => {
+    if (textAreaRef.current) {
+      textAreaRef.current.focus()
+    }
+  }, [])
 
   const handleSubmitQuestion = async (questionToSubmit: string) => {
     if (questionToSubmit) {
@@ -85,6 +92,7 @@ export const UniverseQuestion = () => {
       Ideas have shapes
       <TextAreaWrapper onKeyDown={onEnterPress} py={12} tabIndex={-1}>
         <StyledTextarea
+          ref={textAreaRef}
           onChange={(e) => setQuestion(e.target.value)}
           placeholder="What do you want to know?"
           value={question}


### PR DESCRIPTION
### Problem:
-  Tapping `New Chat` button input field didn't auto-focus for immediate typing.

## Issue ticket number and link:
- **Ticket Number:** [ 2238 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/2238 ]

### closes: #2238

### Evidence:

https://www.loom.com/share/0b75979732484993b57bb9102933c3c0

![image](https://github.com/user-attachments/assets/827e63b0-b920-48d4-9bb2-e19a99f99552)

### Acceptance Criteria
- [x] Tapping `New Chat` should auto-focus, allowing users to start typing immediately.
