### PR TITLE
[Source Table] - The first letter of the second word in labels should be consistent (either all lowercase or all uppercase).

### DIFF
--- a/src/components/SourcesTableModal/SourcesView/constants.ts
+++ b/src/components/SourcesTableModal/SourcesView/constants.ts
@@ -4,9 +4,9 @@ import styled from 'styled-components'
 import { IconButton } from '@mui/material'
 
 export const sourcesMapper: ISourceMap = {
-  [RSS]: 'RSS link',
+  [RSS]: 'RSS Link',
   [TWITTER_HANDLE]: 'Twitter Handle',
-  [YOUTUBE_CHANNEL]: 'Youtube channel',
+  [YOUTUBE_CHANNEL]: 'Youtube Channel',
   [GITHUB_REPOSITORY]: 'Github Repository',
 }
 


### PR DESCRIPTION
### Ticket №: #2406

closes #2406

### Problem:

Currently the second word first letter of labels are not consistent some in uppercase and some are lowercase

### Evidence:

![image](https://github.com/user-attachments/assets/7b706dab-cd97-4a6e-b154-e7f666395302)


