### PR TITLE
feat: update transcript logic for improved playback experience

### DIFF
--- a/src/components/mindset/components/Sidebar/Transcript/Viewer/index.tsx
+++ b/src/components/mindset/components/Sidebar/Transcript/Viewer/index.tsx
@@ -90,21 +90,27 @@ export const Viewer = ({ transcriptString }: Props) => {
 
   return (
     <Wrapper ref={wrapperRef}>
-      {transcriptData.map((i) => {
-        const start = secondsToMediaTime(i.start)
+      {transcriptData[0].start > currentTime ? (
+        <Paragraph active={false} start={secondsToMediaTime(transcriptData[0].start)} text={transcriptData[0].text} />
+      ) : (
+        <>
+          {transcriptData.map((i) => {
+            const start = secondsToMediaTime(i.start)
 
-        const isActive = i.start < currentTime && currentTime < i.end
+            const isActive = i.start < currentTime && currentTime < i.end
 
-        return (
-          <Paragraph
-            key={`${i.start}-${i.end}`}
-            ref={isActive ? activeRef : null}
-            active={isActive}
-            start={start}
-            text={i.text}
-          />
-        )
-      })}
+            return i.start <= currentTime + 5 ? (
+              <Paragraph
+                key={`${i.start}-${i.end}`}
+                ref={isActive ? activeRef : null}
+                active={isActive}
+                start={start}
+                text={i.text}
+              />
+            ) : null
+          })}
+        </>
+      )}
     </Wrapper>
   )
 }

--- a/src/components/mindset/components/Sidebar/Transcript/index.tsx
+++ b/src/components/mindset/components/Sidebar/Transcript/index.tsx
@@ -45,7 +45,7 @@ export const Transcript = () => {
     return () => clearInterval(interval)
   }, [playerRef, setCurrentTime])
 
-  return currentTime ? (
+  return (
     <Wrapper>
       <Flex className="heading">Transcript</Flex>
       {clips.map((clip) => {
@@ -67,7 +67,7 @@ export const Transcript = () => {
         return null
       })}
     </Wrapper>
-  ) : null
+  )
 }
 
 const Wrapper = styled(Flex)`


### PR DESCRIPTION
### Ticket №2503

closes #2503

### Problem:

The transcript viewer was displaying all lines at once, making it difficult to read and follow along with the video content. The requirement was to implement gradual appearance of lines synchronized with playback.

### Solution:

Implemented conditional rendering of transcript lines:
- Only the first line is shown at start
- Subsequently, lines appear with a small lead time (5 seconds) relative to current playback time
- During seek/rewind, only relevant lines are displayed

### Changes:

- Modified Viewer component for conditional line rendering
- Added first fragment start time check to show initial line
- Implemented line filtering based on start time relative to current playback time
- Optimized logic for active/inactive line display

### Testing:

Manual testing was performed for the following scenarios:
- Playback start (initial line display)
- Normal playback (gradual line appearance)
- Forward/backward seek (correct visible line updates)
- Scrolling (auto-scroll functionality)

### Notes:

Used time-based filtering approach instead of line counter for more natural behavior and better performance.
