### PR TITLE
fix: extend mindset timeline across bottom

### DIFF
--- a/src/components/mindset/components/PlayerContols/index.tsx
+++ b/src/components/mindset/components/PlayerContols/index.tsx
@@ -45,7 +45,9 @@ export const PlayerControl = ({ markers, chapters }: Props) => {
 
   return showPlayer ? (
     <Wrapper>
-      <Controls />
+      <ControlsWrapper>
+        <Controls />
+      </ControlsWrapper>
       <ProgressBar
         chapters={chapters}
         duration={duration}
@@ -60,12 +62,27 @@ export const PlayerControl = ({ markers, chapters }: Props) => {
 const Wrapper = styled(Flex).attrs({
   direction: 'row',
   align: 'center',
-  justify: 'space-between',
+  justify: 'center',
 })`
+  position: relative;
   padding: 20px;
   background: ${colors.BG2};
   height: 96px;
   border-radius: 8px;
   box-sizing: border-box;
   margin-right: 4px;
+`
+
+const ControlsWrapper = styled.div`
+  position: absolute;
+  left: 20px;
+  top: 50%;
+  z-index: 30;
+  transform: translateY(-50%);
+
+  @media (max-width: 768px) {
+    position: static;
+    width: 100%;
+    transform: none;
+  }
 `

--- a/src/components/mindset/index.tsx
+++ b/src/components/mindset/index.tsx
@@ -306,6 +306,7 @@ const ContentContainer = styled(Flex)`
 `
 
 const PlayerControlWrapper = styled(Flex)`
-  padding: 16px 16px 16px 0;
-  margin-left: 18px;
+  width: 100%;
+  box-sizing: border-box;
+  padding: 16px 20px;
 `


### PR DESCRIPTION
### Ticket №:

Closes #2537

### Problem:

The Graph Mindset player timeline was constrained by the left-side controls and the bottom control wrapper did not span the full layout width, so the timeline did not continue underneath the transcript/sidebar area.

### Solution:

Let the bottom player control area take the full width and position the playback controls independently from the progress timeline. This keeps the controls in place while allowing the timeline, chapters, markers, hover tooltip, and seeking behavior to use the full bottom row.

### Changes:

- Made `PlayerControlWrapper` full width with consistent horizontal padding.
- Wrapped the playback controls in an overlay container so they no longer reduce the `ProgressBar` width.
- Preserved the existing mobile behavior by keeping the controls in normal flow on small screens.

### Testing:

- `yarn exec prettier --config prettier.config.js --check src/components/mindset/index.tsx src/components/mindset/components/PlayerContols/index.tsx`
- `yarn typecheck`
- `yarn build`

### Notes:

Build completed successfully. Existing repository warnings still appear during build.