### PR TITLE
fix(#448): Black background behind details panel when on worldmap view

### DIFF
--- a/src/components/App/SideBar/SidebarSubView/index.tsx
+++ b/src/components/App/SideBar/SidebarSubView/index.tsx
@@ -57,7 +57,7 @@ export const SideBarSubView = ({ open }: Props) => {
 }
 
 const Wrapper = styled(Flex)(({ theme }) => ({
-  position: 'relative',
+  position: 'absolute',
   background: colors.BG1,
   width: '100%',
   margin: '64px auto 20px 10px',


### PR DESCRIPTION
## Summary
Fixes black background appearing behind the details panel when in worldmap view.

## Root Cause
The \SidebarSubView\ component was using \position: relative\, which created a new stacking context and caused the sidebar to appear above the worldmap canvas instead of overlaying it properly. This resulted in a black background being visible behind the panel instead of the interactive worldmap.

## Fix
Changed \position: relative\ to \position: absolute\ on the \SidebarSubView\ wrapper component, allowing it to overlay the worldmap canvas correctly.