### PR TITLE
[Main Graph] When node text is large then it is going to be behind the Circle node icons

### DIFF
--- a/src/components/Universe/Graph/Cubes/Text/index.tsx
+++ b/src/components/Universe/Graph/Cubes/Text/index.tsx
@@ -161,7 +161,7 @@ export const TextNode = memo(({ node, hide, isHovered }: Props) => {
             color={color}
             fillOpacity={1 || fillOpacity}
             name="text"
-            position={[0, -40, 0]}
+            position={[0, -65, 0]}
             scale={textScale}
             userData={node}
             {...fontProps}


### PR DESCRIPTION

### Ticket №: #1939

closes #1939

### Problem:

When node text is large then it is going to be behind the Circle node icons

### Evidence:

![image](https://github.com/user-attachments/assets/4a6d9e1c-a065-4823-a05b-6b29a7b871a9)

