### PR TITLE
Fixed[BluePrint]: Confirm Button Enabled Without Changes & Node Color Not Reflected in Color Picker

### DIFF
--- a/src/components/ModalsContainer/BlueprintModal/Body/Editor/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Editor/index.tsx
@@ -420,7 +420,7 @@ export const Editor = ({
   })
 
   useEffect(() => {
-    if (selectedColor !== selectedSchema?.primary_color) {
+    if (isPopoverOpen && selectedColor !== selectedSchema?.primary_color) {
       setSubmitDisabled(false)
     }
 
@@ -443,7 +443,7 @@ export const Editor = ({
     })
 
     return () => subscription.unsubscribe()
-  }, [form, attributes, parsedData, selectedSchema, loading, displayParentError, selectedColor])
+  }, [form, attributes, parsedData, selectedSchema, loading, displayParentError, selectedColor, isPopoverOpen])
 
   const resolvedParentValue = () => parentOptions?.find((i) => i.value === parent)
 

--- a/src/components/ModalsContainer/BlueprintModal/Body/Graph/Nodes/Node/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Graph/Nodes/Node/index.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components'
 import { BoxGeometry, Mesh, Vector3 } from 'three'
 import { SchemaExtended } from '~/components/ModalsContainer/BlueprintModal/types'
 import { fontProps } from '~/components/Universe/Graph/Cubes/Text/constants'
+import { useAppStore } from '~/stores/useAppStore'
 import { useSchemaStore } from '~/stores/useSchemaStore'
 import { truncateText } from '~/utils/truncateText'
 import { NODE_RADIUS } from '../../constants'
@@ -43,6 +44,7 @@ export const Node = memo(({ node, setSelectedNode, onSimulationUpdate, isSelecte
   const meshRef = useRef<Mesh | null>(null)
   const [normalizedSchemasByType] = useSchemaStore((s) => [s.normalizedSchemasByType])
   const [showTooltip, setShowTooltip] = useState(false)
+  const { setSelectedColor } = useAppStore((s) => s)
 
   console.log(isSelected)
 
@@ -124,7 +126,7 @@ export const Node = memo(({ node, setSelectedNode, onSimulationUpdate, isSelecte
       onPointerOver={handleMouseOver}
       position={new Vector3(node.x, node.y, 0)}
     >
-      <Circle args={[NODE_RADIUS, 30, 20]}>
+      <Circle args={[NODE_RADIUS, 30, 20]} onClick={() => setSelectedColor(color)}>
         <meshStandardMaterial attach="material" color={color} />
       </Circle>
 


### PR DESCRIPTION
### Problem:
- The Confirm button remains enabled without any changes in the Edit Type or Created Type Modal.
- Node color is not reflected in the color picker button when a node is selected in the blueprint graph.

closes: #2556

## Issue ticket number and link:
- **Ticket Number:** [ 2556 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/2556]

### Evidence:

https://www.loom.com/share/c5f0930b8c544209a7e16bd19308cce1

![image](https://github.com/user-attachments/assets/e2801a96-7fc2-4ad5-b91f-6cfbd2cad690)

![image](https://github.com/user-attachments/assets/cea9c031-9417-42b7-b1e8-400189be6636)

![image](https://github.com/user-attachments/assets/d57ec5e9-db9f-49b8-affd-3fb153dd7803)

### Acceptance Criteria:
- [x] Confirm button is disabled until changes are made in the Edit Type or Created Type Modal.
- [x] Selected node color is accurately reflected in the color picker button on the Edit Type sidebar.