### PR TITLE
[Blueprint] - When we click on the sidebar buttons, Create Type and Add Edge, the button background disappears

### DIFF
--- a/src/components/ModalsContainer/BlueprintModal/Body/Toolbar/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Toolbar/index.tsx
@@ -57,7 +57,7 @@ const ActionButton = styled(Flex).attrs({
 
   &:active {
     color: ${colors.white};
-    background: ${({ disabled }) => (disabled ? colors.BG1 : colors.black)};
+    background: ${({ disabled }) => (disabled ? colors.BG1 : colors.BG1_NORMAL)};
   }
 
   &.root {


### PR DESCRIPTION


### Ticket №: #2399

closes #2399

### Problem:

When clicking on the buttons, the background disappears, which is not ideal for UI/UX.

### Evidence:

![image](https://github.com/user-attachments/assets/d3e5cc96-3cf0-4e4e-91a7-fdee87c242c0)



