### PR TITLE
Fixed[UI Bug]: At Bottom Boost Section is Cut Off in SideBarSubView

### DIFF
--- a/src/components/App/SideBar/SelectedNodeView/Default/index.tsx
+++ b/src/components/App/SideBar/SelectedNodeView/Default/index.tsx
@@ -113,12 +113,13 @@ export const Default = () => {
         <StyledWrapper>
           {Object.entries(customKeys)
             .filter(([key]) => key !== 'media_url' && key !== 'link' && key !== 'pubkey')
-            .map(([key, value]) => (
+            .map(([key, value], index, array) => (
               <NodeDetail
                 key={key}
                 hasAudio={hasAudio}
                 isPlaying={isPlaying}
                 label={formatLabel(key)}
+                showDivider={index !== array.length - 1}
                 togglePlay={togglePlay}
                 value={key === 'date' && value ? moment(value * 1000).format('MMMM Do YYYY') : value}
               />
@@ -126,15 +127,18 @@ export const Default = () => {
         </StyledWrapper>
 
         {pubkey && (
-          <Flex direction="row" justify="space-between" pt={14} px={24}>
-            <BoostAmt amt={boostAmount} />
-            <Booster
-              content={selectedNode}
-              count={boostAmount}
-              refId={selectedNode.ref_id}
-              updateCount={setBoostAmount}
-            />
-          </Flex>
+          <BoostSectionWrapper>
+            <BoostStyledDivider />
+            <Flex direction="row" justify="space-between" pt={14} px={24}>
+              <BoostAmt amt={boostAmount} />
+              <Booster
+                content={selectedNode}
+                count={boostAmount}
+                refId={selectedNode.ref_id}
+                updateCount={setBoostAmount}
+              />
+            </Flex>
+          </BoostSectionWrapper>
         )}
       </StyledContent>
 
@@ -149,9 +153,16 @@ export const Default = () => {
 
 const formatLabel = (label: string) => label.replace(/_/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase())
 
-type Props = { label: string; value: unknown; hasAudio: boolean; isPlaying: boolean; togglePlay: () => void }
+type Props = {
+  label: string
+  value: unknown
+  hasAudio: boolean
+  isPlaying: boolean
+  togglePlay: () => void
+  showDivider: boolean
+}
 
-const NodeDetail = ({ label, value, hasAudio, isPlaying, togglePlay }: Props) => {
+const NodeDetail = ({ label, value, hasAudio, isPlaying, togglePlay, showDivider }: Props) => {
   const isLong = (value as string).length > 140
   const searchTerm = useAppStore((s) => s.currentSearch)
 
@@ -176,7 +187,7 @@ const NodeDetail = ({ label, value, hasAudio, isPlaying, togglePlay }: Props) =>
           </SyntaxHighlighter>
         )}
       </StyledDetail>
-      <StyledDivider />
+      {showDivider && <StyledDivider />}
     </>
   )
 }
@@ -292,4 +303,13 @@ const StyledLinkIcon = styled.a`
     width: 1.3em;
     height: 1.3em;
   }
+`
+
+const BoostSectionWrapper = styled(Flex)`
+  padding-bottom: 20px;
+`
+
+const BoostStyledDivider = styled(Divider)`
+  margin: auto 25px;
+  opacity: 0.75;
 `


### PR DESCRIPTION
### Problem:
- The `Boost` button at the bottom of the `SideBarSubView` is partially cut off, making it hard to see and click. This affects usability, as users may not be able to interact with the Boost feature effectively.
- When the `Boost` section is not displayed, an extra divider line appears at the end of the source details.

closes: #2410

## Issue ticket number and link:
- **Ticket Number:** [ 2410 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/2410 ]

### Evidence:

![image](https://github.com/user-attachments/assets/42849c77-9539-4009-b510-2cf1b8dd5e35)

![image](https://github.com/user-attachments/assets/7b30a173-53cc-4a50-a6de-3ab37f0f4cf6)

### Acceptance Criteria:
- [x] The `Boost` button should be fully visible in the `SideBarSubView`.
- [x]  It should not overlap with other UI elements or be cut off at any screen size.
- [x]  The `Boost` button should be easily clickable on all devices and screen resolutions.
- [x] If the `Boost` section is hidden, there should be no extra divider line appearing at the end of the source details.