### PR TITLE
fix: remove blueprint horizontal scrollbars

### DIFF
--- a/src/components/ModalsContainer/BlueprintModal/Body/Editor/ColorPickerPopover/ColorPickerPopoverView/ColorPicker/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Editor/ColorPickerPopover/ColorPickerPopoverView/ColorPicker/index.tsx
@@ -124,14 +124,17 @@ const Wrapper = styled(Flex)`
 
 const TableWrapper = styled(Flex)`
   min-height: 0;
-  overflow: auto;
+  overflow-y: auto;
+  overflow-x: hidden;
   flex: 1;
   width: 100%;
 `
 
 const PickerContainer = styled.div`
   padding: 0 20px;
-  width: 315px;
+  width: 100%;
+  max-width: 315px;
+  box-sizing: border-box;
 `
 
 const ColorPalette = styled.div`
@@ -169,7 +172,8 @@ const SaturationPickerWrapper = styled.div`
 
 const HuePickerWrapper = styled.div`
   margin-bottom: 15px;
-  width: 224px;
+  width: 100%;
+  max-width: 224px;
   margin-left: 10px;
   display: flex;
   justify-content: center;

--- a/src/components/ModalsContainer/BlueprintModal/Body/Editor/ColorPickerPopover/ColorPickerPopoverView/IconPicker/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Editor/ColorPickerPopover/ColorPickerPopoverView/IconPicker/index.tsx
@@ -73,20 +73,23 @@ const Wrapper = styled(Flex)`
 
 const TableWrapper = styled(Flex)`
   min-height: 0;
-  overflow: auto;
+  overflow-y: auto;
+  overflow-x: hidden;
   flex: 1;
   width: 100%;
 `
 
 const PickerContainer = styled.div`
   padding: 0 20px;
-  width: 300px;
+  width: 100%;
+  max-width: 300px;
   height: 350px;
-  overflow: auto;
+  overflow-y: auto;
+  overflow-x: hidden;
+  box-sizing: border-box;
 `
 
 const IconPaletteWrapper = styled.div`
-  margin-left: 18px;
   margin-bottom: 6px;
 `
 

--- a/src/components/ModalsContainer/BlueprintModal/Body/Editor/ColorPickerPopover/ColorPickerPopoverView/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Editor/ColorPickerPopover/ColorPickerPopoverView/index.tsx
@@ -101,7 +101,9 @@ const TabPanelWrapper = styled(Flex)`
   min-height: 572px;
   padding: 20px 0;
   max-height: 572px;
-  overflow: auto;
+  overflow-y: auto;
+  overflow-x: hidden;
+  box-sizing: border-box;
 
   @media (max-width: 1024px) {
     width: 100%;
@@ -126,6 +128,7 @@ const Wrapper = styled(Flex)`
   min-height: 0;
   flex: 1;
   overflow: hidden;
+  width: 100%;
 
   @media (max-width: 768px) {
     padding: 3px;

--- a/src/components/ModalsContainer/BlueprintModal/Body/Editor/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Editor/index.tsx
@@ -755,7 +755,8 @@ export const Editor = ({
 }
 
 const CustomButton = styled(Button)`
-  width: 400px !important;
+  width: 100% !important;
+  max-width: 400px !important;
   margin: 0 auto !important;
 `
 
@@ -868,8 +869,12 @@ const InputIconWrapper = styled(Flex)`
   flex-direction: row;
   position: relative;
   display: flex;
+  width: 100%;
+  min-width: 0;
 `
 
 const InputWrapper = styled(Flex)`
-  width: 320px;
+  width: 100%;
+  max-width: 320px;
+  min-width: 0;
 `

--- a/src/components/ModalsContainer/BlueprintModal/Body/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/index.tsx
@@ -272,8 +272,10 @@ const EditorWrapper = styled(Flex)<EditorWrapperProps>`
 const InnerEditorWrapper = styled.div`
   height: 100%;
   overflow-y: auto;
+  overflow-x: hidden;
   padding: 16px;
   max-height: calc(90vh - 20px);
+  box-sizing: border-box;
 
   @media (max-width: 1440px) {
     max-height: calc(85vh - 20px);


### PR DESCRIPTION
Fixes stakwork/sphinx-nav-fiber#2315

Removes unwanted horizontal scrollbars from the blueprint modal/editor, including the color and icon picker views.

Changes:
- Hide horizontal overflow in the blueprint editor containers
- Make fixed-width editor controls responsive with max-widths
- Prevent picker containers from overflowing horizontally

Verified:
- yarn typecheck
- targeted prettier check for changed files
- git diff --check
