### PR TITLE
Fixed[AI Search]:  `Listen` Button Stuck in Pause State After Content is Read Aloud

### DIFF
--- a/src/components/App/SideBar/AiSummary/index.tsx
+++ b/src/components/App/SideBar/AiSummary/index.tsx
@@ -48,6 +48,7 @@ export const AiSummary = ({ question, response, refId }: Props) => {
   const { setAiSummaryAnswer } = useAiSummaryStore((s) => s)
   const audioRef = useRef<HTMLAudioElement | null>(null)
   const { currentPlayingAudio, setCurrentPlayingAudio } = useAppStore((s) => s)
+  const [isPlaying, setIsPlaying] = useState(false)
 
   useEffect(() => {
     if (ref.current) {
@@ -60,6 +61,7 @@ export const AiSummary = ({ question, response, refId }: Props) => {
 
     const onAudioPlaybackComplete = () => {
       setCurrentPlayingAudio(null)
+      setIsPlaying(false)
     }
 
     if (audioElement) {
@@ -71,7 +73,7 @@ export const AiSummary = ({ question, response, refId }: Props) => {
         audioElement.removeEventListener('ended', onAudioPlaybackComplete)
       }
     }
-  }, [setCurrentPlayingAudio])
+  }, [setCurrentPlayingAudio, isPlaying])
 
   const toggleCollapse = () => {
     setCollapsed(!collapsed)
@@ -88,9 +90,11 @@ export const AiSummary = ({ question, response, refId }: Props) => {
       if (audioRef.current.paused) {
         audioRef.current.play()
         setCurrentPlayingAudio(audioRef)
+        setIsPlaying(true)
       } else {
         audioRef.current.pause()
         setCurrentPlayingAudio(null)
+        setIsPlaying(false)
       }
     }
   }


### PR DESCRIPTION
### Problem:
- The AI Search Listen Button does not change from the Pause state back to the default state after the content is read aloud, causing it to appear stuck.

closes: #2396

## Issue ticket number and link:
- **Ticket Number:** [ 2396 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/2396 ]

### Evidence:

![image](https://github.com/user-attachments/assets/9014d1c3-0cfe-49ae-a8bf-99643c368877)

https://www.loom.com/share/6bcaa22113904e2494129a81cf2d5f28

### Acceptance Criteria:
- [x]  The Listen Button should automatically return to its default state after reading the content aloud.
- [x] Ensure the button's visual and functional state reflects its intended behavior at all times.