### PR TITLE
feat: added routing for selected episode

### DIFF
--- a/src/components/AppContainer/index.tsx
+++ b/src/components/AppContainer/index.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense } from 'react'
-import { Route, Routes } from 'react-router-dom'
+import { Navigate, Route, Routes } from 'react-router-dom'
 import { isE2E } from '~/constants'
 import { E2ETests } from '~/utils'
 import { AppProviders } from '../App/Providers'
@@ -22,6 +22,7 @@ export const AppContainer = () => {
             <>
               <Route element={<LandingPage />} path="/" />
               <Route element={<LazyMindSet />} path="/episode/:episodeId" />
+              <Route element={<Navigate replace to="/" />} path="/episode" />
             </>
           )}
           <Route

--- a/src/components/AppContainer/index.tsx
+++ b/src/components/AppContainer/index.tsx
@@ -4,6 +4,7 @@ import { isE2E } from '~/constants'
 import { E2ETests } from '~/utils'
 import { AppProviders } from '../App/Providers'
 import { AuthGuard } from '../Auth'
+import { LandingPage } from '../mindset/components/LandingPage'
 
 // Lazy-loaded components
 const LazyApp = lazy(() => import('../App').then(({ App }) => ({ default: App })))
@@ -17,7 +18,12 @@ export const AppContainer = () => {
     <AppProviders>
       <Suspense fallback={<div>Loading...</div>}>
         <Routes>
-          {isMindSetHost && <Route element={<LazyMindSet />} path="/" />}
+          {isMindSetHost && (
+            <>
+              <Route element={<LandingPage />} path="/" />
+              <Route element={<LazyMindSet />} path="/episode/:episodeId" />
+            </>
+          )}
           <Route
             element={
               <AuthGuard>

--- a/src/components/Universe/Graph/Cubes/Text/index.tsx
+++ b/src/components/Universe/Graph/Cubes/Text/index.tsx
@@ -201,7 +201,7 @@ export const TextNode = memo(
               }}
               position={[-15, 15, 0]}
               scale={2}
-              src={`svg-icons/${iconName}.svg`}
+              src={`/svg-icons/${iconName}.svg`}
               userData={node}
             />
           )}

--- a/src/components/mindset/components/LandingPage/index.tsx
+++ b/src/components/mindset/components/LandingPage/index.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { FieldValues } from 'react-hook-form'
+import { useNavigate } from 'react-router-dom'
 import styled from 'styled-components'
 import { Flex } from '~/components/common/Flex'
 import { NODE_ADD_ERROR } from '~/constants'
