### PR TITLE
Fixed[Blue-Graph]: Enable 'Confirm' Button When Attribute is Deleted

### DIFF
--- a/src/components/ModalsContainer/BlueprintModal/Body/Editor/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Editor/index.tsx
@@ -303,6 +303,7 @@ export const Editor = ({
 
   const handleDeleteAttribute = (attributeKey: string) => {
     setDeletedAttributes((prev) => [...prev, attributeKey])
+    setSubmitDisabled(false)
   }
 
   const handleDelete = async () => {


### PR DESCRIPTION
### Problem:
- 'Confirm' button not enabled after attribute deletion in form.

closes: #2554

## Issue ticket number and link:
- **Ticket Number:** [ 2554 ]
- **Link:** [ https://github.com/stakwork/sphinx-nav-fiber/issues/2554 ]

### Evidence:

https://www.loom.com/share/654f6309fbda4647a3904046bfb5d4cf
