### PR TITLE
[AI Chat] Allow user to provide feedback 

### DIFF
--- a/src/components/App/SideBar/AiSummary/AiAnswer/index.tsx
+++ b/src/components/App/SideBar/AiSummary/AiAnswer/index.tsx
@@ -29,7 +29,7 @@ type Props = {
   isPlaying?: boolean
   onTogglePlay?: () => void
   hasAudio?: boolean
-  chain: string // Add chain ID as a prop
+  chain: string
 }
 
 const Wrapper = styled(Flex).attrs({
@@ -78,12 +78,18 @@ const StyledButton = styled(Button)`
     background-color: transparent;
     border-radius: 6px;
     cursor: pointer;
-    transition: ${({ theme }) => theme.transitions.create(['opacity', 'box-shadow', 'background-color'])};
+    transition: ${({ theme }) => theme.transitions.create(['opacity', 'box-shadow', 'background-color', 'transform'])};
 
     &.active {
       background-color: ${colors.COLLAPSE_BUTTON};
     }
 
+    &.hidden {
+      opacity: 0;
+      transform: scale(0.5);
+      pointer-events: none;
+      transition: opacity 0.2s ease, transform 0.2s ease;
+    }
     ${Text} {
       display: none;
       opacity: 0;
@@ -182,13 +188,13 @@ export const AiAnswer = ({
       timeoutId = setTimeout(() => {
         setDisplayedText(answer.slice(0, displayedText.length + 1))
       }, 10)
-
-      // eslint-disable-next-line consistent-return
-      return () => clearTimeout(timeoutId)
+    } else {
+      setIsDescriptionComplete(true)
+      handleLoaded()
     }
 
-    setIsDescriptionComplete(true)
-    handleLoaded()
+    // eslint-disable-next-line consistent-return
+    return () => clearTimeout(timeoutId)
   }, [answer, displayedText, handleLoaded, hasBeenRendered])
 
   useEffect(() => {
@@ -299,14 +305,38 @@ export const AiAnswer = ({
             )}
             <Text>Copy</Text>
           </StyledButton>
-          <StyledButton className={feedback === 'positive' ? 'active' : ''} onClick={handlePositiveFeedback}>
-            <IconWrapper>{feedback === 'positive' ? <ThumbUpIcon /> : <PositiveFeedBackIcon />}</IconWrapper>
-            <Text>Helpful</Text>
-          </StyledButton>
-          <StyledButton className={feedback === 'negative' ? 'active' : ''} onClick={handleNegativeFeedback}>
-            <IconWrapper>{feedback === 'negative' ? <ThumbDownIcon /> : <NegativeFeedBackIcon />}</IconWrapper>
-            <Text>Unhelpful</Text>
-          </StyledButton>
+          {feedback === null && (
+            <>
+              <StyledButton onClick={handlePositiveFeedback}>
+                <IconWrapper>
+                  <PositiveFeedBackIcon />
+                </IconWrapper>
+                <Text>Helpful</Text>
+              </StyledButton>
+              <StyledButton onClick={handleNegativeFeedback}>
+                <IconWrapper>
+                  <NegativeFeedBackIcon />
+                </IconWrapper>
+                <Text>Unhelpful</Text>
+              </StyledButton>
+            </>
+          )}
+          {feedback === 'positive' && (
+            <StyledButton disabled>
+              <IconWrapper>
+                <ThumbUpIcon />
+              </IconWrapper>
+              <Text>Helpful</Text>
+            </StyledButton>
+          )}
+          {feedback === 'negative' && (
+            <StyledButton disabled>
+              <IconWrapper>
+                <ThumbDownIcon />
+              </IconWrapper>
+              <Text>Unhelpful</Text>
+            </StyledButton>
+          )}
           <StyledButton onClick={onRegenerate}>
             <IconWrapper>
               <RegenerateIcon />

--- a/src/components/App/SideBar/AiSummary/AiAnswer/index.tsx
+++ b/src/components/App/SideBar/AiSummary/AiAnswer/index.tsx
@@ -28,6 +28,7 @@ type Props = {
   isPlaying?: boolean
   onTogglePlay?: () => void
   hasAudio?: boolean
+  chain: string // Add chain ID as a prop
 }
 
 const Wrapper = styled(Flex).attrs({
@@ -159,6 +160,7 @@ export const AiAnswer = ({
   isPlaying,
   onTogglePlay,
   hasAudio,
+  chain,
 }: Props) => {
   const { fetchData, setAbortRequests } = useDataStore((s) => s)
   const { setBudget } = useUserStore((s) => s)
@@ -216,6 +218,40 @@ export const AiAnswer = ({
     isDescriptionComplete,
   )
 
+  const sendFeedback = async (feedbackType: 'helpful' | 'unhelpful') => {
+    try {
+      const payload = {
+        answer,
+        chain,
+        feedback_type: feedbackType,
+      }
+
+      const response = await fetch('/answer/feedback', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      })
+
+      if (response.ok) {
+        setFeedback(feedbackType === 'helpful' ? 'positive' : 'negative')
+      } else {
+        console.error('Failed to send feedback')
+      }
+    } catch (error) {
+      console.error('Error sending feedback:', error)
+    }
+  }
+
+  const handlePositiveFeedback = () => {
+    sendFeedback('helpful')
+  }
+
+  const handleNegativeFeedback = () => {
+    sendFeedback('unhelpful')
+  }
+
   console.log(responseTextDisplay)
 
   const handleCopy = async () => {
@@ -229,14 +265,6 @@ export const AiAnswer = ({
     } catch (err) {
       console.error('Failed to copy text:', err)
     }
-  }
-
-  const handlePositiveFeedback = () => {
-    setFeedback((current) => (current === 'positive' ? null : 'positive'))
-  }
-
-  const handleNegativeFeedback = () => {
-    setFeedback((current) => (current === 'negative' ? null : 'negative'))
   }
 
   return (

--- a/src/components/App/SideBar/AiSummary/AiAnswer/index.tsx
+++ b/src/components/App/SideBar/AiSummary/AiAnswer/index.tsx
@@ -14,6 +14,7 @@ import PositiveFeedBackIcon from '~/components/Icons/PositiveFeedBackIcon'
 import RegenerateIcon from '~/components/Icons/RegenerateIcon'
 import ThumbDownIcon from '~/components/Icons/ThumbDownIcon'
 import ThumbUpIcon from '~/components/Icons/ThumbUpIcon'
+import { postFeedback } from '~/network/fetchSourcesData'
 import { useDataStore } from '~/stores/useDataStore'
 import { useUserStore } from '~/stores/useUserStore'
 import { ExtractedEntity } from '~/types/index'
@@ -218,6 +219,10 @@ export const AiAnswer = ({
     isDescriptionComplete,
   )
 
+  interface FeedbackResponse {
+    status: 'success' | 'error'
+  }
+
   const sendFeedback = async (feedbackType: 'helpful' | 'unhelpful') => {
     try {
       const payload = {
@@ -226,18 +231,12 @@ export const AiAnswer = ({
         feedback_type: feedbackType,
       }
 
-      const response = await fetch('/answer/feedback', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(payload),
-      })
+      const response = (await postFeedback(payload)) as FeedbackResponse
 
-      if (response.ok) {
+      if (response.status === 'success') {
         setFeedback(feedbackType === 'helpful' ? 'positive' : 'negative')
       } else {
-        console.error('Failed to send feedback')
+        console.error(response, 'Failed to send feedback')
       }
     } catch (error) {
       console.error('Error sending feedback:', error)
@@ -245,11 +244,19 @@ export const AiAnswer = ({
   }
 
   const handlePositiveFeedback = () => {
-    sendFeedback('helpful')
+    if (feedback === 'positive') {
+      setFeedback(null)
+    } else {
+      sendFeedback('helpful')
+    }
   }
 
   const handleNegativeFeedback = () => {
-    sendFeedback('unhelpful')
+    if (feedback === 'negative') {
+      setFeedback(null)
+    } else {
+      sendFeedback('unhelpful')
+    }
   }
 
   console.log(responseTextDisplay)

--- a/src/components/App/SideBar/AiSummary/index.tsx
+++ b/src/components/App/SideBar/AiSummary/index.tsx
@@ -150,6 +150,7 @@ export const AiSummary = ({ question, response, refId }: Props) => {
           ) : (
             <AiAnswer
               answer={response.answer || ''}
+              chain={refId}
               entities={response.entities}
               handleLoaded={() => handleLoaded()}
               hasAudio={!!response.audio_en}

--- a/src/network/fetchSourcesData/index.ts
+++ b/src/network/fetchSourcesData/index.ts
@@ -189,6 +189,12 @@ export const getNodes = async (): Promise<FetchDataResponse> => {
   return response
 }
 
+export const postFeedback = async (data: { answer: string; chain: string; feedback_type: 'helpful' | 'unhelpful' }) => {
+  const response = await api.post('/answer/feedback', JSON.stringify(data))
+
+  return response
+}
+
 export const editNodeSchemaUpdate = async (ref_id: string, data: UpdateSchemaParams) => {
   const response = await api.put(`/schema/${ref_id}`, JSON.stringify(data))
 


### PR DESCRIPTION
### Ticket №: #2655 

closes #2655

### Problem:

We need to connect our two feedback buttons (“helpful” and “unhelpful”) to the backend so that whenever a user selects either button, it will send a POST request to the /answer/feedback endpoint with the correct parameters.

### Solution:

https://www.loom.com/share/e0d00e0c04274d07ae416ac4915a945a?sid=bad409ba-a89e-41c0-b9ed-7b2d08ecee7b
