### PR TITLE
fix: remove overflow so I can see full error in frontend

### DIFF
--- a/src/components/AddContentModal/BudgetStep/index.tsx
+++ b/src/components/AddContentModal/BudgetStep/index.tsx
@@ -165,7 +165,6 @@ const StyledErrorText = styled(Flex)`
     display: -webkit-box;
     -webkit-line-clamp: 1;
     -webkit-box-orient: vertical;
-    overflow: hidden;
     white-space: normal;
     letter-spacing: 0.2px;
     cursor: pointer;


### PR DESCRIPTION
I want to be able to see the full error since sometimes I get an error but only seeing the partial error doesnt give me much info

not totally sure how to make the background still cover the error message since it now will bleed off of the modal