### PR TITLE
[Blueprint] - When we select a node in blue print graph then node color should be reflected to color picker button at edit type sidebar 

### DIFF
--- a/src/components/ModalsContainer/BlueprintModal/Body/Graph/Nodes/Node/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Graph/Nodes/Node/index.tsx
@@ -9,6 +9,7 @@ import { fontProps } from '~/components/Universe/Graph/Cubes/Text/constants'
 import { useSchemaStore } from '~/stores/useSchemaStore'
 import { truncateText } from '~/utils/truncateText'
 import { NODE_RADIUS } from '../../constants'
+import { useAppStore } from '~/stores/useAppStore'
 
 export const NODE_TYPE_COLORS = ['#ff13c9', '#5af0ff', '#3233ff', '#c2f0c2', '#ff6666', '#99ccff', '#ffb3b3']
 
@@ -42,6 +43,7 @@ export const boxGeometry = new BoxGeometry(2, 2, 2)
 export const Node = memo(({ node, setSelectedNode, onSimulationUpdate, isSelected }: Props) => {
   const meshRef = useRef<Mesh | null>(null)
   const [normalizedSchemasByType] = useSchemaStore((s) => [s.normalizedSchemasByType])
+  const { setSelectedColor } = useAppStore((s) => s)
   const [showTooltip, setShowTooltip] = useState(false)
 
   console.log(isSelected)
@@ -124,7 +126,7 @@ export const Node = memo(({ node, setSelectedNode, onSimulationUpdate, isSelecte
       onPointerOver={handleMouseOver}
       position={new Vector3(node.x, node.y, 0)}
     >
-      <Circle args={[NODE_RADIUS, 30, 20]}>
+      <Circle args={[NODE_RADIUS, 30, 20]} onClick={() => setSelectedColor(color)}>
         <meshStandardMaterial attach="material" color={color} />
       </Circle>
 


### PR DESCRIPTION
### Ticket №: #2374

closes #2374

### Problem:

When we select a node in blue print graph then node color should be reflected to color picker button at edit type sidebar

### Evidence:




