### PR TITLE
fix: enable pointer-events on scrubber bar for Chrome (#2612)

### DIFF
--- a/src/components/mindset/components/PlayerContols/ProgressBar/index.tsx
+++ b/src/components/mindset/components/PlayerContols/ProgressBar/index.tsx
@@ -98,7 +98,6 @@ export const ProgressBar = ({ duration, markers, handleProgressChange, playingTi
     <ProgressWrapper>
       <SliderWrapper
         ref={sliderRef}
-        onClick={handleSliderClick}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
         onMouseMove={handleMouseMove}
@@ -106,7 +105,6 @@ export const ProgressBar = ({ duration, markers, handleProgressChange, playingTi
         <ProgressSlider
           max={duration}
           onChange={handleProgressChange}
-          onMouseDown={(e) => e.preventDefault()}
           value={playingTime}
           width={width}
         />
@@ -213,7 +211,6 @@ const ProgressSlider = styled(Slider)<{ width: number }>`
     height: 3px;
     width: calc(100% - 12px);
     box-sizing: border-box;
-    pointer-events: none;
 
     .MuiSlider-track {
       border: none;


### PR DESCRIPTION
## Summary

Fixes issue #2612 where tapping on the scrubber bar in Chrome (before playback starts) doesn't visually move the indicator.

## Changes

- Remove  from ProgressSlider component
- Remove custom handleSliderClick wrapper handler
- Remove onMouseDown prevention
- Let native MUI Slider handle user interactions properly

The issue was that the custom click handler was preventing the native Slider component from updating its visual state, especially before playback started. By removing the pointer-events: none and using the native Slider's built-in interactions, the scrubber indicator will now visually update immediately when tapped, even before playback starts.

## Acceptance Criteria

- ✅ Fix the issue where tapping on the timeline scrubber in Chrome immediately updates the indicator to the newly tapped position
- ✅ Ensure consistent behavior across major browsers and devices