### PR TITLE
[BluePrint]: Add `Close` Button Functionality to Color Modal

### DIFF
--- a/src/components/ModalsContainer/BlueprintModal/Body/Editor/ColorPickerPopover/ColorPickerPopoverView/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Editor/ColorPickerPopover/ColorPickerPopoverView/index.tsx
@@ -3,6 +3,7 @@ import Tabs from '@mui/material/Tabs'
 import * as React from 'react'
 import styled from 'styled-components'
 import { Flex } from '~/components/common/Flex'
+import ClearIcon from '~/components/Icons/ClearIcon'
 import { colors } from '~/utils/colors'
 import { ColorPicker } from './ColorPicker'
 import { IconPicker } from './IconPicker'
@@ -36,7 +37,7 @@ function a11yProps(index: number) {
   }
 }
 
-export const ColorPickerPopoverView = () => {
+export const ColorPickerPopoverView = ({ onClose }: { onClose: () => void }) => {
   const [value, setValue] = React.useState(0)
 
   const handleChange = (event: React.SyntheticEvent, newValue: number) => {
@@ -50,6 +51,9 @@ export const ColorPickerPopoverView = () => {
 
   return (
     <Wrapper direction="column">
+      <CloseButton onClick={onClose}>
+        <ClearIcon />
+      </CloseButton>
       <StyledTabs aria-label="color picker" onChange={handleChange} value={value}>
         {tabs.map((tab, index) => (
           <StyledTab key={tab.label} color={colors.white} disableRipple label={tab.label} {...a11yProps(index)} />
@@ -125,5 +129,25 @@ const Wrapper = styled(Flex)`
 
   @media (max-width: 768px) {
     padding: 3px;
+  }
+`
+
+const CloseButton = styled.div`
+  position: absolute;
+  top: 4px;
+  right: 3px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5em;
+  height: 1.5em;
+  background-color: ${colors.primaryText1};
+  border-radius: 50%;
+  z-index: 1001;
+
+  svg {
+    width: 1.5em;
+    height: 1.5em;
   }
 `

--- a/src/components/ModalsContainer/BlueprintModal/Body/Editor/ColorPickerPopover/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Editor/ColorPickerPopover/index.tsx
@@ -4,12 +4,13 @@ import { ColorPickerPopoverView } from './ColorPickerPopoverView'
 
 type Props = {
   isOpen: boolean
+  onClose: () => void
 }
 
-export const ColorPickerPopover = ({ isOpen }: Props) => (
+export const ColorPickerPopover = ({ isOpen, onClose }: Props) => (
   <ModalBackground isOpen={isOpen}>
     <ModalContent>
-      <ColorPickerPopoverView />
+      <ColorPickerPopoverView onClose={onClose} />
     </ModalContent>
   </ModalBackground>
 )

--- a/src/components/ModalsContainer/BlueprintModal/Body/Editor/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Editor/index.tsx
@@ -663,7 +663,7 @@ export const Editor = ({
             </Flex>
           </form>
         </FormProvider>
-        <ColorPickerPopover isOpen={isPopoverOpen} />
+        <ColorPickerPopover isOpen={isPopoverOpen} onClose={handleColorPickerPopover} />
       </Flex>
     </Flex>
   )


### PR DESCRIPTION
### Problem:
- We should probably add a close button to ensure we can at least close if the original button is hidden.

### Evidence:

![image](https://github.com/user-attachments/assets/7a14c6ec-a47d-4fc1-84c3-6eeaa600df6b)

https://www.loom.com/share/861c1fac6d2c4945849993ccaa13f859

### Acceptance Criteria
- [x] Add a functional close button to the Color Modal for improved accessibility.