### PR TITLE
[Blueprint] UI Bug:  Color/Icon Button Misplacement After Clicking `Add Attribute` Button

### DIFF
--- a/src/components/ModalsContainer/BlueprintModal/Body/Editor/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Editor/index.tsx
@@ -754,6 +754,7 @@ const ColorPickerIconWrapper = styled.span<{ selectedColor?: string }>`
   height: 36px;
   border-radius: 6px;
   margin-left: 12px;
+  margin-block-start: 3px;
   background: ${(props) => props.selectedColor ?? colors.THING};
   display: flex;
   justify-content: center;
@@ -774,8 +775,9 @@ const ColorPickerIconWrapper = styled.span<{ selectedColor?: string }>`
 
 const InputIconWrapper = styled(Flex)`
   justify-content: space-between;
-  align-items: center;
   flex-direction: row;
+  position: relative;
+  display: flex;
 `
 
 const InputWrapper = styled(Flex)`


### PR DESCRIPTION
### Problem:
- When I click the `Add Attribute` button in the `Create Type`, the `color/icon` button located next to the `Enter type name` field moves down or below its original position.

closes: #2356

## Issue ticket number and link:
- **Ticket Number:** [ 2356 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/2356 ]

### Evidence:
`Without a Name:`

![image](https://github.com/user-attachments/assets/62308fc1-54ad-4989-b174-7f026dbe08be)

`With a Name:`

![image](https://github.com/user-attachments/assets/d2790a95-7c18-4b82-ba7f-1ba138171d92)

https://www.loom.com/share/b778382c9f2e41178f8ddd6bc20aed8e

### Acceptance Criteria
- [x] Icon button should remain properly aligned next to the `Enter type name` field after adding attributes.