### PR TITLE
feat: Add Engagement Report button to analytics sidebar (#2788)

### DIFF
--- a/src/components/mindset/tweet/components/Sidebar/Stats/index.tsx
+++ b/src/components/mindset/tweet/components/Sidebar/Stats/index.tsx
@@ -121,6 +121,18 @@ export const Stats = ({ node, handleAnalyzeClick }: Props) => {
           <Value>{getSentimentIcon(node?.properties?.analytics_sentiment_score)}</Value>
         </Metric>
       </Grid>
+      <EngagementButton
+        onClick={(e) => {
+          e.stopPropagation()
+          window.open(
+            `https://analytics.twitter.com/`,
+            '_blank',
+            'noopener,noreferrer'
+          )
+        }}
+      >
+        Engagement Report
+      </EngagementButton>
     </Card>
   )
 }
@@ -191,5 +203,22 @@ const IconButton = styled.a`
   cursor: pointer;
   &:hover {
     opacity: 0.6;
+  }
+`
+
+const EngagementButton = styled.button`
+  margin-top: 16px;
+  width: 100%;
+  background: #2563eb;
+  color: white;
+  padding: 10px 16px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  border: none;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+  &:hover {
+    background: #1d4ed8;
   }
 `


### PR DESCRIPTION
## Summary

Added an Engagement Report button to the analytics sidebar as requested in issue #2788.

### Changes
- Added `EngagementButton` styled component with blue background (`#2563eb`)
- Button opens Twitter Analytics in a new tab when clicked
- Proper event handling to prevent propagation
- Hover effect with darker blue (`#1d4ed8`)

### Design
Matches the issue requirements:
- `margin-top: 16px`
- `width: 100%`
- `bg-blue-600 hover:bg-blue-700` (Tailwind equivalent in styled-components)
- `rounded-lg` border-radius
- `transition duration-200`

### Files Changed
- `src/components/mindset/tweet/components/Sidebar/Stats/index.tsx`

Closes #2788