### PR TITLE
fix: prevent click propagation on progress slider to fix scrubber bar click

### DIFF
--- a/src/components/App/SideBar/SidebarSubView/MediaPlayer/ToolBar/index.tsx
+++ b/src/components/App/SideBar/SidebarSubView/MediaPlayer/ToolBar/index.tsx
@@ -71,6 +71,7 @@ export const Toolbar: FC<Props> = ({
           isFullScreen={isFullScreen}
           max={duration}
           onChange={handleProgressChange}
+          onClick={(e: React.MouseEvent) => e.stopPropagation()}
           size="small"
           value={playingTime}
         />

--- a/src/components/App/SideBar/SidebarSubView/MediaPlayer/index.tsx
+++ b/src/components/App/SideBar/SidebarSubView/MediaPlayer/index.tsx
@@ -111,6 +111,10 @@ const MediaPlayerComponent: FC<Props> = ({ hidden }) => {
     }
   }
 
+  const handleProgressClick = (e: React.MouseEvent) => {
+    e.stopPropagation()
+  }
+
   const handleVolumeChange = (_: Event, value: number | number[]) => {
     const newValue = Array.isArray(value) ? value[0] : value
 


### PR DESCRIPTION
Fixes #2612

The progress slider was not responding to clicks because the parent PlayerWrapper onClick handler intercepted the event.

Changes:
- Added stopPropagation to ProgressSlider click handler