### PR TITLE
fix: Improve YouTube /live/ URL regex to prevent channel misclassification

### DIFF
--- a/src/components/AddContentModal/utils/__tests__/index.ts
+++ b/src/components/AddContentModal/utils/__tests__/index.ts
@@ -12,6 +12,17 @@ describe('youtubeRegex', () => {
     await expect(getInputType('https://youtube.com/live/tkdMgjEFNWs')).resolves.toBe(LINK)
   })
 
+  it('should classify youtube live URLs as LINK, not YOUTUBE_CHANNEL', async () => {
+    await expect(getInputType('https://youtube.com/live/tkdMgjEFNWs')).resolves.toBe(LINK)
+    await expect(getInputType('https://www.youtube.com/live/abc123')).resolves.toBe(LINK)
+    await expect(getInputType('https://m.youtube.com/live/xyz789')).resolves.toBe(LINK)
+  })
+
+  it('should not classify youtube non-channel paths as channels', async () => {
+    await expect(getInputType('https://youtube.com/results?search_query=test')).resolves.not.toBe(YOUTUBE_CHANNEL)
+    await expect(getInputType('https://youtube.com/shorts/abc123')).resolves.toBe(LINK)
+  })
+
   it('should assert we can check for twitter spaces regex', async () => {
     await expect(getInputType('https://twitter.com/i/spaces/1zqKVqwrVzlxB?s=20')).resolves.toBe(LINK)
   })

