### PR TITLE
[Blueprint] Remove `Delete Icon` from Graph View

### DIFF
--- a/src/components/ModalsContainer/BlueprintModal/Body/Toolbar/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Toolbar/index.tsx
@@ -1,9 +1,8 @@
 import styled from 'styled-components'
 import { Flex } from '~/components/common/Flex'
-import { colors } from '~/utils/colors'
-import PlusIcon from '~/components/Icons/PlusIcon'
 import CreateEdgeIcon from '~/components/Icons/CreateEdgeIcon'
-import DeleteIcon from '~/components/Icons/DeleteIcon'
+import PlusIcon from '~/components/Icons/PlusIcon'
+import { colors } from '~/utils/colors'
 
 type Props = {
   onCreateNew: () => void
@@ -20,11 +19,6 @@ export const Toolbar = ({ onCreateNew, onAddEdgeNode }: Props) => (
     <ActionButton data-testid="add-edge" onClick={onAddEdgeNode}>
       <IconWrapper>
         <CreateEdgeIcon />
-      </IconWrapper>
-    </ActionButton>
-    <ActionButton disabled>
-      <IconWrapper>
-        <DeleteIcon />
       </IconWrapper>
     </ActionButton>
   </Wrapper>


### PR DESCRIPTION
### Problem:
- Remove delete icon from graph view. Delete is already at the bottom of the sidebar

closes: #2367

## Issue ticket number and link:
- **Ticket Number:** [ 2367 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/2367 ]

### Evidence:

![image](https://github.com/user-attachments/assets/2f9453f7-df8f-48e9-9548-65621890946c)

![image](https://github.com/user-attachments/assets/e360505b-c5b7-4afb-976d-bb226011e6e1)
