### PR TITLE
Add edge type filters to graph search

### DIFF
--- a/src/components/App/SideBar/FilterSearch/EdgeTypes/index.tsx
+++ b/src/components/App/SideBar/FilterSearch/EdgeTypes/index.tsx
@@ -1,0 +1,164 @@
+import { useState } from 'react'
+import styled from 'styled-components'
+import PlusIcon from '~/components/Icons/PlusIcon'
+import { Flex } from '~/components/common/Flex'
+import { SchemaLink } from '~/network/fetchSourcesData'
+import { colors } from '~/utils'
+import { PopoverBody } from '..'
+
+type Props = {
+  handleEdgeTypeClick: (type: string) => void
+  selectedEdgeTypes: string[]
+  schemaEdges: SchemaLink[]
+}
+
+export const EdgeTypes = ({ handleEdgeTypeClick, selectedEdgeTypes, schemaEdges }: Props) => {
+  const [showAllEdges, setShowAllEdges] = useState(false)
+
+  const edgesPerRow = 3
+  const MAX_ROWS = 4
+  const maxVisibleEdges = edgesPerRow * MAX_ROWS
+
+  const uniqueEdgeTypes = [...new Set(schemaEdges.map((edge) => edge.edge_type))]
+    .filter((edgeType) => edgeType && edgeType !== 'CHILD_OF')
+    .sort()
+
+  const visibleEdgeTypes = showAllEdges ? uniqueEdgeTypes : uniqueEdgeTypes.slice(0, maxVisibleEdges)
+
+  if (!uniqueEdgeTypes.length) {
+    return null
+  }
+
+  return (
+    <>
+      <PopoverHeader>
+        <div>Edges</div>
+        <CountSelectedWrapper>
+          <Count>{selectedEdgeTypes.length}</Count>
+          <SelectedText>Selected</SelectedText>
+        </CountSelectedWrapper>
+      </PopoverHeader>
+      <PopoverBody>
+        <SchemaTypeWrapper>
+          {visibleEdgeTypes.map((edgeType) => (
+            <SchemaType
+              key={edgeType}
+              isSelected={selectedEdgeTypes.includes(edgeType)}
+              onClick={() => handleEdgeTypeClick(edgeType)}
+            >
+              {edgeType}
+            </SchemaType>
+          ))}
+        </SchemaTypeWrapper>
+        {!showAllEdges && uniqueEdgeTypes.length > maxVisibleEdges && (
+          <ViewMoreButton onClick={() => setShowAllEdges(true)}>
+            <PlusIconWrapper>
+              <PlusIcon /> View More
+            </PlusIconWrapper>
+          </ViewMoreButton>
+        )}
+      </PopoverBody>
+    </>
+  )
+}
+
+const PopoverHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-bottom: 8px;
+  font-family: Barlow;
+  font-size: 18px;
+  font-weight: 500;
+`
+
+const CountSelectedWrapper = styled.div`
+  font-size: 13px;
+  display: flex;
+  align-items: center;
+`
+
+const Count = styled.span`
+  color: ${colors.white};
+`
+
+const SelectedText = styled.span`
+  color: ${colors.GRAY3};
+  margin-left: 4px;
+`
+
+const PlusIconWrapper = styled.span`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 6px;
+
+  svg {
+    width: 23px;
+    height: 23px;
+    fill: none;
+    margin-top: 2px;
+  }
+`
+
+const SchemaTypeWrapper = styled(Flex).attrs({
+  align: 'center',
+  direction: 'row',
+  grow: 1,
+  justify: 'flex-start',
+})`
+  flex-wrap: wrap;
+  gap: 10px;
+  padding-right: 10px;
+  margin-right: calc(0px - 16px);
+`
+
+const SchemaType = styled(Flex).attrs({
+  align: 'center',
+  direction: 'row',
+  justify: 'flex-start',
+})<{ isSelected: boolean }>`
+  color: ${({ isSelected }) => (isSelected ? colors.black : colors.white)};
+  background: ${({ isSelected }) => (isSelected ? colors.white : colors.BUTTON1_PRESS)};
+  padding: 6px 10px 6px 8px;
+  font-family: Barlow;
+  font-size: 13px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 15px;
+  letter-spacing: 0.78px;
+  margin: 0 3px;
+  border-radius: 200px;
+  cursor: pointer;
+
+  &:hover {
+    background: ${({ isSelected }) => (isSelected ? colors.white : colors.BUTTON1_PRESS)};
+  }
+
+  &:active {
+    background: ${colors.white};
+    color: ${colors.black};
+  }
+`
+
+const ViewMoreButton = styled.button`
+  background: transparent;
+  color: ${colors.white};
+  border: none;
+  padding: 6px 12px 6px 3px;
+  margin-top: 20px;
+  cursor: pointer;
+  border-radius: 4px;
+  font-family: Barlow;
+  font-size: 13px;
+  font-weight: 500;
+
+  &:hover {
+    background: ${colors.BUTTON1_HOVER};
+  }
+
+  &:active {
+    background: ${colors.BUTTON1_PRESS};
+  }
+`
+

--- a/src/components/App/SideBar/FilterSearch/__tests__/index.tsx
+++ b/src/components/App/SideBar/FilterSearch/__tests__/index.tsx
@@ -39,7 +39,14 @@ jest.mock('~/stores/useSchemaStore', () => ({
 
 describe('FilterSearch Component', () => {
   const mockSetSchemas = jest.fn()
+  const mockSetSchemaLinks = jest.fn()
   const mockSchemaAll = [{ type: 'Type1' }, { type: 'Type2' }, { type: 'Type3' }]
+  const mockSchemaEdges = [
+    { edge_type: 'HAS', ref_id: '1', source: 'source-1', target: 'target-1' },
+    { edge_type: 'HAS', ref_id: '2', source: 'source-2', target: 'target-2' },
+    { edge_type: 'SOURCE', ref_id: '3', source: 'source-3', target: 'target-3' },
+    { edge_type: 'CHILD_OF', ref_id: '4', source: 'source-4', target: 'target-4' },
+  ]
 
   beforeEach(() => {
     jest.clearAllMocks()
@@ -53,13 +60,13 @@ describe('FilterSearch Component', () => {
     })
 
     //
-    ;(useSchemaStore as jest.Mock).mockReturnValue([mockSchemaAll, mockSetSchemas]) // Return an array
+    ;(useSchemaStore as jest.Mock).mockReturnValue([mockSchemaAll, mockSchemaEdges, mockSetSchemas, mockSetSchemaLinks])
 
     //
     ;(useFeatureFlagStore as jest.Mock).mockReturnValue({ fastFiltersFeatureFlag: true })
 
     //
-    ;(getSchemaAll as jest.Mock).mockResolvedValue({ schemas: mockSchemaAll })
+    ;(getSchemaAll as jest.Mock).mockResolvedValue({ edges: mockSchemaEdges, schemas: mockSchemaAll })
   })
 
   const renderComponent = () =>
@@ -78,6 +85,16 @@ describe('FilterSearch Component', () => {
       mockSchemaAll.forEach((schema) => {
         expect(screen.getByText(schema.type)).toBeInTheDocument()
       })
+    })
+  })
+
+  it('should fetch and display unique edge types except CHILD_OF', async () => {
+    renderComponent()
+
+    await waitFor(() => {
+      expect(screen.getByText('HAS')).toBeInTheDocument()
+      expect(screen.getByText('SOURCE')).toBeInTheDocument()
+      expect(screen.queryByText('CHILD_OF')).not.toBeInTheDocument()
     })
   })
 
@@ -106,6 +123,24 @@ describe('FilterSearch Component', () => {
     await waitFor(() => {
       expect(mockSetFilters).toHaveBeenCalledWith({
         node_type: ['Type1'],
+        edge_type: [],
+        limit: 1000,
+        depth: '3',
+        top_node_count: '10',
+      })
+    })
+  })
+
+  it('should apply selected edge types when "Apply" is clicked', async () => {
+    renderComponent()
+
+    fireEvent.click(screen.getByText('HAS'))
+    fireEvent.click(screen.getByText('Apply'))
+
+    await waitFor(() => {
+      expect(mockSetFilters).toHaveBeenCalledWith({
+        node_type: [],
+        edge_type: ['HAS'],
         limit: 1000,
         depth: '3',
         top_node_count: '10',

--- a/src/components/App/SideBar/FilterSearch/index.tsx
+++ b/src/components/App/SideBar/FilterSearch/index.tsx
@@ -8,6 +8,7 @@ import { useDataStore } from '~/stores/useDataStore'
 import { useFeatureFlagStore } from '~/stores/useFeatureFlagStore'
 import { useSchemaStore } from '~/stores/useSchemaStore'
 import { colors } from '~/utils/colors'
+import { EdgeTypes } from './EdgeTypes'
 import { FastFilters } from './FastFilters'
 import { Hops } from './Hops'
 import { MaxResults } from './MaxResults'
@@ -22,19 +23,27 @@ type Props = {
 
 const defaultValues = {
   selectedTypes: [] as string[],
+  selectedEdgeTypes: [] as string[],
   hops: 3,
   sourceNodes: 10,
   maxResults: 1000,
 }
 
 export const FilterSearch = ({ anchorEl, setAnchorEl, onClose }: Props) => {
-  const [schemaAll, setSchemaAll] = useSchemaStore((s) => [s.schemas, s.setSchemas])
+  const [schemaAll, schemaEdges, setSchemaAll, setSchemaLinks] = useSchemaStore((s) => [
+    s.schemas,
+    s.links,
+    s.setSchemas,
+    s.setSchemaLinks,
+  ])
   const { abortFetchData, resetGraph, setFilters, resetData } = useDataStore((s) => s)
   const [selectedTypes, setSelectedTypes] = useState<string[]>(defaultValues.selectedTypes)
+  const [selectedEdgeTypes, setSelectedEdgeTypes] = useState<string[]>(defaultValues.selectedEdgeTypes)
   const [hops, setHops] = useState(defaultValues.hops)
   const [sourceNodes, setSourceNodes] = useState<number>(defaultValues.sourceNodes)
   const [maxResults, setMaxResults] = useState<number>(defaultValues.maxResults)
   const { fastFiltersFeatureFlag } = useFeatureFlagStore((s) => s)
+  const hasVisibleEdgeTypes = schemaEdges.some((edge) => edge.edge_type && edge.edge_type !== 'CHILD_OF')
 
   useEffect(() => {
     const fetchSchemaData = async () => {
@@ -42,13 +51,14 @@ export const FilterSearch = ({ anchorEl, setAnchorEl, onClose }: Props) => {
         const response = await getSchemaAll()
 
         setSchemaAll(response.schemas.filter((schema) => !schema.is_deleted))
+        setSchemaLinks(response.edges || [])
       } catch (error) {
         console.error('Error fetching schema:', error)
       }
     }
 
     fetchSchemaData()
-  }, [setSchemaAll])
+  }, [setSchemaAll, setSchemaLinks])
 
   const handleSchemaTypeClick = (type: string) => {
     setSelectedTypes((prevSelectedTypes) =>
@@ -60,8 +70,15 @@ export const FilterSearch = ({ anchorEl, setAnchorEl, onClose }: Props) => {
     setSelectedTypes(types)
   }
 
+  const handleEdgeTypeClick = (type: string) => {
+    setSelectedEdgeTypes((prevSelectedTypes) =>
+      prevSelectedTypes.includes(type) ? prevSelectedTypes.filter((t) => t !== type) : [...prevSelectedTypes, type],
+    )
+  }
+
   const resetToDefaultValues = () => {
     setSelectedTypes(defaultValues.selectedTypes)
+    setSelectedEdgeTypes(defaultValues.selectedEdgeTypes)
     setHops(defaultValues.hops)
     setSourceNodes(defaultValues.sourceNodes)
     setMaxResults(defaultValues.maxResults)
@@ -76,6 +93,7 @@ export const FilterSearch = ({ anchorEl, setAnchorEl, onClose }: Props) => {
   const handleFiltersApply = async () => {
     setFilters({
       node_type: selectedTypes,
+      edge_type: selectedEdgeTypes,
       limit: maxResults,
       depth: hops.toString(),
       top_node_count: sourceNodes.toString(),
@@ -111,6 +129,12 @@ export const FilterSearch = ({ anchorEl, setAnchorEl, onClose }: Props) => {
 
       <NodeTypes handleSchemaTypeClick={handleSchemaTypeClick} schemaAll={schemaAll} selectedTypes={selectedTypes} />
       <LineBar />
+      <EdgeTypes
+        handleEdgeTypeClick={handleEdgeTypeClick}
+        schemaEdges={schemaEdges}
+        selectedEdgeTypes={selectedEdgeTypes}
+      />
+      {hasVisibleEdgeTypes && <LineBar />}
       <SourceNodes setSourceNodes={setSourceNodes} sourceNodes={sourceNodes} />
       <LineBar />
       <Hops hops={hops} setHops={setHops} />

--- a/src/stores/useAiSummaryStore/index.ts
+++ b/src/stores/useAiSummaryStore/index.ts
@@ -102,17 +102,18 @@ export const useAiSummaryStore = create<AiSummaryStore>()(
 
       abortController = controller
 
-      const { node_type: filterNodeTypes, ...withoutNodeType } = filters
+      const { node_type: filterNodeTypes, edge_type: filterEdgeTypes, ...withoutNodeAndEdgeTypes } = filters
       const word = fullAiSearchQuery || currentSearch
 
       const isLatest = isEqual(filters, defaultFilters) && !word
 
       const updatedParams = {
-        ...withoutNodeType,
+        ...withoutNodeAndEdgeTypes,
         ...ai,
         skip: currentPage === 0 ? String(currentPage * itemsPerPage) : String(currentPage * itemsPerPage + 1),
         limit: word ? '25' : String(itemsPerPage),
         ...(filterNodeTypes.length > 0 ? { node_type: JSON.stringify(filterNodeTypes) } : {}),
+        ...(filterEdgeTypes.length > 0 ? { edge_type: JSON.stringify(filterEdgeTypes) } : {}),
         ...(word ? { word } : {}),
         ...(aiRefId && AISearchQuery ? { previous_search_ref_id: aiRefId } : {}),
         ...(!word && !AISearchQuery ? { sort_by: 'date_added_to_graph' } : {}),

--- a/src/stores/useDataStore/index.ts
+++ b/src/stores/useDataStore/index.ts
@@ -28,6 +28,7 @@ export const defaultFilters = {
   top_node_count: '40',
   includeContent: 'true',
   node_type: [],
+  edge_type: [],
   search_method: 'hybrid',
 }
 
@@ -188,18 +189,19 @@ export const useDataStore = create<DataStore>()(
 
       abortController = controller
 
-      const { node_type: filterNodeTypes, ...withoutNodeType } = filters
+      const { edge_type: filterEdgeTypes, node_type: filterNodeTypes, ...withoutNodeAndEdgeTypes } = filters
       const word = AISearchQuery || currentSearch
 
       const isLatest = isEqual(filters, defaultData.filters) && !word
 
       const updatedParams = {
-        ...withoutNodeType,
+        ...withoutNodeAndEdgeTypes,
         depth: filters.depth || '0',
         ...ai,
         skip: currentPage === 0 ? String(currentPage * itemsPerPage) : String(currentPage * itemsPerPage + 1),
         limit: word ? String(itemsPerPage) : String(itemsPerPage),
         ...(filterNodeTypes.length > 0 ? { node_type: JSON.stringify(filterNodeTypes) } : {}),
+        ...(filterEdgeTypes.length > 0 ? { edge_type: JSON.stringify(filterEdgeTypes) } : {}),
         ...(word ? { word } : {}),
         ...(aiRefId && AISearchQuery ? { previous_search_ref_id: aiRefId } : {}),
         ...(!word && !AISearchQuery ? { sort_by: 'date_added_to_graph' } : {}),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -80,6 +80,7 @@ export type FilterParams = {
   top_node_count: string
   include_properties: string
   node_type: string[]
+  edge_type: string[]
   search_method: string
   free?: string
   word?: string // Add other optional filter properties as needed


### PR DESCRIPTION
### Ticket №:

Closes #2444

### Problem:

The graph search filter popover only exposed node types. Issue #2444 asks for an `Edges` filter under `Type`, backed by the `/schema/all` edge data, with `CHILD_OF` excluded and selected edges applied to `/graph/search` through `edge_type`.

### Solution:

Added an `EdgeTypes` filter section that mirrors the existing node type pill UI and reads unique `edge_type` values from the schema store links returned by `/schema/all`.

### Changes:

- Store schema links from `getSchemaAll()` alongside schemas in `FilterSearch`.
- Render `Edges` after `Type` and before `Source Nodes`.
- De-duplicate edge types and filter out `CHILD_OF`.
- Track selected edge types in local filter state and reset/apply them with the other filters.
- Add `edge_type` to filter params and serialize it consistently with the existing `node_type` query param path.
- Update the AI summary fetch path so the new filter shape does not pass raw arrays into graph query params.
- Add FilterSearch test coverage for rendering, excluding `CHILD_OF`, de-duping, and applying selected edge types.

### Testing:

- `git diff --check`
- `yarn typecheck`
- `yarn jest src/components/App/SideBar/FilterSearch/__tests__/index.tsx --runInBand --no-cache --coverage=false --watchAll=false --ci`

### Notes:

I used the same JSON-array encoding pattern already used by `node_type` for `edge_type` to keep query serialization consistent with the existing graph search filters.