### PR TITLE
fix: updated default values and fixed depth on search

### DIFF
--- a/src/components/App/SideBar/FilterSearch/__tests__/index.tsx
+++ b/src/components/App/SideBar/FilterSearch/__tests__/index.tsx
@@ -106,8 +106,8 @@ describe('FilterSearch Component', () => {
     await waitFor(() => {
       expect(mockSetFilters).toHaveBeenCalledWith({
         node_type: ['Type1'],
-        limit: 30,
-        depth: '1',
+        limit: 1000,
+        depth: '3',
         top_node_count: '10',
       })
     })

--- a/src/components/App/SideBar/FilterSearch/index.tsx
+++ b/src/components/App/SideBar/FilterSearch/index.tsx
@@ -22,9 +22,9 @@ type Props = {
 
 const defaultValues = {
   selectedTypes: [] as string[],
-  hops: 1,
+  hops: 3,
   sourceNodes: 10,
-  maxResults: 30,
+  maxResults: 1000,
 }
 
 export const FilterSearch = ({ anchorEl, setAnchorEl, onClose }: Props) => {

--- a/src/stores/useDataStore/index.ts
+++ b/src/stores/useDataStore/index.ts
@@ -21,11 +21,11 @@ import { useUserStore } from '../useUserStore'
 
 export const defaultFilters = {
   skip: 0,
-  limit: 300,
-  depth: '0',
+  limit: 1000,
+  depth: '3',
   sort_by: 'score',
   include_properties: 'true',
-  top_node_count: '50',
+  top_node_count: '40',
   includeContent: 'true',
   node_type: [],
   search_method: 'hybrid',
@@ -195,7 +195,7 @@ export const useDataStore = create<DataStore>()(
 
       const updatedParams = {
         ...withoutNodeType,
-        depth: '0',
+        depth: filters.depth || "0",
         ...ai,
         skip: currentPage === 0 ? String(currentPage * itemsPerPage) : String(currentPage * itemsPerPage + 1),
         limit: word ? String(itemsPerPage) : String(itemsPerPage),


### PR DESCRIPTION
This updated the defaults for search and also fixes depth always being set to 0 in the query params