### PR TITLE
fix: clear filter button not resetting results when clicked

### DIFF
--- a/src/components/App/SideBar/FilterSearch/index.tsx
+++ b/src/components/App/SideBar/FilterSearch/index.tsx
@@ -29,7 +29,7 @@ const defaultValues = {
 
 export const FilterSearch = ({ anchorEl, setAnchorEl, onClose }: Props) => {
   const [schemaAll, setSchemaAll] = useSchemaStore((s) => [s.schemas, s.setSchemas])
-  const { setFilters } = useDataStore((s) => s)
+  const { abortFetchData, resetGraph, setFilters } = useDataStore((s) => s)
   const [selectedTypes, setSelectedTypes] = useState<string[]>(defaultValues.selectedTypes)
   const [hops, setHops] = useState(defaultValues.hops)
   const [sourceNodes, setSourceNodes] = useState<number>(defaultValues.sourceNodes)
@@ -69,6 +69,8 @@ export const FilterSearch = ({ anchorEl, setAnchorEl, onClose }: Props) => {
 
   const handleClear = async () => {
     resetToDefaultValues()
+    abortFetchData()
+    resetGraph()
   }
 
   const handleFiltersApply = async () => {


### PR DESCRIPTION
### Change:

This PR ensures that results are reset after the `Clear` filters button is clicked

closes #2370

### Preview:

https://www.loom.com/share/76b287ed8b024c8f980e7f28e5acecd3?sid=a2c3e914-1381-494e-93c1-8382b6f258f8

