### PR TITLE
[Stats] stats tooltip text  should be plural

### DIFF
--- a/src/components/Stats/index.tsx
+++ b/src/components/Stats/index.tsx
@@ -93,7 +93,7 @@ export const Stats = () => {
 
   const generateStatConfigItem = (key: string) => {
     const name = convertToTitleCase(key.split('_')[0])
-    const tooltip = name
+    const tooltip = `${name}s`
     const primaryIcon = normalizedSchemasByType[name]?.icon
     const Icon = Icons[primaryIcon as string] || NodesIcon
 


### PR DESCRIPTION
### Ticket №: #2206

closes #2206

### Problem:

Stats label name is singular but that should be plural as above stats node numbers are large

### Evidence:

https://www.loom.com/share/be4096c3b0c844318afca59a03caa524?sid=efafcba9-d51a-4454-b0a9-7977ed5fb0f0


