### PR TITLE
[BluePrint]: `Duplicate Indexes` When Adding `Attributes` with Same Name

### DIFF
--- a/src/components/ModalsContainer/BlueprintModal/Body/Editor/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Editor/index.tsx
@@ -489,6 +489,12 @@ export const Editor = ({
 
   const parentType = selectedSchema ? selectedSchema.type : parent
 
+  const getUniqueAttributes = (attrList: Attribute[]): TAutocompleteOption[] => {
+    const uniqueKeys = new Set(attributes.map((attr) => attr.key))
+
+    return Array.from(uniqueKeys).map((key) => ({ label: key, value: key }))
+  }
+
   return (
     <Flex>
       <HeaderRow>
@@ -614,9 +620,7 @@ export const Editor = ({
                 <Grid item mb={2} width="70%">
                   <AutoComplete
                     onSelect={(val) => setValue('selectedIndex', val?.value || '')}
-                    options={attributes
-                      .filter((attr) => attr.key)
-                      .map((attr) => ({ label: attr.key, value: attr.key }))}
+                    options={getUniqueAttributes(attributes)}
                     selectedValue={resolvedSelectedIndexValue}
                   />
                 </Grid>


### PR DESCRIPTION
### Problem:
- When a user adds multiple attributes with the same name, the indexes section displays duplicate index.

closes: #2346

## Issue ticket number and link:
- **Ticket Number:** [ 2346 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/2346 ]

### Evidence:

![image](https://github.com/user-attachments/assets/99c78406-8847-496d-9a30-ca5e2aabee58)

https://www.loom.com/share/9f0aea199a57476bab7ebf84a1163af3

### Acceptance Criteria:
- [x] Ensure that the indexes section only reflects unique attributes.