### PR TITLE
Add edge type filters to graph search

### DIFF
--- a/src/components/App/SideBar/FilterSearch/EdgeTypes/index.tsx
+++ b/src/components/App/SideBar/FilterSearch/EdgeTypes/index.tsx
@@ -1,0 +1,160 @@
+import { useState } from 'react'
+import styled from 'styled-components'
+import PlusIcon from '~/components/Icons/PlusIcon'
+import { Flex } from '~/components/common/Flex'
+import { SchemaLink } from '~/network/fetchSourcesData'
+import { colors } from '~/utils'
+import { PopoverBody } from '..'
+
+type Props = {
+  edgeTypes: SchemaLink[]
+  handleEdgeTypeClick: (type: string) => void
+  selectedEdgeTypes: string[]
+}
+
+export const EdgeTypes = ({ edgeTypes, handleEdgeTypeClick, selectedEdgeTypes }: Props) => {
+  const [showAllEdgeTypes, setShowAllEdgeTypes] = useState(false)
+
+  const edgeTypesPerRow = 3
+  const MAX_ROWS = 4
+  const maxVisibleEdgeTypes = edgeTypesPerRow * MAX_ROWS
+
+  const uniqueEdgeTypes = edgeTypes
+    .map((edge) => edge.edge_type)
+    .filter((type): type is string => Boolean(type) && type !== 'CHILD_OF')
+    .filter((type, index, self) => index === self.indexOf(type))
+
+  const visibleEdgeTypes = showAllEdgeTypes ? uniqueEdgeTypes : uniqueEdgeTypes.slice(0, maxVisibleEdgeTypes)
+
+  return (
+    <>
+      <PopoverHeader>
+        <div>Edges</div>
+        <CountSelectedWrapper>
+          <Count>{selectedEdgeTypes.length}</Count>
+          <SelectedText>Selected</SelectedText>
+        </CountSelectedWrapper>
+      </PopoverHeader>
+      <PopoverBody>
+        <SchemaTypeWrapper>
+          {visibleEdgeTypes.map((edgeType) => (
+            <SchemaType
+              key={edgeType}
+              isSelected={selectedEdgeTypes.includes(edgeType)}
+              onClick={() => handleEdgeTypeClick(edgeType)}
+            >
+              {edgeType}
+            </SchemaType>
+          ))}
+        </SchemaTypeWrapper>
+        {!showAllEdgeTypes && uniqueEdgeTypes.length > maxVisibleEdgeTypes && (
+          <ViewMoreButton onClick={() => setShowAllEdgeTypes(true)}>
+            <PlusIconWrapper>
+              <PlusIcon /> View More
+            </PlusIconWrapper>
+          </ViewMoreButton>
+        )}
+      </PopoverBody>
+    </>
+  )
+}
+
+const PopoverHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-bottom: 8px;
+  font-family: Barlow;
+  font-size: 18px;
+  font-weight: 500;
+`
+
+const CountSelectedWrapper = styled.div`
+  font-size: 13px;
+  display: flex;
+  align-items: center;
+`
+
+const Count = styled.span`
+  color: ${colors.white};
+`
+
+const SelectedText = styled.span`
+  color: ${colors.GRAY3};
+  margin-left: 4px;
+`
+
+const PlusIconWrapper = styled.span`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 6px;
+
+  svg {
+    width: 23px;
+    height: 23px;
+    fill: none;
+    margin-top: 2px;
+  }
+`
+
+const SchemaTypeWrapper = styled(Flex).attrs({
+  align: 'center',
+  direction: 'row',
+  grow: 1,
+  justify: 'flex-start',
+})`
+  flex-wrap: wrap;
+  gap: 10px;
+  padding-right: 10px;
+  margin-right: calc(0px - 16px);
+`
+
+const SchemaType = styled(Flex).attrs({
+  align: 'center',
+  direction: 'row',
+  justify: 'flex-start',
+})<{ isSelected: boolean }>`
+  color: ${({ isSelected }) => (isSelected ? colors.black : colors.white)};
+  background: ${({ isSelected }) => (isSelected ? colors.white : colors.BUTTON1_PRESS)};
+  padding: 6px 10px 6px 8px;
+  font-family: Barlow;
+  font-size: 13px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 15px;
+  letter-spacing: 0.78px;
+  margin: 0 3px;
+  border-radius: 200px;
+  cursor: pointer;
+
+  &:hover {
+    background: ${({ isSelected }) => (isSelected ? colors.white : colors.BUTTON1_PRESS)};
+  }
+
+  &:active {
+    background: ${colors.white};
+    color: ${colors.black};
+  }
+`
+
+const ViewMoreButton = styled.button`
+  background: transparent;
+  color: ${colors.white};
+  border: none;
+  padding: 6px 12px 6px 3px;
+  margin-top: 20px;
+  cursor: pointer;
+  border-radius: 4px;
+  font-family: Barlow;
+  font-size: 13px;
+  font-weight: 500;
+
+  &:hover {
+    background: ${colors.BUTTON1_HOVER};
+  }
+
+  &:active {
+    background: ${colors.BUTTON1_PRESS};
+  }
+`

--- a/src/components/App/SideBar/FilterSearch/__tests__/index.tsx
+++ b/src/components/App/SideBar/FilterSearch/__tests__/index.tsx
@@ -39,7 +39,13 @@ jest.mock('~/stores/useSchemaStore', () => ({
 
 describe('FilterSearch Component', () => {
   const mockSetSchemas = jest.fn()
+  const mockSetSchemaLinks = jest.fn()
   const mockSchemaAll = [{ type: 'Type1' }, { type: 'Type2' }, { type: 'Type3' }]
+  const mockSchemaLinks = [
+    { edge_type: 'HAS', ref_id: 'edge1', source: 'source1', target: 'target1' },
+    { edge_type: 'SOURCE', ref_id: 'edge2', source: 'source2', target: 'target2' },
+    { edge_type: 'CHILD_OF', ref_id: 'edge3', source: 'source3', target: 'target3' },
+  ]
 
   beforeEach(() => {
     jest.clearAllMocks()
@@ -53,13 +59,13 @@ describe('FilterSearch Component', () => {
     })
 
     //
-    ;(useSchemaStore as jest.Mock).mockReturnValue([mockSchemaAll, mockSetSchemas]) // Return an array
+    ;(useSchemaStore as jest.Mock).mockReturnValue([mockSchemaAll, mockSchemaLinks, mockSetSchemas, mockSetSchemaLinks]) // Return an array
 
     //
     ;(useFeatureFlagStore as jest.Mock).mockReturnValue({ fastFiltersFeatureFlag: true })
 
     //
-    ;(getSchemaAll as jest.Mock).mockResolvedValue({ schemas: mockSchemaAll })
+    ;(getSchemaAll as jest.Mock).mockResolvedValue({ schemas: mockSchemaAll, edges: mockSchemaLinks })
   })
 
   const renderComponent = () =>
@@ -79,6 +85,9 @@ describe('FilterSearch Component', () => {
         expect(screen.getByText(schema.type)).toBeInTheDocument()
       })
     })
+
+    expect(screen.getByText('HAS')).toBeInTheDocument()
+    expect(screen.queryByText('CHILD_OF')).not.toBeInTheDocument()
   })
 
   it('should highlight selected schema type when clicked', async () => {
@@ -92,12 +101,25 @@ describe('FilterSearch Component', () => {
     expect(type1Pill).toHaveStyle(`color: ${colors.black}`)
   })
 
+  it('should highlight selected edge type when clicked', async () => {
+    renderComponent()
+
+    const edgePill = screen.getByText('HAS')
+
+    fireEvent.click(edgePill)
+
+    expect(edgePill).toHaveStyle(`background: ${colors.white}`)
+    expect(edgePill).toHaveStyle(`color: ${colors.black}`)
+  })
+
   it('should apply filters when "Apply" is clicked', async () => {
     renderComponent()
 
     const type1Pill = screen.getByText('Type1')
+    const edgePill = screen.getByText('HAS')
 
     fireEvent.click(type1Pill)
+    fireEvent.click(edgePill)
 
     const showResultsButton = screen.getByText('Apply')
 
@@ -106,6 +128,7 @@ describe('FilterSearch Component', () => {
     await waitFor(() => {
       expect(mockSetFilters).toHaveBeenCalledWith({
         node_type: ['Type1'],
+        edge_type: ['HAS'],
         limit: 1000,
         depth: '3',
         top_node_count: '10',

--- a/src/components/App/SideBar/FilterSearch/index.tsx
+++ b/src/components/App/SideBar/FilterSearch/index.tsx
@@ -11,6 +11,7 @@ import { colors } from '~/utils/colors'
 import { FastFilters } from './FastFilters'
 import { Hops } from './Hops'
 import { MaxResults } from './MaxResults'
+import { EdgeTypes } from './EdgeTypes'
 import { NodeTypes } from './NodeTypes'
 import { SourceNodes } from './SourceNodes'
 
@@ -22,15 +23,22 @@ type Props = {
 
 const defaultValues = {
   selectedTypes: [] as string[],
+  selectedEdgeTypes: [] as string[],
   hops: 3,
   sourceNodes: 10,
   maxResults: 1000,
 }
 
 export const FilterSearch = ({ anchorEl, setAnchorEl, onClose }: Props) => {
-  const [schemaAll, setSchemaAll] = useSchemaStore((s) => [s.schemas, s.setSchemas])
+  const [schemaAll, schemaLinks, setSchemaAll, setSchemaLinks] = useSchemaStore((s) => [
+    s.schemas,
+    s.links,
+    s.setSchemas,
+    s.setSchemaLinks,
+  ])
   const { abortFetchData, resetGraph, setFilters, resetData } = useDataStore((s) => s)
   const [selectedTypes, setSelectedTypes] = useState<string[]>(defaultValues.selectedTypes)
+  const [selectedEdgeTypes, setSelectedEdgeTypes] = useState<string[]>(defaultValues.selectedEdgeTypes)
   const [hops, setHops] = useState(defaultValues.hops)
   const [sourceNodes, setSourceNodes] = useState<number>(defaultValues.sourceNodes)
   const [maxResults, setMaxResults] = useState<number>(defaultValues.maxResults)
@@ -42,13 +50,14 @@ export const FilterSearch = ({ anchorEl, setAnchorEl, onClose }: Props) => {
         const response = await getSchemaAll()
 
         setSchemaAll(response.schemas.filter((schema) => !schema.is_deleted))
+        setSchemaLinks(response.edges.length > 0 ? response.edges : [])
       } catch (error) {
         console.error('Error fetching schema:', error)
       }
     }
 
     fetchSchemaData()
-  }, [setSchemaAll])
+  }, [setSchemaAll, setSchemaLinks])
 
   const handleSchemaTypeClick = (type: string) => {
     setSelectedTypes((prevSelectedTypes) =>
@@ -60,8 +69,17 @@ export const FilterSearch = ({ anchorEl, setAnchorEl, onClose }: Props) => {
     setSelectedTypes(types)
   }
 
+  const handleEdgeTypeClick = (type: string) => {
+    setSelectedEdgeTypes((prevSelectedEdgeTypes) =>
+      prevSelectedEdgeTypes.includes(type)
+        ? prevSelectedEdgeTypes.filter((t) => t !== type)
+        : [...prevSelectedEdgeTypes, type],
+    )
+  }
+
   const resetToDefaultValues = () => {
     setSelectedTypes(defaultValues.selectedTypes)
+    setSelectedEdgeTypes(defaultValues.selectedEdgeTypes)
     setHops(defaultValues.hops)
     setSourceNodes(defaultValues.sourceNodes)
     setMaxResults(defaultValues.maxResults)
@@ -76,6 +94,7 @@ export const FilterSearch = ({ anchorEl, setAnchorEl, onClose }: Props) => {
   const handleFiltersApply = async () => {
     setFilters({
       node_type: selectedTypes,
+      edge_type: selectedEdgeTypes,
       limit: maxResults,
       depth: hops.toString(),
       top_node_count: sourceNodes.toString(),
@@ -110,6 +129,12 @@ export const FilterSearch = ({ anchorEl, setAnchorEl, onClose }: Props) => {
       )}
 
       <NodeTypes handleSchemaTypeClick={handleSchemaTypeClick} schemaAll={schemaAll} selectedTypes={selectedTypes} />
+      <LineBar />
+      <EdgeTypes
+        edgeTypes={schemaLinks}
+        handleEdgeTypeClick={handleEdgeTypeClick}
+        selectedEdgeTypes={selectedEdgeTypes}
+      />
       <LineBar />
       <SourceNodes setSourceNodes={setSourceNodes} sourceNodes={sourceNodes} />
       <LineBar />

--- a/src/stores/useAiSummaryStore/index.ts
+++ b/src/stores/useAiSummaryStore/index.ts
@@ -102,17 +102,18 @@ export const useAiSummaryStore = create<AiSummaryStore>()(
 
       abortController = controller
 
-      const { node_type: filterNodeTypes, ...withoutNodeType } = filters
+      const { node_type: filterNodeTypes, edge_type: filterEdgeTypes, ...withoutNodeAndEdgeType } = filters
       const word = fullAiSearchQuery || currentSearch
 
       const isLatest = isEqual(filters, defaultFilters) && !word
 
       const updatedParams = {
-        ...withoutNodeType,
+        ...withoutNodeAndEdgeType,
         ...ai,
         skip: currentPage === 0 ? String(currentPage * itemsPerPage) : String(currentPage * itemsPerPage + 1),
         limit: word ? '25' : String(itemsPerPage),
         ...(filterNodeTypes.length > 0 ? { node_type: JSON.stringify(filterNodeTypes) } : {}),
+        ...(filterEdgeTypes.length > 0 ? { edge_type: JSON.stringify(filterEdgeTypes) } : {}),
         ...(word ? { word } : {}),
         ...(aiRefId && AISearchQuery ? { previous_search_ref_id: aiRefId } : {}),
         ...(!word && !AISearchQuery ? { sort_by: 'date_added_to_graph' } : {}),

--- a/src/stores/useDataStore/index.ts
+++ b/src/stores/useDataStore/index.ts
@@ -28,6 +28,7 @@ export const defaultFilters = {
   top_node_count: '40',
   includeContent: 'true',
   node_type: [],
+  edge_type: [],
   search_method: 'hybrid',
 }
 
@@ -188,18 +189,19 @@ export const useDataStore = create<DataStore>()(
 
       abortController = controller
 
-      const { node_type: filterNodeTypes, ...withoutNodeType } = filters
+      const { node_type: filterNodeTypes, edge_type: filterEdgeTypes, ...withoutNodeAndEdgeType } = filters
       const word = AISearchQuery || currentSearch
 
       const isLatest = isEqual(filters, defaultData.filters) && !word
 
       const updatedParams = {
-        ...withoutNodeType,
+        ...withoutNodeAndEdgeType,
         depth: filters.depth || '0',
         ...ai,
         skip: currentPage === 0 ? String(currentPage * itemsPerPage) : String(currentPage * itemsPerPage + 1),
         limit: word ? String(itemsPerPage) : String(itemsPerPage),
         ...(filterNodeTypes.length > 0 ? { node_type: JSON.stringify(filterNodeTypes) } : {}),
+        ...(filterEdgeTypes.length > 0 ? { edge_type: JSON.stringify(filterEdgeTypes) } : {}),
         ...(word ? { word } : {}),
         ...(aiRefId && AISearchQuery ? { previous_search_ref_id: aiRefId } : {}),
         ...(!word && !AISearchQuery ? { sort_by: 'date_added_to_graph' } : {}),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -80,6 +80,7 @@ export type FilterParams = {
   top_node_count: string
   include_properties: string
   node_type: string[]
+  edge_type: string[]
   search_method: string
   free?: string
   word?: string // Add other optional filter properties as needed


### PR DESCRIPTION
Adds an `Edges` filter section below `Type` and above `Source Nodes`.

Details:
- reads edge links from the existing `/schema/all` store data
- renders unique edge types with the same pill and View More treatment as node types
- filters out `CHILD_OF`
- sends selected edge types as the `edge_type` graph search param

Testing:
- `bun x prettier --config prettier.config.js --check src/components/App/SideBar/FilterSearch/index.tsx src/components/App/SideBar/FilterSearch/EdgeTypes/index.tsx src/stores/useDataStore/index.ts src/stores/useAiSummaryStore/index.ts src/types/index.ts src/components/App/SideBar/FilterSearch/__tests__/index.tsx`
- `bun x tsc --noEmit --pretty false` could not complete because this environment has no npm/yarn and Bun cannot resolve the repo dependency set from the existing Yarn lockfile.

/claim #2444