### PR TITLE
Fix Blueprint horizontal scrollbars

### DIFF
--- a/src/components/ModalsContainer/BlueprintModal/Body/AddEdgeNode/Body/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/AddEdgeNode/Body/index.tsx
@@ -158,7 +158,9 @@ export const Body = ({ onCancel, edgeLinkData, setGraphLoading }: Props) => {
 }
 
 const CustomButton = styled(Button)`
-  width: 400px !important;
+  flex: 1 1 0;
+  min-width: 0 !important;
+  width: auto !important;
   margin: 0 0 10px auto !important;
 `
 

--- a/src/components/ModalsContainer/BlueprintModal/Body/Editor/ColorPickerPopover/ColorPickerPopoverView/ColorPicker/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Editor/ColorPickerPopover/ColorPickerPopoverView/ColorPicker/index.tsx
@@ -124,14 +124,16 @@ const Wrapper = styled(Flex)`
 
 const TableWrapper = styled(Flex)`
   min-height: 0;
-  overflow: auto;
+  overflow-x: hidden;
+  overflow-y: auto;
   flex: 1;
   width: 100%;
 `
 
 const PickerContainer = styled.div`
+  box-sizing: border-box;
   padding: 0 20px;
-  width: 315px;
+  width: 100%;
 `
 
 const ColorPalette = styled.div`

--- a/src/components/ModalsContainer/BlueprintModal/Body/Editor/ColorPickerPopover/ColorPickerPopoverView/IconPicker/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Editor/ColorPickerPopover/ColorPickerPopoverView/IconPicker/index.tsx
@@ -73,16 +73,19 @@ const Wrapper = styled(Flex)`
 
 const TableWrapper = styled(Flex)`
   min-height: 0;
-  overflow: auto;
+  overflow-x: hidden;
+  overflow-y: auto;
   flex: 1;
   width: 100%;
 `
 
 const PickerContainer = styled.div`
+  box-sizing: border-box;
   padding: 0 20px;
-  width: 300px;
+  width: 100%;
   height: 350px;
-  overflow: auto;
+  overflow-x: hidden;
+  overflow-y: auto;
 `
 
 const IconPaletteWrapper = styled.div`

--- a/src/components/ModalsContainer/BlueprintModal/Body/Editor/ColorPickerPopover/ColorPickerPopoverView/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Editor/ColorPickerPopover/ColorPickerPopoverView/index.tsx
@@ -98,10 +98,13 @@ const StyledTab = styled(Tab)`
 const TabPanelWrapper = styled(Flex)`
   display: flex;
   flex: 1;
+  box-sizing: border-box;
+  width: 100%;
   min-height: 572px;
   padding: 20px 0;
   max-height: 572px;
-  overflow: auto;
+  overflow-x: hidden;
+  overflow-y: auto;
 
   @media (max-width: 1024px) {
     width: 100%;
@@ -126,6 +129,7 @@ const Wrapper = styled(Flex)`
   min-height: 0;
   flex: 1;
   overflow: hidden;
+  width: 100%;
 
   @media (max-width: 768px) {
     padding: 3px;

--- a/src/components/ModalsContainer/BlueprintModal/Body/Editor/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Editor/index.tsx
@@ -755,7 +755,9 @@ export const Editor = ({
 }
 
 const CustomButton = styled(Button)`
-  width: 400px !important;
+  flex: 1 1 0;
+  min-width: 0 !important;
+  width: auto !important;
   margin: 0 auto !important;
 `
 

--- a/src/components/ModalsContainer/BlueprintModal/Body/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/index.tsx
@@ -270,7 +270,10 @@ const EditorWrapper = styled(Flex)<EditorWrapperProps>`
 `
 
 const InnerEditorWrapper = styled.div`
+  box-sizing: border-box;
+  width: 100%;
   height: 100%;
+  overflow-x: hidden;
   overflow-y: auto;
   padding: 16px;
   max-height: calc(90vh - 20px);


### PR DESCRIPTION
Closes #2315

## Summary
- Prevent horizontal overflow in the Blueprint editor sidebar wrapper.
- Make create/edit type and edge action buttons flex within the available sidebar width instead of forcing a 400px width.
- Constrain the color/icon picker popover panels and inner picker containers to vertical scrolling only, including the icon and color picker bodies.

## Difference from #2991
There is already an open PR for this issue, but this patch covers the additional overflow sources called out in the issue: the create/edit type/edge sidebar button widths and the fixed-width picker containers inside the color/icon popover. The goal is to remove sideway scrolling across all affected Blueprint surfaces rather than only the outer wrappers.

## Tests
- yarn typecheck
- yarn build
- yarn jest src/components/ModalsContainer/BlueprintModal/Body/Editor/__tests__/index.tsx src/components/ModalsContainer/BlueprintModal/Body/AddEdgeNode/__tests__/index.tsx --runInBand --no-cache --coverage=false

Note: I could not fully verify the Blueprint UI in-browser locally because the app preview is gated by `This is a private Graph, Contact Admin` without an admin backend/session.