### PR TITLE
Fix S3 media loading inconsistencies

### DIFF
--- a/src/components/App/SideBar/AiSummary/index.tsx
+++ b/src/components/App/SideBar/AiSummary/index.tsx
@@ -10,6 +10,7 @@ import { useDataStore } from '~/stores/useDataStore'
 import { useUserStore } from '~/stores/useUserStore'
 import { AIEntity } from '~/types'
 import { colors } from '~/utils/colors'
+import { normalizeMediaUrl } from '~/utils/mediaUrl'
 import { EpisodeSkeleton } from '../Relevance/EpisodeSkeleton'
 import { AiAnswer } from './AiAnswer'
 import { AiQuestions } from './AiQuestions'
@@ -175,7 +176,7 @@ export const AiSummary = ({ question, response, refId }: Props) => {
         </>
       )}
       {response.audio_en && (
-        <StyledAudio ref={audioRef} src={response.audio_en}>
+        <StyledAudio ref={audioRef} src={normalizeMediaUrl(response.audio_en)}>
           <track kind="captions" />
         </StyledAudio>
       )}

--- a/src/components/App/SideBar/SelectedNodeView/Default/index.tsx
+++ b/src/components/App/SideBar/SelectedNodeView/Default/index.tsx
@@ -23,6 +23,7 @@ import { usePlayerStore } from '~/stores/usePlayerStore'
 import { useSchemaStore } from '~/stores/useSchemaStore'
 import { Link, Node } from '~/types'
 import { colors } from '~/utils/colors'
+import { normalizeMediaUrl } from '~/utils/mediaUrl'
 import { BoostAmt } from '../../../Helper/BoostAmt'
 
 interface EdgeWithTargetNode extends Link<string> {
@@ -125,8 +126,10 @@ export const Default = () => {
     return null
   }
 
-  const hasImage = !playingNode?.ref_id && !!selectedNode.properties?.image_url
-  const hasAudio = !!selectedNode.properties?.audio_EN
+  const imageUrl = normalizeMediaUrl(selectedNode.properties?.image_url)
+  const audioUrl = normalizeMediaUrl(selectedNode.properties?.audio_EN)
+  const hasImage = !playingNode?.ref_id && !!imageUrl
+  const hasAudio = !!audioUrl
   const customKeys = selectedNode.properties || {}
   const sourceLink = selectedNode.properties?.source_link
   const pubkey = selectedNode.properties?.pubkey
@@ -147,7 +150,7 @@ export const Default = () => {
               e.currentTarget.src = 'generic_placeholder_img.png'
               e.currentTarget.className = 'default-img'
             }}
-            src={selectedNode.properties?.image_url}
+            src={imageUrl}
           />
         </StyledImageWrapper>
       )}
@@ -204,8 +207,8 @@ export const Default = () => {
         )}
       </StyledContent>
 
