### PR TITLE
Add Github Repository to Source Table 

### DIFF
--- a/src/components/SourcesTableModal/SourcesView/constants.ts
+++ b/src/components/SourcesTableModal/SourcesView/constants.ts
@@ -1,4 +1,4 @@
-import { RSS, TWITTER_HANDLE, YOUTUBE_CHANNEL } from '~/constants'
+import { GITHUB_REPOSITORY, RSS, TWITTER_HANDLE, YOUTUBE_CHANNEL } from '~/constants'
 import { ISourceMap } from './types'
 import styled from 'styled-components'
 import { IconButton } from '@mui/material'
@@ -7,6 +7,7 @@ export const sourcesMapper: ISourceMap = {
   [RSS]: 'RSS link',
   [TWITTER_HANDLE]: 'Twitter Handle',
   [YOUTUBE_CHANNEL]: 'Youtube channel',
+  [GITHUB_REPOSITORY]: 'Github Repository',
 }
 
 export const SOURCE_TABLE = 'Sources Table'


### PR DESCRIPTION
### Ticket №: #2384

closes #2384

### Problem:

Add new label to source table for Github Repository:

### Evidence:

![image](https://github.com/user-attachments/assets/53a51165-c15f-4448-9eec-ed521b2e5786)