@@ -94,8 +95,10 @@ export const LandingPage = () => {
   const [error, setError] = useState(false)
   const [requestError, setRequestError] = useState<string>('')
   const { setRunningProjectId } = useDataStore((s) => s)
-  const { setSelectedEpisodeId, setSelectedEpisodeLink } = useMindsetStore((s) => s)
+  const { setSelectedEpisodeLink } = useMindsetStore((s) => s)
   const { setSchemas } = useSchemaStore((s) => s)
+
+  const navigate = useNavigate()
 
   useEffect(() => {
     const fetchSchemaData = async () => {
@@ -130,7 +133,7 @@ export const LandingPage = () => {
         }
 
         if (res.data.ref_id) {
-          setSelectedEpisodeId(res.data.ref_id)
+          navigate(`/episode/${res.data.ref_id}`)
           setSelectedEpisodeLink(source)
         }
 
@@ -144,7 +147,7 @@ export const LandingPage = () => {
           errorMessage = res.errorCode || res?.status || NODE_ADD_ERROR
 
           if (res.data.ref_id) {
-            setSelectedEpisodeId(res.data.ref_id)
+            navigate(`/episode/${res.data.ref_id}`)
             setSelectedEpisodeLink(source)
           }
         } else if (err instanceof Error) {

--- a/src/components/mindset/index.tsx
+++ b/src/components/mindset/index.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useParams } from 'react-router-dom'
 import { Socket } from 'socket.io-client'
 import styled from 'styled-components'
 import { Flex } from '~/components/common/Flex'
@@ -11,16 +12,14 @@ import { useMindsetStore } from '~/stores/useMindsetStore'
 import { usePlayerStore } from '~/stores/usePlayerStore'
 import { FetchDataResponse, Link, Node } from '~/types'
 import { Header } from './components/Header'
-import { LandingPage } from './components/LandingPage'
 import { PlayerControl } from './components/PlayerContols'
-import { Scene } from './components/Scene'
 import { SideBar } from './components/Sidebar'
 
 export const MindSet = () => {
   const { addNewNode, isFetching, runningProjectId } = useDataStore((s) => s)
   const [dataInitial, setDataInitial] = useState<FetchDataResponse | null>(null)
   const [showTwoD, setShowTwoD] = useState(false)
-  const { selectedEpisodeId, setSelectedEpisode } = useMindsetStore((s) => s)
+  const { setSelectedEpisode } = useMindsetStore((s) => s)
   const setClips = useMindsetStore((s) => s.setClips)
   const clips = useMindsetStore((s) => s.clips)
   const socket: Socket | undefined = useSocket()
@@ -31,12 +30,14 @@ export const MindSet = () => {
   const queueRef = useRef<FetchDataResponse | null>(null)
   const timerRef = useRef<NodeJS.Timeout | null>(null)
 
+  const { episodeId: selectedEpisodeId } = useParams()
+
   const { setPlayingNode } = usePlayerStore((s) => s)
 
   useEffect(() => {
-    const init = async () => {
+    const init = async (id: string) => {
       try {
-        const data = await getNode(selectedEpisodeId)
+        const data = await getNode(id)
 
         if (data) {
           setPlayingNode(data)
@@ -49,7 +50,7 @@ export const MindSet = () => {
     }
 
     if (selectedEpisodeId) {
-      init()
+      init(selectedEpisodeId)
     }
   }, [selectedEpisodeId, setPlayingNode, setSelectedEpisode, addNewNode])
 
@@ -57,12 +58,12 @@ export const MindSet = () => {
     const fetchInitialData = async () => {
       try {
         // Fetch the initial set of edges and nodes for the episode
-        const starterNodes = await fetchNodeEdges(selectedEpisodeId, 0, 50, {
+        const starterNodes = await fetchNodeEdges(selectedEpisodeId || '', 0, 50, {
           nodeType: ['Show', 'Host', 'Guest'],
           useSubGraph: false,
         })
 
-        const clipNodes = await fetchNodeEdges(selectedEpisodeId, 0, 50, {
+        const clipNodes = await fetchNodeEdges(selectedEpisodeId || '', 0, 50, {
           nodeType: ['Clip'],
           useSubGraph: false,
         })
@@ -282,23 +283,19 @@ export const MindSet = () => {
   return (
     <MainContainer>
       <ContentWrapper direction="row">
-        {selectedEpisodeId ? (
-          <>
-            <Flex>
-              <Flex onClick={() => setShowTwoD(!showTwoD)}>
-                <Header />
-              </Flex>
-              <SideBar />
+        <>
+          <Flex>
+            <Flex onClick={() => setShowTwoD(!showTwoD)}>
+              <Header />
             </Flex>
-            <ContentContainer>
-              <Flex basis="100%" grow={1} shrink={1}>
-                {showTwoD ? <Scene /> : <Universe />}
-              </Flex>
-            </ContentContainer>
-          </>
-        ) : (
-          <LandingPage />
-        )}
+            <SideBar />
+          </Flex>
+          <ContentContainer>
+            <Flex basis="100%" grow={1} shrink={1}>
+              <Universe />
+            </Flex>
+          </ContentContainer>
+        </>
       </ContentWrapper>
       <PlayerControlWrapper>
         <PlayerControl markers={markers} />

--- a/src/components/mindset/index.tsx
+++ b/src/components/mindset/index.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { useParams } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
 import { Socket } from 'socket.io-client'
 import styled from 'styled-components'
 import { Flex } from '~/components/common/Flex'
@@ -30,6 +30,8 @@ export const MindSet = () => {
   const queueRef = useRef<FetchDataResponse | null>(null)
   const timerRef = useRef<NodeJS.Timeout | null>(null)
 
+  const navigate = useNavigate()
+
   const { episodeId: selectedEpisodeId } = useParams()
 
   const { setPlayingNode } = usePlayerStore((s) => s)
@@ -45,6 +47,7 @@ export const MindSet = () => {
           addNewNode({ nodes: [data], edges: [] })
         }
       } catch (error) {
+        navigate('/')
         console.error(error)
       }
     }
@@ -52,7 +55,7 @@ export const MindSet = () => {
     if (selectedEpisodeId) {
       init(selectedEpisodeId)
     }
-  }, [selectedEpisodeId, setPlayingNode, setSelectedEpisode, addNewNode])
+  }, [selectedEpisodeId, setPlayingNode, setSelectedEpisode, addNewNode, navigate])
 
   useEffect(() => {
     const fetchInitialData = async () => {
@@ -78,6 +81,7 @@ export const MindSet = () => {
           setClips(clipNodes?.nodes)
         }
       } catch (error) {
+        navigate('/')
         console.error('Error fetching initial data:', error)
       }
     }
@@ -85,7 +89,7 @@ export const MindSet = () => {
     if (selectedEpisodeId) {
       fetchInitialData()
     }
-  }, [selectedEpisodeId, addNewNode, setClips])
+  }, [selectedEpisodeId, addNewNode, setClips, navigate])
 
   useEffect(() => {
     if (!clips) {


### PR DESCRIPTION
### Ticket №2625

closes #2625

### Problem:

Currently, the application lacks direct routing to specific episodes via URL. Users cannot directly access episodes through URLs or share links to specific episodes, as the episode selection is handled through store state rather than URL routing.

### Solution:

Implemented new routing logic that allows direct access to episodes via URL parameters. Episodes can now be accessed through mainroute/episode_ref_id where ref_id is the unique identifier for each episode.

### Changes:

- Added new route pattern: mainroute/episode_ref_id
- Modified LandingPage component (src/components/mindset/components/LandingPage/index.tsx) to: load landing page on mainroute, replace store state management with URL-based navigation, implement navigation to mainroute/episode_ref_id when episode is selected
- Updated mindset to: extract episode red id from URL, fetch episode data based on route, initialize episode player and graph based on fetched data

### Testing:

- Landing page loads correctly on mainroute
- Episode selection navigates to correct URL
- Direct episode URL access loads correct episode
- Page reload with episode ID maintains correct episode state
- Verified routing works specifically for graphmindset

### Notes:

This change improves user experience by enabling direct episode access via URLs and allowing users to share specific episode links.
