### PR TITLE
Fix: Reduce Line Height Between Sequenced Nodes in Sidebar

### DIFF
--- a/src/components/App/SideBar/SelectedNodeView/Default/index.tsx
+++ b/src/components/App/SideBar/SelectedNodeView/Default/index.tsx
@@ -361,12 +361,12 @@ const StyledLinkIcon = styled.a`
 const StyledSequenceWrapper = styled(Flex)`
   padding: 16px 24px;
   flex-direction: column;
-  gap: 8px;
+  gap: 4px;
   overflow-y: auto;
 `
 
 const StyledLineBreak = styled.div`
   width: 100%;
   height: 1px;
-  margin: 8px 0;
+  margin: 2px 0;
 `


### PR DESCRIPTION
### Ticket №: https://github.com/stakwork/sphinx-nav-fiber/issues/2553

closes #2553


![image](https://github.com/user-attachments/assets/f7b54246-1877-4cbc-84a6-0914e361d996)
