### PR TITLE
Add Engagement Report button to tweet analytics

### DIFF
--- a/src/components/mindset/tweet/components/Sidebar/Stats/index.tsx
+++ b/src/components/mindset/tweet/components/Sidebar/Stats/index.tsx
@@ -121,6 +121,7 @@ export const Stats = ({ node, handleAnalyzeClick }: Props) => {
           <Value>{getSentimentIcon(node?.properties?.analytics_sentiment_score)}</Value>
         </Metric>
       </Grid>
+      <EngagementReportButton type="button">Engagement Report</EngagementReportButton>
     </Card>
   )
 }
@@ -191,5 +192,21 @@ const IconButton = styled.a`
   cursor: pointer;
   &:hover {
     opacity: 0.6;
+  }
+`
+
+const EngagementReportButton = styled.button`
+  margin-top: 16px;
+  width: 100%;
+  border: 0;
+  border-radius: 8px;
+  background: #2563eb;
+  color: ${colors.white};
+  cursor: pointer;
+  padding: 8px 16px;
+  transition: background 0.2s ease;
+
+  &:hover {
+    background: #1d4ed8;
   }
 `


### PR DESCRIPTION
Adds the requested `Engagement Report` button to the tweet analytics sidebar stats card.

The project uses styled-components in this file, so the button is implemented as a local styled button matching the requested full-width blue treatment.

Testing: not run locally because this environment has Node but no npm/yarn binary installed for this yarn-based repo. The change is scoped to a single presentational component.

/claim #2788