### PR TITLE
fix: refactor graph search endpoint

### DIFF
--- a/cypress/e2e/seeLatest/latest.cy.ts
+++ b/cypress/e2e/seeLatest/latest.cy.ts
@@ -1,4 +1,4 @@
-//describe('See latest button as new node are added', () => {
+// describe('See latest button as new node are added', () => {
 //  it('See latest as nodes are being added', () => {
 //    cy.initialSetup('carol', 300)
 //
@@ -34,7 +34,7 @@
 //
 //      cy.intercept({
 //        method: 'GET',
-//        url: 'http://localhost:8444/api/prediction/graph/search/latest*',
+//        url: 'http://localhost:8444/api/graph/search/latest*',
 //      }).as('getLatest')
 //
 //      cy.get('[data-testid="see_latest_button"]').should('exist')
@@ -53,4 +53,4 @@
 //      // })
 //    })
 //  })
-//})
+// })

--- a/cypress/e2e/trendingTopics/trendingTopics.cy.ts
+++ b/cypress/e2e/trendingTopics/trendingTopics.cy.ts
@@ -2,7 +2,7 @@ describe('test trending topics', () => {
   it('Checking it trending topics exist', () => {
     cy.intercept({
       method: 'GET',
-      url: 'http://localhost:8444/api/prediction/graph/search/latest*',
+      url: 'http://localhost:8444/api/graph/search/latest*',
     }).as('loadLatest')
 
     cy.intercept({
@@ -22,7 +22,7 @@ describe('test trending topics', () => {
 
     cy.intercept({
       method: 'GET',
-      url: 'http://localhost:8444/api/prediction/graph/search*',
+      url: 'http://localhost:8444/api/graph/search*',
     }).as('search')
 
     cy.visit('/', {
@@ -59,7 +59,7 @@ describe('test trending topics', () => {
 
       cy.intercept({
         method: 'GET',
-        url: 'http://localhost:8444/api/prediction/graph/search*',
+        url: 'http://localhost:8444/api/graph/search*',
       }).as('search2')
 
       cy.wait('@search2')

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -49,7 +49,7 @@ Cypress.Commands.add('initialSetup', (username, budget) => {
 
   cy.intercept({
     method: 'GET',
-    url: 'http://localhost:8444/api/prediction/graph/search/latest*',
+    url: 'http://localhost:8444/api/graph/search/latest*',
   }).as('loadLatest')
 
   cy.visit('/', {

--- a/src/components/mindset/components/LandingPage/fetchNodes/index.ts
+++ b/src/components/mindset/components/LandingPage/fetchNodes/index.ts
@@ -2,7 +2,7 @@ import { api } from '~/network/api'
 import { FetchDataResponse } from '~/types'
 
 export const getNodes = async (): Promise<FetchDataResponse> => {
-  const url = `/prediction/graph/search?node_type=['Episode']&include_properties=true&includeContent=true&sort_by=date&top_node_count=20`
+  const url = `/graph/search?node_type=['Episode']&include_properties=true&includeContent=true&sort_by=date&top_node_count=20`
 
   const response = await api.get<FetchDataResponse>(url)
 

--- a/src/network/fetchGraphData/index.ts
+++ b/src/network/fetchGraphData/index.ts
@@ -22,7 +22,7 @@ const fetchNodes = async (
   setAbortRequests: (status: boolean) => void,
 ): Promise<FetchDataResponse> => {
   const args = new URLSearchParams(params).toString()
-  const url = isLatest ? `/prediction/graph/search/latest?` : `/prediction/graph/search?${args}`
+  const url = isLatest ? `/graph/search/latest?` : `/graph/search?${args}`
 
   const fetchWithLSAT = async (): Promise<FetchDataResponse> => {
     const lsatToken = await getLSat()


### PR DESCRIPTION
### Ticket №:  
https://github.com/stakwork/sphinx-nav-fiber/issues/2826

### Problem:  
The `/prediction/graph/search` and `/prediction/graph/search/latest` endpoints were being deprecated in favor of cleaner, more concise URLs. We needed to update all references to these endpoints across the codebase before removing the old ones.  

### Solution:  
Updated all instances of `/prediction/graph/search` to `/graph/search` and `/prediction/graph/search/latest` to `/graph/search/latest`. Ensured that all calls to these endpoints reflect the new paths, and verified that the new endpoints are functional.  

### Changes:  
- Updated API calls from `/prediction/graph/search` → `/graph/search`  
- Updated API calls from `/prediction/graph/search/latest` → `/graph/search/latest`  
- Checked and modified any helper functions that referenced the old paths  
- Removed any deprecated references to `/prediction/graph/search`  

### Testing:  
- Verified that all affected endpoints return the expected responses.  
- Ran existing test cases that cover graph search functionality.  
- Checked logs and API responses to confirm no breakage in dependent services.  