### PR TITLE
[Graph] - Node controls overlap the text node section in the graph at certain points

### DIFF
--- a/src/components/Universe/Graph/UI/NodeControls/index.tsx
+++ b/src/components/Universe/Graph/UI/NodeControls/index.tsx
@@ -251,7 +251,7 @@ type ButtonProps = {
 
 const IconButton = styled.div<ButtonProps>`
   position: fixed;
-  top: -60px;
+  top: -80px;
   left: ${(p: ButtonProps) => -7 + p.left}px;
   width: 24px;
   height: 24px;


### PR DESCRIPTION


### Ticket №: #2247

closes #2247

### Problem:

Node controls are overlapping the text node section in graph at some poi

### Evidence:

https://www.loom.com/share/efe3ae74b8a741b58fd6b2f0d1dac127?sid=bfbd2f72-4f9a-496e-89be-db1a01249175

