### PR TITLE
[ BluePrint ] - At create type and edit type sidebar the Parent and Name fields are not in same order ( UI/UX )

### DIFF
--- a/src/components/ModalsContainer/BlueprintModal/Body/Editor/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Editor/index.tsx
@@ -471,7 +471,7 @@ export const Editor = ({
                 <>
                   <Flex mb={12}>
                     <Flex mb={12}>
-                      <Text>Select Parent</Text>
+                      <Text>Parent</Text>
                     </Flex>
 
                     <AutoComplete
@@ -487,7 +487,7 @@ export const Editor = ({
                   </Flex>
                   <Flex>
                     <Flex mb={12}>
-                      <Text>Type name</Text>
+                      <Text>Name</Text>
                     </Flex>
                     <Flex mb={12}>
                       <TextInput
@@ -507,6 +507,22 @@ export const Editor = ({
                 <>
                   <Flex mb={12}>
                     <Flex mb={12}>
+                      <Text>Parent</Text>
+                    </Flex>
+
+                    <AutoComplete
+                      isLoading={parentsLoading || graphLoading}
+                      onSelect={(e) => {
+                        setValue('parent', e?.value || '')
+                        setDisplayParentError(false)
+                      }}
+                      options={selectedNodeParentOptions || []}
+                      selectedValue={resolvedSelectedParentValue}
+                    />
+                    {errMessage && <StyledError>{errMessage}</StyledError>}
+                  </Flex>
+                  <Flex mb={12}>
+                    <Flex mb={12}>
                       <Text>Name</Text>
                     </Flex>
                     <Flex mb={12}>
@@ -523,22 +539,6 @@ export const Editor = ({
                         value={parent}
                       />
                     </Flex>
-                  </Flex>
-                  <Flex mb={12}>
-                    <Flex mb={12}>
-                      <Text>Parent</Text>
-                    </Flex>
-
-                    <AutoComplete
-                      isLoading={parentsLoading || graphLoading}
-                      onSelect={(e) => {
-                        setValue('parent', e?.value || '')
-                        setDisplayParentError(false)
-                      }}
-                      options={selectedNodeParentOptions || []}
-                      selectedValue={resolvedSelectedParentValue}
-                    />
-                    {errMessage && <StyledError>{errMessage}</StyledError>}
                   </Flex>
                 </>
               )}


### PR DESCRIPTION
### Ticket №: #2287

closes #2287

### Problem:

At create type and edit type sidebar the Parent and Name fields are not in same order

### Evidence:

![image](https://github.com/user-attachments/assets/acf8611c-9559-49eb-a2b1-75bd1c77e832)