-      {hasAudio && selectedNode.properties?.audio_EN && (
-        <StyledAudio ref={audioRef} src={selectedNode.properties.audio_EN}>
+      {hasAudio && (
+        <StyledAudio ref={audioRef} src={audioUrl}>
           <track kind="captions" />
         </StyledAudio>
       )}

--- a/src/components/App/SideBar/SelectedNodeView/Document/index.tsx
+++ b/src/components/App/SideBar/SelectedNodeView/Document/index.tsx
@@ -11,11 +11,13 @@ import { Text } from '~/components/common/Text'
 import { useAppStore } from '~/stores/useAppStore'
 import { useSelectedNode } from '~/stores/useGraphStore'
 import { colors } from '~/utils'
+import { normalizeMediaUrl } from '~/utils/mediaUrl'
 
 export const Document = () => {
   const [playing, setPlaying] = useState(false)
   const selectedNode = useSelectedNode()
   const hasSourceLink = !!selectedNode?.source_link
+  const audioUrl = normalizeMediaUrl(selectedNode?.audio?.[0]?.link)
 
   const audioRef = useRef<HTMLVideoElement>(null)
 
@@ -58,12 +60,12 @@ export const Document = () => {
           </StyledLink>
         </StyledHeader>
       )}
-      {selectedNode?.audio?.length ? (
+      {audioUrl ? (
         <Flex justify="flex-start" p={12}>
           <Button onClick={(e) => handleClick(e)} startIcon={playing ? <PauseIcon /> : <PlayIcon />}>
             {playing ? 'Pause' : 'Play'}
           </Button>
-          <StyledAudio ref={audioRef} src={selectedNode.audio[0]?.link || ''}>
+          <StyledAudio ref={audioRef} src={audioUrl}>
             <track kind="captions" />
           </StyledAudio>
         </Flex>

--- a/src/components/App/SideBar/SidebarSubView/MediaPlayer/index.tsx
+++ b/src/components/App/SideBar/SidebarSubView/MediaPlayer/index.tsx
@@ -6,6 +6,7 @@ import { Avatar } from '~/components/common/Avatar'
 import { Flex } from '~/components/common/Flex'
 import { usePlayerStore } from '~/stores/usePlayerStore'
 import { colors, videoTimeToSeconds } from '~/utils'
+import { normalizeMediaUrl } from '~/utils/mediaUrl'
 import { Toolbar } from './ToolBar'
 import { useSelectedNode } from '~/stores/useGraphStore'
 
@@ -56,8 +57,11 @@ const MediaPlayerComponent: FC<Props> = ({ hidden }) => {
     setIsSeeking,
   } = usePlayerStore((s) => s)
 
-  const mediaUrl =
+  const rawMediaUrl =
     playingNode?.media_url || playingNode?.link || playingNode?.properties?.link || playingNode?.properties?.media_url
+
+  const mediaUrl = normalizeMediaUrl(rawMediaUrl)
+  const imageUrl = normalizeMediaUrl(playingNode?.image_url || playingNode?.properties?.image_url)
 
   const isYouTubeVideo = mediaUrl?.includes('youtube') || mediaUrl?.includes('youtu.be')
 
@@ -222,10 +226,11 @@ const MediaPlayerComponent: FC<Props> = ({ hidden }) => {
       tabIndex={0}
     >
       <Cover isFullScreen={isFullScreen}>
-        <Avatar size={120} src={playingNode?.image_url || ''} type="clip" />
+        <Avatar size={120} src={imageUrl} type="clip" />
       </Cover>
       <PlayerWrapper isFullScreen={isFullScreen} onClick={handlePlayerClick}>
         <ReactPlayer
+          key={mediaUrl}
           ref={playerRef}
           controls={false}
           height={!isFullScreen ? '200px' : window.screen.height}

--- a/src/components/App/SideBar/Trending/index.tsx
+++ b/src/components/App/SideBar/Trending/index.tsx
@@ -20,6 +20,7 @@ import { useModal } from '~/stores/useModalStore'
 import { Trending as TrendingType } from '~/types'
 import { getTrendingTopic, showPlayButton } from '~/utils'
 import { colors } from '~/utils/colors'
+import { normalizeMediaUrl } from '~/utils/mediaUrl'
 
 const TRENDING_TOPICS = ['Drivechain', 'Ordinals', 'L402', 'Nostr', 'AI']
 
@@ -172,7 +173,11 @@ export const Trending = () => {
               <Button onClick={(e) => handleClick(e)} startIcon={playing ? <PauseIcon /> : <PlayIcon />}>
                 {playing ? 'Pause' : 'Play All'}
               </Button>
-              <StyledAudio ref={audioRef} onEnded={goToNextSong} src={trendingTopics[currentFileIndex]?.audio_EN}>
+              <StyledAudio
+                ref={audioRef}
+                onEnded={goToNextSong}
+                src={normalizeMediaUrl(trendingTopics[currentFileIndex]?.audio_EN)}
+              >
                 <track kind="captions" />
               </StyledAudio>
             </div>

--- a/src/components/AudioPlayer/index.tsx
+++ b/src/components/AudioPlayer/index.tsx
@@ -4,6 +4,7 @@ import ReactAudioPlayer from 'react-audio-player'
 import styled from 'styled-components'
 import { Flex } from '~/components/common/Flex'
 import { Text } from '~/components/common/Text'
+import { normalizeMediaUrl } from '~/utils/mediaUrl'
 import { videoTimeToSeconds } from '~/utils/videoTimetoSeconds'
 
 const Audio = styled(ReactAudioPlayer as unknown as ComponentType<typeof ReactAudioPlayer.defaultProps>)`
@@ -31,6 +32,7 @@ const _AudioPlayer = ({
   onPlay = noop,
 }: AudioPlayerProps) => {
   const [loadError, setLoadError] = useState(false)
+  const normalizedMediaUrl = normalizeMediaUrl(mediaUrl)
 
   const [player, setPlayer] = useState<HTMLAudioElement | null>(null)
 
@@ -79,6 +81,10 @@ const _AudioPlayer = ({
   }, [mediaUrl, onPause])
 
   useEffect(() => {
+    setLoadError(false)
+  }, [normalizedMediaUrl])
+
+  useEffect(() => {
     if (player) {
       player.currentTime = timestamp ? videoTimeToSeconds(timestamp) : 0
     }
@@ -102,7 +108,7 @@ const _AudioPlayer = ({
             setLoadError(false)
             onLoaded()
           }}
-          src={mediaUrl}
+          src={normalizedMediaUrl}
           volume={1}
         />
       )}

--- a/src/components/ModalsContainer/BriefDescriptionModal/BriefDescriptionContent/index.tsx
+++ b/src/components/ModalsContainer/BriefDescriptionModal/BriefDescriptionContent/index.tsx
@@ -14,6 +14,7 @@ import { useModal } from '~/stores/useModalStore'
 import { useUserStore } from '~/stores/useUserStore'
 import { Trending } from '~/types'
 import { colors } from '~/utils'
+import { normalizeMediaUrl } from '~/utils/mediaUrl'
 
 type Props = {
   trend: Trending
@@ -23,6 +24,7 @@ type Props = {
 export const BriefDescriptionContent: FC<Props> = ({ trend, onClose }) => {
   const [isPlaying, setIsPlaying] = useState(false)
   const { close } = useModal('briefDescription')
+  const audioUrl = normalizeMediaUrl(trend.audio_EN)
 
   const { currentPlayingAudio, setCurrentPlayingAudio } = useAppStore((s) => s)
 
@@ -86,11 +88,11 @@ export const BriefDescriptionContent: FC<Props> = ({ trend, onClose }) => {
   }, [setCurrentPlayingAudio])
 
   const showPlayBtn =
-    (currentPlayingAudio?.current?.src === trend.audio_EN && !currentPlayingAudio?.current?.paused) || isPlaying
+    (currentPlayingAudio?.current?.src === audioUrl && !currentPlayingAudio?.current?.paused) || isPlaying
 
   return (
     <>
-      {trend.audio_EN ? (
+      {audioUrl ? (
         <>
           <StyledHeader>
             <StyleButton
@@ -106,7 +108,7 @@ export const BriefDescriptionContent: FC<Props> = ({ trend, onClose }) => {
               Learn More
             </StyleButton>
           </StyledHeader>
-          <StyledAudio ref={audioRef} src={trend.audio_EN}>
+          <StyledAudio ref={audioRef} src={audioUrl}>
             <track kind="captions" />
           </StyledAudio>
         </>

--- a/src/components/ModalsContainer/TweetAnalyze/Body/index.tsx
+++ b/src/components/ModalsContainer/TweetAnalyze/Body/index.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom'
 import styled from 'styled-components'
 import { Flex } from '~/components/common/Flex'
 import { colors } from '~/utils'
+import { getCssMediaUrl } from '~/utils/mediaUrl'
 import { EngagementTable } from './Engagement'
 import { RetweetsTable } from './Retweets'
 import { SentimentTable } from './Sentiment'
@@ -40,7 +41,7 @@ export const Avatar = styled.div<{ imageUrl?: string }>`
   height: 32px;
   border-radius: 50%;
   background-color: ${colors.BG1};
-  ${({ imageUrl }) => imageUrl && `background-image: url(${imageUrl});`}
+  ${({ imageUrl }) => imageUrl && `background-image: ${getCssMediaUrl(imageUrl)};`}
   background-size: cover;
 `
 

--- a/src/components/Universe/Graph/Cubes/Candidates/CandidateWrapper/NodeSprite/index.tsx
+++ b/src/components/Universe/Graph/Cubes/Candidates/CandidateWrapper/NodeSprite/index.tsx
@@ -8,6 +8,7 @@ import NodesIcon from '~/components/Icons/NodesIcon'
 import { useSchemaStore } from '~/stores/useSchemaStore'
 import { NodeExtended } from '~/types'
 import { colors } from '~/utils'
+import { getCssMediaUrl } from '~/utils/mediaUrl'
 import { truncateText } from '~/utils/truncateText'
 
 type Props = {
@@ -106,7 +107,7 @@ type AvatarProps = {
 }
 
 const Avatar = styled(Flex)<AvatarProps>`
-  background-image: ${({ src }) => `url(${src})`};
+  background-image: ${({ src }) => getCssMediaUrl(src)};
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;

--- a/src/components/Universe/Graph/Cubes/Cube/hooks/useMaterial/constants.ts
+++ b/src/components/Universe/Graph/Cubes/Cube/hooks/useMaterial/constants.ts
@@ -3,6 +3,8 @@ import { smoothness } from '../../constants'
 
 export const loader = new TextureLoader()
 
+loader.setCrossOrigin('anonymous')
+
 export const noImageTexture = loader.load('noimage.jpeg')
 
 export const noImageMaterial = new MeshStandardMaterial({

--- a/src/components/Universe/Graph/Cubes/Cube/hooks/useMaterial/index.ts
+++ b/src/components/Universe/Graph/Cubes/Cube/hooks/useMaterial/index.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { MeshStandardMaterial } from 'three'
+import { normalizeMediaUrl } from '~/utils/mediaUrl'
 import { smoothness } from '../../constants'
 import { loader, noImageMaterial, noImageTexture, noImageTransparentMaterial, transparentValue } from './constants'
 
@@ -15,7 +16,8 @@ export const useMaterial = (url: string, transparent: boolean) => {
   const [material, setMaterial] = useState(noImageMaterial)
 
   useEffect(() => {
-    const cashPath = `${url}${transparent && '-transparent'}`
+    const mediaUrl = normalizeMediaUrl(url) || 'noimage.jpeg'
+    const cashPath = `${mediaUrl}${transparent ? '-transparent' : ''}`
 
     if (cachedMaterials[cashPath]) {
       setTexture(cachedMaterials[cashPath].texture)
@@ -25,7 +27,7 @@ export const useMaterial = (url: string, transparent: boolean) => {
     }
 
     loader.load(
-      url,
+      mediaUrl,
       (loadedTexture) => {
         // on load
         const newMaterial = new MeshStandardMaterial({

--- a/src/components/Universe/Graph/Cubes/RelevanceBadges/styles.ts
+++ b/src/components/Universe/Graph/Cubes/RelevanceBadges/styles.ts
@@ -1,6 +1,7 @@
 import styled from 'styled-components'
 import { Flex } from '~/components/common/Flex'
 import { colors } from '~/utils/colors'
+import { getCssMediaUrl } from '~/utils/mediaUrl'
 
 type TagProps = {
   selected: boolean
@@ -134,7 +135,7 @@ type ImageProps = {
 }
 
 export const Image = styled.img<ImageProps>`
-  background-image: ${({ src }) => `url(${src})`};
+  background-image: ${({ src }) => getCssMediaUrl(src)};
   background-size: contain;
   background-repeat: no-repeat;
   width: ${(p) => p.size}px;

--- a/src/components/Universe/Graph/Cubes/RelevanceGroups/styles.ts
+++ b/src/components/Universe/Graph/Cubes/RelevanceGroups/styles.ts
@@ -1,6 +1,7 @@
 import styled from 'styled-components'
 import { Flex } from '~/components/common/Flex'
 import { colors } from '~/utils/colors'
+import { getCssMediaUrl } from '~/utils/mediaUrl'
 
 type TagProps = {
   selected: boolean
@@ -106,7 +107,7 @@ type ImageProps = {
 }
 
 export const Image = styled.img<ImageProps>`
-  background-image: ${({ src }) => `url(${src})`};
+  background-image: ${({ src }) => getCssMediaUrl(src)};
   background-size: contain;
   background-repeat: no-repeat;
   width: ${(p) => p.size}px;

--- a/src/components/Universe/Graph/Cubes/SelectionDataNodes/Node/index.tsx
+++ b/src/components/Universe/Graph/Cubes/SelectionDataNodes/Node/index.tsx
@@ -20,6 +20,7 @@ import { useSchemaStore } from '~/stores/useSchemaStore'
 import { useUserStore } from '~/stores/useUserStore'
 import { ActionDetail } from '~/types'
 import { colors } from '~/utils'
+import { getCssMediaUrl } from '~/utils/mediaUrl'
 import { truncateText } from '~/utils/truncateText'
 import { PathNode } from '..'
 
@@ -340,7 +341,7 @@ type AvatarProps = {
 }
 
 const Avatar = styled(Flex)<AvatarProps>`
-  background-image: ${({ src }) => `url(${src})`};
+  background-image: ${({ src }) => getCssMediaUrl(src)};
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;

--- a/src/components/Universe/Graph/Cubes/Text/index.tsx
+++ b/src/components/Universe/Graph/Cubes/Text/index.tsx
@@ -4,6 +4,7 @@ import { Group, Mesh, MeshBasicMaterial, Texture, TextureLoader } from 'three'
 import { Icons } from '~/components/Icons'
 import { useSchemaStore } from '~/stores/useSchemaStore'
 import { NodeExtended } from '~/types'
+import { normalizeMediaUrl } from '~/utils/mediaUrl'
 import { removeEmojis } from '~/utils/removeEmojisFromText'
 import { removeLeadingMentions } from '~/utils/removeLeadingMentions'
 import { truncateText } from '~/utils/truncateText'
@@ -11,6 +12,9 @@ import { NodeCircleGeometry, nodeSize } from '../constants'
 import { TextWithBackground } from './TextWithBackgound'
 
 const textureLoader = new TextureLoader()
+
+textureLoader.setCrossOrigin('anonymous')
+
 const svgIconMaterial = new MeshBasicMaterial({ color: 'rgba(255, 255, 255, 0.5)' })
 
 type Props = {
@@ -41,16 +45,17 @@ export const TextNode = memo(
       }
 
       let cancelled = false
+      const imageUrl = normalizeMediaUrl(node.properties.image_url)
 
       textureLoader.load(
-        node.properties.image_url,
+        imageUrl,
         (t) => {
           if (!cancelled) {
             setTexture(t)
           }
         },
         undefined,
-        () => console.error(`Failed to load texture: ${node?.properties?.image_url}`),
+        () => console.error(`Failed to load texture: ${imageUrl}`),
       )
 
       return () => {

--- a/src/components/common/Avatar/index.tsx
+++ b/src/components/common/Avatar/index.tsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components'
+import { getCssMediaUrl } from '~/utils/mediaUrl'
 
 type Props = {
   size?: number
@@ -29,7 +30,7 @@ const TypesMapper: TTypeMapper = {
 
 export const Avatar = styled.div<Props>`
   background-image: ${({ src, type = 'audio' }) =>
-    `url(${src}), url('/${TypesMapper[type] || 'generic'}_placeholder_img.png')`};
+    `${getCssMediaUrl(src)}, url('/${TypesMapper[type] || 'generic'}_placeholder_img.png')`};
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;

--- a/src/components/mindset/components/MediaPlayer/index.tsx
+++ b/src/components/mindset/components/MediaPlayer/index.tsx
@@ -11,6 +11,7 @@ import { useMindsetStore } from '~/stores/useMindsetStore'
 import { usePlayerStore } from '~/stores/usePlayerStore'
 import { Link } from '~/types'
 import { colors } from '~/utils'
+import { normalizeMediaUrl } from '~/utils/mediaUrl'
 import { secondsToMediaTime } from '~/utils/secondsToMediaTime'
 
 const isVideoFile = (url: string) => /\.(mp4|webm|mov|mkv|avi)(\?.*)?$/i.test(url)
@@ -48,6 +49,7 @@ type Props = {
 
 const MediaPlayerComponent = ({ mediaUrl }: Props) => {
   const wrapperRef = useRef<HTMLDivElement | null>(null)
+  const normalizedMediaUrl = normalizeMediaUrl(mediaUrl)
   const [status, setStatus] = useState<'buffering' | 'error' | 'ready'>('ready')
   const [isReady, setIsReady] = useState(false)
   const [hasSeekedFromURL, setHasSeekedFromURL] = useState(false)
@@ -181,13 +183,14 @@ const MediaPlayerComponent = ({ mediaUrl }: Props) => {
     [setPlayerRef, playerRef],
   )
 
-  return mediaUrl ? (
+  return normalizedMediaUrl ? (
     <Wrapper ref={wrapperRef} isFullScreen={isFullScreen} tabIndex={0}>
       <Cover isFullScreen={isFullScreen}>
-        <Avatar size={200} src={playingNode?.properties?.image_url || ''} type="clip" />
+        <Avatar size={200} src={normalizeMediaUrl(playingNode?.properties?.image_url)} type="clip" />
       </Cover>
       <PlayerWrapper isFullScreen={isFullScreen}>
         <ReactPlayer
+          key={normalizedMediaUrl}
           ref={playerRefCallback}
           height={isFullScreen ? '100%' : 'auto'}
           onBuffer={() => setStatus('buffering')}
@@ -206,7 +209,7 @@ const MediaPlayerComponent = ({ mediaUrl }: Props) => {
             height: isFullScreen ? '100%' : 'auto',
             objectFit: 'contain',
           }}
-          url={mediaUrl || ''}
+          url={normalizedMediaUrl}
           volume={volume}
           width="100%"
         />
@@ -216,7 +219,7 @@ const MediaPlayerComponent = ({ mediaUrl }: Props) => {
           </TimeDisplay>
         </Overlay>
       </PlayerWrapper>
-      {isVideoFile(mediaUrl) && (
+      {isVideoFile(normalizedMediaUrl) && (
         <ExpandButton onClick={() => setIsFullScreen(!isFullScreen)}>
           {!isFullScreen ? <FullScreenIcon /> : <ExitFullScreen />}
         </ExpandButton>

--- a/src/utils/mediaUrl/__tests__/index.ts
+++ b/src/utils/mediaUrl/__tests__/index.ts
@@ -1,0 +1,27 @@
+import { getCssMediaUrl, normalizeMediaUrl } from '..'
+
+describe('mediaUrl helpers', () => {
+  it('normalizes path-style S3 upload URLs to the virtual-hosted bucket URL', () => {
+    expect(
+      normalizeMediaUrl(
+        'https://s3.amazonaws.com/stakwork-uploads/uploads/customers/4291/media_to_local/file name.mp3',
+      ),
+    ).toBe('https://stakwork-uploads.s3.amazonaws.com/uploads/customers/4291/media_to_local/file%20name.mp3')
+  })
+
+  it('trims and encodes regular media URLs', () => {
+    expect(normalizeMediaUrl(' https://example.com/content/image one.png ')).toBe(
+      'https://example.com/content/image%20one.png',
+    )
+  })
+
+  it('returns a quoted and escaped CSS URL', () => {
+    expect(getCssMediaUrl('https://example.com/content/image "one".png')).toBe(
+      'url("https://example.com/content/image%20%22one%22.png")',
+    )
+  })
+
+  it('returns none for empty CSS media values', () => {
+    expect(getCssMediaUrl('')).toBe('none')
+  })
+})

--- a/src/utils/mediaUrl/index.ts
+++ b/src/utils/mediaUrl/index.ts
@@ -1,0 +1,42 @@
+const S3_UPLOADS_BUCKET = 'stakwork-uploads'
+const S3_PATH_STYLE_HOST = 's3.amazonaws.com'
+const S3_VIRTUAL_HOST = `${S3_UPLOADS_BUCKET}.s3.amazonaws.com`
+
+export const normalizeMediaUrl = (value?: string | null): string => {
+  if (typeof value !== 'string') {
+    return ''
+  }
+
+  const trimmedValue = value.trim()
+
+  if (!trimmedValue) {
+    return ''
+  }
+
+  try {
+    const url = new URL(trimmedValue)
+
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      return encodeURI(trimmedValue)
+    }
+
+    if (url.hostname === S3_PATH_STYLE_HOST && url.pathname.startsWith(`/${S3_UPLOADS_BUCKET}/`)) {
+      url.hostname = S3_VIRTUAL_HOST
+      url.pathname = url.pathname.replace(`/${S3_UPLOADS_BUCKET}`, '')
+    }
+
+    return url.toString()
+  } catch {
+    return encodeURI(trimmedValue)
+  }
+}
+
+export const getCssMediaUrl = (value?: string | null): string => {
+  const normalizedUrl = normalizeMediaUrl(value)
+
+  if (!normalizedUrl) {
+    return 'none'
+  }
+
+  return `url("${normalizedUrl.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}")`
+}


### PR DESCRIPTION
## Summary
- Add shared media URL helpers to trim and encode media URLs and normalize path-style stakwork upload S3 URLs to the virtual-hosted bucket URL.
- Use the helpers for audio, ReactPlayer URLs, img URLs, and CSS background-image URLs so media sources are handled consistently.
- Configure Three.js texture loaders for anonymous cross-origin image loads and reset the audio player error state when its source changes.

Fixes #146

## Testing
- HOME=/private/tmp node .yarn/releases/yarn-3.5.0.cjs install --immutable
- HOME=/private/tmp NODE_ENV=test node .yarn/releases/yarn-3.5.0.cjs jest src/utils/mediaUrl/__tests__/index.ts src/components/AudioPlayer/utils/__tests__/index.tsx --runInBand --no-cache --coverage=false
- HOME=/private/tmp node .yarn/releases/yarn-3.5.0.cjs typecheck
- HOME=/private/tmp node .yarn/releases/yarn-3.5.0.cjs build
- HOME=/private/tmp ./node_modules/.bin/eslint <changed files>
- git diff --check

Notes: the targeted AudioPlayer Jest suite still prints the existing jsdom HTMLMediaElement play/pause not implemented console noise, and build still reports existing repo warnings for console statements, constant conditions, lottie eval usage, a runtime font path, and large chunks.