### PR TITLE
[MainGraph] - Big icons like youtube icon are going to be cutt off from side in front of node sphere

### DIFF
--- a/src/components/Universe/Graph/Cubes/Text/index.tsx
+++ b/src/components/Universe/Graph/Cubes/Text/index.tsx
@@ -160,7 +160,7 @@ export const TextNode = memo(({ node, hide }: Props) => {
           <mesh name={node.id} userData={node} visible={!hide}>
             <sphereGeometry args={[30, 32, 32]} userData={node} />
             <meshStandardMaterial {...smoothness} color={color} />
-            <Svg ref={svgRef} position={[20, 20, 20]} scale={2} src={`svg-icons/${iconName}.svg`} />
+            <Svg ref={svgRef} position={[20, 40, 40]} scale={2} src={`svg-icons/${iconName}.svg`} />
           </mesh>
         </Select>
       )}


### PR DESCRIPTION

### Ticket №: #2274

closes #2274

### Problem:

Big icons like youtube icon are going to be cutt off from side in front of node sphere

### Evidence:

![image](https://github.com/user-attachments/assets/f6af52fc-8486-474d-ac10-ff88bcaee0f6)



