### PR TITLE
The blue boundary on input fields is always visible; it should only appear on hover or while typing

### DIFF
--- a/src/components/common/TextInput/index.tsx
+++ b/src/components/common/TextInput/index.tsx
@@ -23,7 +23,7 @@ const getBorderColor = (props: WrapperProps): string => {
     return colors.primaryRed
   }
 
-  if (props.hasContent || props.isFocused || props.isHovered) {
+  if (props.isFocused || props.isHovered) {
     return colors.primaryBlue
   }
 


### PR DESCRIPTION
### Ticket №: #2357

closes #2357

### Problem:

The blue boundary of the input fields is incorrectly displayed at all times. It should only appear when the user hovers over the field or is actively typing, and should not be visible otherwise.

### Evidence:

https://www.loom.com/share/b29041b26d5b4a26b3b83e1647c88b4b?sid=fb5a80ff-4741-4d2c-b58a-b5c3d01527de

