### PR TITLE
[BluePrint]: Color Modal `Overlapping` UI and Difficult to Close

### DIFF
--- a/src/components/ModalsContainer/BlueprintModal/Body/Editor/ColorPickerPopover/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Editor/ColorPickerPopover/index.tsx
@@ -1,6 +1,6 @@
-import { ColorPickerPopoverView } from './ColorPickerPopoverView'
 import styled from 'styled-components'
 import { colors } from '~/utils'
+import { ColorPickerPopoverView } from './ColorPickerPopoverView'
 
 type Props = {
   isOpen: boolean
@@ -33,4 +33,24 @@ const ModalContent = styled.div`
   z-index: 1001;
   border-radius: 8px;
   box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3);
+
+  @media (max-width: 1550px) {
+    top: 44%;
+    left: 38%;
+  }
+
+  @media (max-width: 1024px) {
+    top: 58%;
+    left: 56%;
+  }
+
+  @media (max-width: 768px) {
+    top: 50%;
+    left: 64%;
+  }
+
+  @media (max-width: 480px) {
+    top: 37%;
+    left: 76%;
+  }
 `


### PR DESCRIPTION
### Problem:
- The color modal is overlapping the `Create Type` Modal and the Blueprint `Header`. Additionally, the color modal is `difficult` to close once opened.
- 
We need to make it dynamic dependant on width of the screen

closes: #2299

## Issue ticket number and link:
- **Ticket Number:** [ 2299 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/2299 ]

### Evidence:

![image](https://github.com/user-attachments/assets/bdabf114-1238-4664-84de-5d1509a7a773)

https://www.loom.com/share/94fd4a8fd4114d2fbca5385b5a194aba

### Acceptance Criteria
- [x] The color modal should no longer overlap with other modals or headers.
- [x] The modal should be easier to close once opened.
- [x] The modal should adjust dynamically depending on screen width.
