### PR TITLE
Fix: Remove horizontal scrollbars from Blueprint sidebars and Color picker

### DIFF
--- a/src/components/ModalsContainer/BlueprintModal/Body/Editor/ColorPickerPopover/ColorPickerPopoverView/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Editor/ColorPickerPopover/ColorPickerPopoverView/index.tsx
@@ -101,7 +101,8 @@ const TabPanelWrapper = styled(Flex)`
   min-height: 572px;
   padding: 20px 0;
   max-height: 572px;
-  overflow: auto;
+  overflow-y: auto;
+  overflow-x: hidden;
 
   @media (max-width: 1024px) {
     width: 100%;

--- a/src/components/ModalsContainer/BlueprintModal/Body/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/index.tsx
@@ -272,6 +272,7 @@ const EditorWrapper = styled(Flex)<EditorWrapperProps>`
 const InnerEditorWrapper = styled.div`
   height: 100%;
   overflow-y: auto;
+  overflow-x: hidden;
   padding: 16px;
   max-height: calc(90vh - 20px);
 


### PR DESCRIPTION
**Fixes #2315**

### Bug
The newly added color/icon feature window and the create/edit sidebars in the Blueprint functionality were causing an unintentional horizontal scroll (`sideway scroll`) inside their wrapping containers on varying screen widths, degrading the UX.

### Fix
- Modified the styling of `InnerEditorWrapper` inside `BlueprintModal/Body/index.tsx` (which houses the create/edit sidebar component) to explicitly hide the horizontal axis (`overflow-x: hidden`).
- Modified `TabPanelWrapper` inside `ColorPickerPopoverView/index.tsx` (which houses the color/icon modal body) by switching `overflow: auto` to targeted vertical scrolling `overflow-y: auto`, and strictly blocking horizontal scrolling via `overflow-x: hidden`. 

This permanently forces a clean visual edge matching Stakwork UI guidelines without impacting the required vertical content scrolling.
