### PR TITLE
fix: ontology nodes not movable after adding/editing (#2531)

### DIFF
--- a/src/components/ModalsContainer/BlueprintModal/Body/Graph/ForceGraph/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Graph/ForceGraph/index.tsx
@@ -40,11 +40,10 @@ export const ForceGraph = ({
     const links = structuredClone(filteredLinks)
 
     if (simulation2d) {
+      // Update whenever nodes or links change (not just both at once)
       if (
-        prevSchemas &&
-        prevSchemas.length !== schemasWithPositions.length &&
-        prevLinks &&
-        prevLinks.length !== filteredLinks.length
+        (prevSchemas && prevSchemas.length !== schemasWithPositions.length) ||
+        (prevLinks && prevLinks.length !== filteredLinks.length)
       ) {
         simulation2d
           .nodes(nodes)

--- a/src/components/ModalsContainer/BlueprintModal/Body/Graph/Nodes/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Graph/Nodes/index.tsx
@@ -22,10 +22,8 @@ export const Nodes = ({ simulation, setSelectedSchemaId, selectedId, setIsAddEdg
 
   return (
     <>
-      {schemaAll.map((schema: SchemaExtended, index: number) => {
-        const node = simulation.nodes()[index]
-
-        return node ? (
+      {simulation.nodes().map((node: SchemaExtended) => {
+        return (
           <Node
             key={node.ref_id}
             isSelected={node.ref_id === selectedId}
@@ -36,7 +34,7 @@ export const Nodes = ({ simulation, setSelectedSchemaId, selectedId, setIsAddEdg
               setSelectedSchemaId(node.ref_id)
             }}
           />
-        ) : null
+        )
       })}
     </>
   )


### PR DESCRIPTION
## Summary

Fixes issue #2531 where nodes could not be moved around after editing or adding a node.

## Changes

1. **Fix ForceGraph update condition**: Changed from && (nodes AND links must change) to || (nodes OR links change), allowing the simulation to update whenever either one changes
2. **Fix Nodes component render**: Render simulation.nodes() directly instead of matching by index from schemaAll, which could lead to incorrect node association when nodes are added/removed

This ensures the simulation stays in sync with the latest data and nodes remain movable after any edit/adding operations.

Closes #2531