### PR TITLE
fix: stops failure when links.index does not exist

### DIFF
--- a/src/stores/useSimulationStore/index.ts
+++ b/src/stores/useSimulationStore/index.ts
@@ -93,7 +93,8 @@ export const useSimulationStore = create<SimulationStore>((set, get) => ({
     const filteredLinks = links.filter(
       (i: Link) =>
         nodes.some((n: NodeExtended) => n.ref_id === i.source) &&
-        nodes.some((n: NodeExtended) => n.ref_id === i.target),
+        nodes.some((n: NodeExtended) => n.ref_id === i.target) && 
+        i.index !== null,
     )
 
     try {


### PR DESCRIPTION
This fixes an error I was seeing and was causing the screen to go black

![Screenshot 2025-06-18 at 3 42 01 PM](https://github.com/user-attachments/assets/e4f451f0-f2a3-4337-85be-6b4d6e01f389)
