### PR TITLE
fix: failing cypress test due to mindset graph

### DIFF
--- a/src/components/AppContainer/index.tsx
+++ b/src/components/AppContainer/index.tsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense } from 'react'
 import { Route, Routes } from 'react-router-dom'
+import { isE2E } from '~/constants'
 import { E2ETests } from '~/utils'
 import { AppProviders } from '../App/Providers'
 import { AuthGuard } from '../Auth'
@@ -10,7 +11,7 @@ const LazyMindSet = lazy(() => import('../mindset').then(({ MindSet }) => ({ def
 
 export const AppContainer = () => {
   const isMindSetHost =
-    window.location?.hostname === 'graphmindset.sphinx.chat' || window.location.hostname === 'localhost'
+    window.location?.hostname === 'graphmindset.sphinx.chat' || (window.location.hostname === 'localhost' && !isE2E)
 
   return (
     <AppProviders>


### PR DESCRIPTION
### Ticket №:

closes 2523

### Problem:

Cypress tests are failing

### Solution:

The issue was with a variable added to confirm if it was a mindset graph or not and all localhost defaulted to the mindset graph. I ensured when it's E2E we don't display the mindset component

### Changes:
Ensured mindset graph is loaded only when it's when it's localhost and not e2e

### Testing:

did you add any aditional test coverage if so where and what did you test

### Notes:

any additional notes
