### PR TITLE
[Blueprint] - When the 'Create Type' sidebar is already open and we click on a node in the graph, the 'Edit Type' sidebar opens, but the 'Parent' field is not automatically populated.

### DIFF
--- a/src/components/ModalsContainer/BlueprintModal/Body/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/index.tsx
@@ -146,6 +146,7 @@ export const Body = ({ Close }: BodyProps) => {
             <EditorWrapper hasSchema>
               <InnerEditorWrapper>
                 <Editor
+                  key={selectedSchema?.ref_id}
                   graphLoading={graphLoading}
                   onDelete={onSchemaDelete}
                   onSchemaCreate={onSchemaCreate}


### PR DESCRIPTION
### Ticket №: #2353

closes #2353

### Problem:

[Blueprint] - When the 'Create Type' sidebar is already open and we click on a node in the graph, the 'Edit Type' sidebar opens, but the 'Parent' field is not automatically populated.

### Evidence:

https://www.loom.com/share/63a6b16bb89c4f68827e8ae987e28632?sid=67b7afdf-ba01-4ff2-baf3-b5bb0e2cb329

