### PR TITLE
[Search Filtering]: `View More` for Node Types Rendering with Default Limit of `4 Rows`

### DIFF
--- a/src/components/App/SideBar/FilterSearch/NodeTypes/index.tsx
+++ b/src/components/App/SideBar/FilterSearch/NodeTypes/index.tsx
@@ -15,7 +15,11 @@ type Props = {
 export const NodeTypes = ({ handleSchemaTypeClick, selectedTypes, schemaAll }: Props) => {
   const [showAllSchemas, setShowAllSchemas] = useState(false)
 
-  const uniqueSchemas = (showAllSchemas ? schemaAll : schemaAll.slice(0, 4)).filter(
+  const schemasPerRow = 3
+  const MAX_ROWS = 4
+  const maxVisibleSchemas = schemasPerRow * MAX_ROWS
+
+  const uniqueSchemas = (showAllSchemas ? schemaAll : schemaAll.slice(0, maxVisibleSchemas)).filter(
     (schema, index, self) => index === self.findIndex((s) => s.type === schema.type),
   )
 
@@ -40,7 +44,7 @@ export const NodeTypes = ({ handleSchemaTypeClick, selectedTypes, schemaAll }: P
             </SchemaType>
           ))}
         </SchemaTypeWrapper>
-        {!showAllSchemas && schemaAll.length > 4 && (
+        {!showAllSchemas && schemaAll.length > maxVisibleSchemas && (
           <ViewMoreButton onClick={() => setShowAllSchemas(true)}>
             <PlusIconWrapper>
               <PlusIcon /> View More


### PR DESCRIPTION
### Problem:
- Currently, search filter `Type` section does not display `4 rows` by default, and does not according to Figma.

closes: #2420

## Issue ticket number and link:
- **Ticket Number:** [ 2420 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/2420 ]

### Evidence:

![image](https://github.com/user-attachments/assets/8ffd20b4-94f3-484f-b2ee-7e31a817813f)

https://www.loom.com/share/c5cf67d52d58407b9436a659da99f0af

### Acceptance Criteria:
- [x] Render `4 rows` by default.
- [x] Show `View More` if there are more node types than can be displayed in 4 rows.
- [x] Clicking `View More` should render all remaining node types.