### PR TITLE
fix: prevent color picker from popping up when node is selected

### DIFF
--- a/src/components/ModalsContainer/BlueprintModal/Body/Editor/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Editor/index.tsx
@@ -14,14 +14,14 @@ import { Text } from '~/components/common/Text'
 import { TextInput } from '~/components/common/TextInput'
 import { NODE_ADD_ERROR, requiredRule } from '~/constants'
 import { api } from '~/network/api'
-import { editNodeSchemaUpdate, getNodeSchemaTypes, getNodeType, Schema } from '~/network/fetchSourcesData'
+import { Schema, editNodeSchemaUpdate, getNodeSchemaTypes, getNodeType } from '~/network/fetchSourcesData'
 import { useAppStore } from '~/stores/useAppStore'
 import { useModal } from '~/stores/useModalStore'
 import { colors } from '~/utils'
 import { ColorPickerPopover } from './ColorPickerPopover'
 import { CreateCustomNodeAttribute } from './CustomAttributesStep'
 import MediaOptions from './MediaOptions'
-import { convertAttributes, parsedObjProps, parseJson } from './utils'
+import { convertAttributes, parseJson, parsedObjProps } from './utils'
 
 const defaultValues = {
   type: '',
@@ -225,7 +225,7 @@ export const Editor = ({
   })
 
   const { selectedColor, selectedIcon } = useAppStore((s) => s)
-  const [isPopoverOpen, setPopoverOpen] = useState(!!selectedSchema)
+  const [isPopoverOpen, setPopoverOpen] = useState(false)
 
   const selectedPrimaryColor = selectedColor.replace('#', '')
 
@@ -266,8 +266,6 @@ export const Editor = ({
     resetForm()
 
     if (selectedSchema) {
-      setPopoverOpen(true)
-
       setValue('type', selectedSchema.type as string)
       setValue('parent', selectedSchema.parent)
 


### PR DESCRIPTION
closes #2368

### Description:

This PR prevents the color & icon picker to open when a node is selected in the blueprint section

### Preview:
https://www.loom.com/share/b83740e8277841b395172275bb09f226?sid=6ac0b0ca-ee61-4ca6-b28d-9d6e78cf75b4