--- a/src/components/AddContentModal/utils/index.ts
+++ b/src/components/AddContentModal/utils/index.ts
@@ -3,7 +3,7 @@ import { DOCUMENT, LINK, RSS, TWITTER_HANDLE, TWITTER_SOURCE, WEB_PAGE, YOUTUBE_
 export const twitterHandlePattern = /\b(?:twitter\.com|x\.com)\/(?:@)?([\w_]+)(?:$|\?[^/]*$)/
 
 const youtubeRegex = /(https?:\/\/)?(www\.)?youtube\.com\/watch\?v=([A-Za-z0-9_-]+)/
-const youtubeLiveRegex = /(https?:\/\/)?(www\.)?youtube\.com\/live\/([A-Za-z0-9_-]+)/
+const youtubeLiveRegex = /(https?:\/\/)?(www\.|m\.)?youtube\.com\/live\/([A-Za-z0-9_-]+)/
 const youtubeShortRegex = /(https?:\/\/)?(www\.)?youtu\.be\/([A-Za-z0-9_-]+)/
 const twitterSpaceRegex = /https:\/\/twitter\.com\/i\/spaces\/([A-Za-z0-9_-]+)/
 const tweetUrlRegex = /https:\/\/(twitter\.com|x\.com)\/[^/]+\/status\/(\d+)/
@@ -11,7 +11,7 @@ const mp3Regex = /(https?:\/\/)?.*\.mp3/
 const mp4Regex = /(https?:\/\/)?.*\.mp4/
 
 const rssRegex = /(https?:\/\/)?(.*\.)?.+\/(feed|rss|rss\.xml|.*\?(feed|format)=rss)(\/.*)?$/
-const youtubeChannelPattern = /https?:\/\/(www\.)?youtube\.com\/(user\/)?(@)?([\w-]+)/
+const youtubeChannelPattern = /https?:\/\/(www\.|m\.)?youtube\.com\/(?!live\/|watch|shorts\/|embed\/|results|feed|playlist)(user\/|c\/)?(@)?([\w-]+)/
 
 const genericUrlRegex = /^(https?|ftp):\/\/[^\s/$.?#].[^\s]*$/
 const twitterBroadcastRegex = /https:\/\/twitter\.com\/i\/broadcasts\/([A-Za-z0-9_-]+)/

--- a/src/components/AddItemModal/utils/index.ts
+++ b/src/components/AddItemModal/utils/index.ts
@@ -3,13 +3,13 @@ import { DOCUMENT, LINK, RSS, TWITTER_HANDLE, TWITTER_SOURCE, WEB_PAGE, YOUTUBE_
 export const twitterHandlePattern = /\btwitter\.com\/(?:@)?([\w_]+)(?:$|\?[^/]*$)/
 
 const youtubeRegex = /(https?:\/\/)?(www\.)?youtube\.com\/watch\?v=([A-Za-z0-9_-]+)/
-const youtubeLiveRegex = /(https?:\/\/)?(www\.)?youtube\.com\/live\/([A-Za-z0-9_-]+)/
+const youtubeLiveRegex = /(https?:\/\/)?(www\.|m\.)?youtube\.com\/live\/([A-Za-z0-9_-]+)/
 const twitterSpaceRegex = /https:\/\/twitter\.com\/i\/spaces\/([A-Za-z0-9_-]+)/
 const tweetUrlRegex = /https:\/\/twitter\.com\/[^/]+\/status\/(\d+)/
 const mp3Regex = /(https?:\/\/)?([A-Za-z0-9_-]+)\.mp3/
 
 const rssRegex = /(https?:\/\/)?(.*\.)?.+\/(feed|rss|rss.xml|.*.rss|.*\?(feed|format)=rss)$/
-const youtubeChannelPattern = /https?:\/\/(www\.)?youtube\.com\/(user\/)?(@)?([\w-]+)/
+const youtubeChannelPattern = /https?:\/\/(www\.|m\.)?youtube\.com\/(?!live\/|watch|shorts\/|embed\/|results|feed|playlist)(user\/|c\/)?(@)?([\w-]+)/
 
 const genericUrlRegex = /^(https?|ftp):\/\/[^\s/$.?#].[^\s]*$/
 const twitterBroadcastRegex = /https:\/\/twitter\.com\/i\/broadcasts\/([A-Za-z0-9_-]+)/

--- a/src/components/mindset/components/LandingPage/utils/index.tsx
+++ b/src/components/mindset/components/LandingPage/utils/index.tsx
@@ -6,7 +6,7 @@ const path = /(\/[^\s?]*)?/
 const query = /(\?[^\s]*)?/
 
 const youtubeRegex = /(https?:\/\/)?(www\.)?youtube\.com\/watch\?v=([A-Za-z0-9_-]+)/
-const youtubeLiveRegex = /(https?:\/\/)?(www\.)?youtube\.com\/live\/([A-Za-z0-9_-]+)/
+const youtubeLiveRegex = /(https?:\/\/)?(www\.|m\.)?youtube\.com\/live\/([A-Za-z0-9_-]+)/
 const youtubeShortRegex = /(https?:\/\/)?(www\.)?youtu\.be\/([A-Za-z0-9_-]+)/
 const mp3Regex = /(https?:\/\/)?([A-Za-z0-9_-]+)\.mp3/
 

--- a/src/components/mindset/tweet/components/LandingPage/utils/index.tsx
+++ b/src/components/mindset/tweet/components/LandingPage/utils/index.tsx
@@ -6,7 +6,7 @@ const path = /(\/[^\s?]*)?/
 const query = /(\?[^\s]*)?/
 
 const youtubeRegex = /(https?:\/\/)?(www\.)?youtube\.com\/watch\?v=([A-Za-z0-9_-]+)/
-const youtubeLiveRegex = /(https?:\/\/)?(www\.)?youtube\.com\/live\/([A-Za-z0-9_-]+)/
+const youtubeLiveRegex = /(https?:\/\/)?(www\.|m\.)?youtube\.com\/live\/([A-Za-z0-9_-]+)/
 const youtubeShortRegex = /(https?:\/\/)?(www\.)?youtu\.be\/([A-Za-z0-9_-]+)/
 const mp3Regex = /(https?:\/\/)?([A-Za-z0-9_-]+)\.mp3/
 


### PR DESCRIPTION
## Fix for #643: Support youtube `/live/` in regex

### Problem

YouTube `/live/` URLs (e.g., `https://youtube.com/live/tkdMgjEFNWs`) were being incorrectly classified as YouTube channels instead of individual video links.

The root cause was that `youtubeChannelPattern` was too broad — it matched any `youtube.com/{word}` path, including `/live/`, `/watch`, `/shorts/`, `/results`, etc.

While the existing code already had `youtubeLiveRegex` in `linkPatterns` (checked before `youtubeChannelPattern`), the channel pattern could still incorrectly match live URLs in edge cases or if the check order changed.

### Changes

1. **`youtubeChannelPattern`**: Added negative lookahead `(?!live/|watch|shorts/|embed/|results|feed|playlist)` to exclude non-channel YouTube paths
2. **`youtubeChannelPattern`**: Added `m.` subdomain support for mobile YouTube URLs
3. **`youtubeChannelPattern`**: Added `c/` path support for custom channel URLs
4. **`youtubeLiveRegex`**: Added `m.` subdomain support for mobile live URLs
5. **Consistency**: Updated all 4 files that use these patterns
6. **Tests**: Added test cases for mobile live URLs and non-channel paths

### Files Modified

| File | Change |
|------|--------|
| `src/components/AddContentModal/utils/index.ts` | Updated youtubeChannelPattern + youtubeLiveRegex |
| `src/components/AddItemModal/utils/index.ts` | Updated youtubeChannelPattern + youtubeLiveRegex |
| `src/components/mindset/components/LandingPage/utils/index.tsx` | Updated youtubeLiveRegex |
| `src/components/mindset/tweet/components/LandingPage/utils/index.tsx` | Updated youtubeLiveRegex |
| `src/components/AddContentModal/utils/__tests__/index.ts` | Added test cases |

### Testing

Before fix: `youtubeChannelPattern` matched `/live/`, `/watch`, `/results` URLs as channels
After fix: Only actual channel URLs match (e.g., `youtube.com/@MrBeast`, `youtube.com/user/PewDiePie`)

Closes #643