### PR TITLE
[Safari] Remove Auto-Capitalize Behavior

### DIFF
--- a/src/components/BaseTextInput/WebTextInput/index.tsx
+++ b/src/components/BaseTextInput/WebTextInput/index.tsx
@@ -2,7 +2,9 @@ import styled from 'styled-components'
 import { colors } from '~/utils/colors'
 import { BaseTextInputProps } from '../types'
 
-type Props = Required<Pick<BaseTextInputProps, 'colorName' | 'disabled' | 'placeholderTextColor' | 'textAlign'>>
+type Props = Required<
+  Pick<BaseTextInputProps, 'autoCapitalize' | 'colorName' | 'disabled' | 'placeholderTextColor' | 'textAlign'>
+>
 
 export const WebTextInput = styled.input<Props>`
   -webkit-appearance: none;
@@ -16,6 +18,7 @@ export const WebTextInput = styled.input<Props>`
   outline: 0;
   padding: 0;
   text-align: ${({ textAlign }) => textAlign};
+  text-transform: ${({ autoCapitalize }) => autoCapitalize};
 
   &:focus {
     border: none;

--- a/src/components/BaseTextInput/defaultProps/index.ts
+++ b/src/components/BaseTextInput/defaultProps/index.ts
@@ -4,6 +4,7 @@ type DefaultProps = Required<
   Pick<
     BaseTextInputProps,
     | 'autoComplete'
+    | 'autoCapitalize'
     | 'colorName'
     | 'disabled'
     | 'maxLength'
@@ -18,6 +19,7 @@ type DefaultProps = Required<
 export const defaultProps: DefaultProps = {
   autoComplete: 'off',
   colorName: 'black',
+  autoCapitalize: 'none',
   disabled: false,
   maxLength: 524288,
   placeholder: '',

--- a/src/components/BaseTextInput/index.tsx
+++ b/src/components/BaseTextInput/index.tsx
@@ -8,6 +8,7 @@ export const BaseTextInput = forwardRef(
   (
     {
       autoComplete = defaultProps.autoComplete,
+      autoCapitalize = defaultProps.autoCapitalize,
       autoFocus,
       className,
       colorName = defaultProps.colorName,
@@ -41,6 +42,7 @@ export const BaseTextInput = forwardRef(
     return (
       <WebTextInput
         ref={ref}
+        autoCapitalize={autoCapitalize}
         autoComplete={autoComplete}
         autoFocus={autoFocus}
         className={className}

--- a/src/components/BaseTextInput/types/index.ts
+++ b/src/components/BaseTextInput/types/index.ts
@@ -7,10 +7,13 @@ type TextAlign = 'left' | 'right'
 
 type ReturnKeyType = 'done' | 'go' | 'next' | 'search' | 'send'
 
+type AutoCapitalize = 'characters' | 'none' | 'sentences' | 'words'
+
 export type InputType = 'email' | 'number' | 'password' | 'search' | 'tel' | 'text' | 'url'
 
 export type BaseTextInputProps = {
   autoComplete?: string
+  autoCapitalize?: AutoCapitalize
   autoFocus?: boolean
   className?: string
   colorName?: ColorName

--- a/src/components/ModalsContainer/BlueprintModal/Body/Editor/CustomAttributesStep/FormInput/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Editor/CustomAttributesStep/FormInput/index.tsx
@@ -90,6 +90,7 @@ export const FormInput = ({
                 <Fragment key={field.id}>
                   <Grid item xs={5}>
                     <TextInput
+                      autoCapitalize="none"
                       autoComplete="off"
                       className="text-input"
                       dataTestId={`cy-item-name-${index}`}

--- a/src/components/common/TextInput/index.tsx
+++ b/src/components/common/TextInput/index.tsx
@@ -212,6 +212,7 @@ export const TextInput = ({
                 value={value}
               >
                 <WebTextInput
+                  autoCapitalize="none"
                   colorName="white"
                   data-testid={dataTestId}
                   disabled={disabled}
@@ -226,6 +227,7 @@ export const TextInput = ({
             ) : (
               <BaseTextInput
                 {...props}
+                autoCapitalize="none"
                 colorName="white"
                 dataTestId={dataTestId}
                 id={id}


### PR DESCRIPTION
### Problem:
- Remove auto capitalize that happens with Safari.

closes: #2340

## Issue ticket number and link:
- **Ticket Number:** [ 2340 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/2340 ]

### Evidence:

![image](https://github.com/user-attachments/assets/eb606047-863f-452a-b026-60398e64f2d7)

### Acceptance Criteria
- [x]  Remove auto capitalize for all input screens in secondbrain
- [x] Seems to happen in safari only