### PR TITLE
[Setting modal] - Save Changes button position should be consistent on all tabs

### DIFF
--- a/src/components/SettingsModal/SettingsView/General/index.tsx
+++ b/src/components/SettingsModal/SettingsView/General/index.tsx
@@ -89,7 +89,7 @@ export const General: FC<Props> = ({ initialValues, onClose }) => {
             </Flex>
           </Flex>
 
-          <Flex py={error ? 0 : 24}>
+          <Flex mt={210} py={error ? 0 : 24}>
             <Button
               color="secondary"
               disabled={isSubmitting}


### PR DESCRIPTION
### Ticket №: #2160

closes #2160

### Problem:

Save Changes button position is not consistent on among all tabs

### Evidence:


https://www.loom.com/share/211b8b0fc1094d789b7f6e285ce24b29?sid=cb40bf43-1ca9-497a-8c9c-f1ca6175368c

