### PR TITLE
`[Stats Bar]`:  `Popover` Overflowing on `InfoIcon` in Stats Bar Button

### DIFF
--- a/src/components/Alerts/index.tsx
+++ b/src/components/Alerts/index.tsx
@@ -34,7 +34,7 @@ export const Alerts = () => {
           </div>
         </Tooltip>
       </Info>
-      <Popover
+      <StyledPopover
         anchorEl={anchorEl}
         anchorOrigin={{
           vertical: 'bottom',
@@ -51,7 +51,7 @@ export const Alerts = () => {
             </p>
           ))}
         </ContentWrapper>
-      </Popover>
+      </StyledPopover>
     </AlertWrapper>
   ) : null
 }
@@ -67,6 +67,7 @@ const ContentWrapper = styled(Flex)`
   max-height: 33vh;
   max-width: 30vw;
   background: ${colors.BG1};
+  padding-top: 0 !important;
 
   .item {
     padding: 8px 0;
@@ -123,5 +124,11 @@ const Info = styled(Flex).attrs({
     display: flex;
     align-items: center;
     justify-content: center;
+  }
+`
+
+const StyledPopover = styled(Popover)`
+  .MuiPopover-paper {
+    margin-top: 4px;
   }
 `


### PR DESCRIPTION
### Problem:
- The popover on the Info Icon in the Stats Bar Button is overflowing, causing layout issues.
- Top many space is empty:

closes: #2289

## Issue ticket number and link:
- **Ticket Number:** [ 2289 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/2289 ]

### Evidence:

![image](https://github.com/user-attachments/assets/825c3f75-efbb-471f-a673-d29b4f312309)

![image](https://github.com/user-attachments/assets/f094fe5c-f6cf-4cb4-aae0-dc632a53f844)

### Acceptance Criteria
- [x] The popover should fit within the bounds of the Stats Bar Button without overflowing.