### PR TITLE
fix(#2315): Remove unwanted horizontal scrollbar in blueprint modals

### DIFF
--- a/src/components/ModalsContainer/BlueprintModal/Body/AddEdgeNode/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/AddEdgeNode/index.tsx
@@ -52,8 +52,7 @@ const HeaderFlex = styled(Flex)`
 
 const LineBar = styled.div`
   border-bottom: 1px solid ${colors.black};
-  width: calc(100% + 32px);
-  margin: 0 -16px 16px;
+  width: 100%;
   opacity: 0.3;
 `
 

--- a/src/components/ModalsContainer/BlueprintModal/Body/Editor/ColorPickerPopover/ColorPickerPopoverView/ColorPicker/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Editor/ColorPickerPopover/ColorPickerPopoverView/ColorPicker/index.tsx
@@ -124,7 +124,8 @@ const Wrapper = styled(Flex)`
 
 const TableWrapper = styled(Flex)`
   min-height: 0;
-  overflow: auto;
+  overflow-x: hidden;
+  overflow-y: auto;
   flex: 1;
   width: 100%;
 `
@@ -132,6 +133,8 @@ const TableWrapper = styled(Flex)`
 const PickerContainer = styled.div`
   padding: 0 20px;
   width: 315px;
+  max-width: 100%;
+  overflow-x: hidden;
 `
 
 const ColorPalette = styled.div`

--- a/src/components/ModalsContainer/BlueprintModal/Body/Editor/ColorPickerPopover/ColorPickerPopoverView/IconPicker/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Editor/ColorPickerPopover/ColorPickerPopoverView/IconPicker/index.tsx
@@ -73,7 +73,8 @@ const Wrapper = styled(Flex)`
 
 const TableWrapper = styled(Flex)`
   min-height: 0;
-  overflow: auto;
+  overflow-x: hidden;
+  overflow-y: auto;
   flex: 1;
   width: 100%;
 `
@@ -82,7 +83,8 @@ const PickerContainer = styled.div`
   padding: 0 20px;
   width: 300px;
   height: 350px;
-  overflow: auto;
+  overflow-x: hidden;
+  overflow-y: auto;
 `
 
 const IconPaletteWrapper = styled.div`

--- a/src/components/ModalsContainer/BlueprintModal/Body/Editor/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Editor/index.tsx
@@ -755,14 +755,14 @@ export const Editor = ({
 }
 
 const CustomButton = styled(Button)`
-  width: 400px !important;
+  width: 100%;
+  max-width: 320px;
   margin: 0 auto !important;
 `
 
 const LineBarWrapper = styled.div`
   border-bottom: 1px solid ${colors.black};
-  width: calc(100% + 32px);
-  margin: 0 -16px 16px;
+  width: 100%;
   opacity: 0.3;
 `
 
@@ -811,9 +811,8 @@ const StyledError = styled(Flex)`
 
 const LineBar = styled.div`
   border: 1px solid ${colors.BG2};
-  width: calc(100% + 32px);
+  width: 100%;
   opacity: 0.5;
-  margin-left: -16px;
 `
 
 const HeaderRow = styled(Flex)`


### PR DESCRIPTION
## Summary
Fixes unwanted horizontal scrollbar appearing in:
- Blueprint color/icon picker window
- Create/Edit Type sidebar
- Add Edge (type/edge) sidebar

## Changes
1. **ColorPicker/IconPicker TableWrapper**: Changed overflow: auto to overflow-x: hidden; overflow-y: auto
2. **ColorPicker/IconPicker PickerContainer**: Added overflow-x: hidden
3. **Editor CustomButton**: Changed width: 400px to width: 100%; max-width: 320px
4. **LineBar/LineBarWrapper**: Removed width: calc(100% + 32px) with negative margins; now width: 100%

## Root Cause
overflow: auto showed horizontal scrollbars when content exceeded container width. CustomButton at 400px was wider than its 320px parent container.