### PR TITLE
[Filters] Add Edge Types list

### DIFF
--- a/src/components/App/SideBar/FilterSearch/EdgeTypes/index.tsx
+++ b/src/components/App/SideBar/FilterSearch/EdgeTypes/index.tsx
@@ -1,0 +1,157 @@
+import { useState } from 'react'
+import styled from 'styled-components'
+import { Flex } from '~/components/common/Flex'
+import PlusIcon from '~/components/Icons/PlusIcon'
+import { SchemaLink } from '~/network/fetchSourcesData'
+import { colors } from '~/utils'
+import { PopoverBody } from '..'
+
+type Props = {
+  handleEdgeTypeClick: (type: string) => void
+  selectedEdgeTypes: string[]
+  schemaLinks: SchemaLink[]
+}
+
+export const EdgeTypes = ({ handleEdgeTypeClick, selectedEdgeTypes, schemaLinks }: Props) => {
+  const [showAllEdges, setShowAllEdges] = useState(false)
+
+  const edgesPerRow = 3
+  const MAX_ROWS = 4
+  const maxVisibleEdges = edgesPerRow * MAX_ROWS
+
+  const uniqueEdgeTypes = (showAllEdges ? schemaLinks : schemaLinks.slice(0, maxVisibleEdges))
+    .filter((link, index, self) => index === self.findIndex((l) => l.edge_type === link.edge_type))
+    .filter((link) => link.edge_type !== 'CHILD_OF')
+
+  return (
+    <>
+      <PopoverHeader>
+        <div>Edges</div>
+        <CountSelectedWrapper>
+          <Count>{selectedEdgeTypes.length}</Count>
+          <SelectedText>Selected</SelectedText>
+        </CountSelectedWrapper>
+      </PopoverHeader>
+      <PopoverBody>
+        <EdgeTypeWrapper>
+          {uniqueEdgeTypes.map((link) => (
+            <EdgeType
+              key={link.edge_type}
+              isSelected={selectedEdgeTypes.includes(link.edge_type)}
+              onClick={() => handleEdgeTypeClick(link.edge_type)}
+            >
+              {link.edge_type}
+            </EdgeType>
+          ))}
+        </EdgeTypeWrapper>
+        {!showAllEdges && schemaLinks.length > maxVisibleEdges && (
+          <ViewMoreButton onClick={() => setShowAllEdges(true)}>
+            <PlusIconWrapper>
+              <PlusIcon /> View More
+            </PlusIconWrapper>
+          </ViewMoreButton>
+        )}
+      </PopoverBody>
+    </>
+  )
+}
+
+const PopoverHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-bottom: 8px;
+  font-family: Barlow;
+  font-size: 18px;
+  font-weight: 500;
+`
+
+const CountSelectedWrapper = styled.div`
+  font-size: 13px;
+  display: flex;
+  align-items: center;
+`
+
+const Count = styled.span`
+  color: ${colors.white};
+`
+
+const SelectedText = styled.span`
+  color: ${colors.GRAY3};
+  margin-left: 4px;
+`
+
+const PlusIconWrapper = styled.span`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 6px;
+
+  svg {
+    width: 23px;
+    height: 23px;
+    fill: none;
+    margin-top: 2px;
+  }
+`
+
+const EdgeTypeWrapper = styled(Flex).attrs({
+  align: 'center',
+  direction: 'row',
+  grow: 1,
+  justify: 'flex-start',
+})`
+  flex-wrap: wrap;
+  gap: 10px;
+  padding-right: 10px;
+  margin-right: calc(0px - 16px);
+`
+
+const EdgeType = styled(Flex).attrs({
+  align: 'center',
+  direction: 'row',
+  justify: 'flex-start',
+})<{ isSelected: boolean }>`
+  color: ${({ isSelected }) => (isSelected ? colors.black : colors.white)};
+  background: ${({ isSelected }) => (isSelected ? colors.white : colors.BUTTON1_PRESS)};
+  padding: 6px 10px 6px 8px;
+  font-family: Barlow;
+  font-size: 13px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 15px;
+  letter-spacing: 0.78px;
+  margin: 0 3px;
+  border-radius: 200px;
+  cursor: pointer;
+
+  &:hover {
+    background: ${({ isSelected }) => (isSelected ? colors.white : colors.BUTTON1_PRESS)};
+  }
+
+  &:active {
+    background: ${colors.white};
+    color: ${colors.black};
+  }
+`
+
+const ViewMoreButton = styled.button`
+  background: transparent;
+  color: ${colors.white};
+  border: none;
+  padding: 6px 12px 6px 3px;
+  margin-top: 20px;
+  cursor: pointer;
+  border-radius: 4px;
+  font-family: Barlow;
+  font-size: 13px;
+  font-weight: 500;
+
+  &:hover {
+    background: ${colors.BUTTON1_HOVER};
+  }
+
+  &:active {
+    background: ${colors.BUTTON1_PRESS};
+  }
+`

--- a/src/components/App/SideBar/FilterSearch/index.tsx
+++ b/src/components/App/SideBar/FilterSearch/index.tsx
@@ -8,6 +8,7 @@ import { useDataStore } from '~/stores/useDataStore'
 import { useFeatureFlagStore } from '~/stores/useFeatureFlagStore'
 import { useSchemaStore } from '~/stores/useSchemaStore'
 import { colors } from '~/utils/colors'
+import { EdgeTypes } from './EdgeTypes'
 import { FastFilters } from './FastFilters'
 import { Hops } from './Hops'
 import { MaxResults } from './MaxResults'
@@ -22,15 +23,22 @@ type Props = {
 
 const defaultValues = {
   selectedTypes: [] as string[],
+  selectedEdgeTypes: [] as string[],
   hops: 3,
   sourceNodes: 10,
   maxResults: 1000,
 }
 
 export const FilterSearch = ({ anchorEl, setAnchorEl, onClose }: Props) => {
-  const [schemaAll, setSchemaAll] = useSchemaStore((s) => [s.schemas, s.setSchemas])
+  const [schemaAll, setSchemaAll, schemaLinks, setSchemaLinks] = useSchemaStore((s) => [
+    s.schemas,
+    s.setSchemas,
+    s.links,
+    s.setSchemaLinks,
+  ])
   const { abortFetchData, resetGraph, setFilters, resetData } = useDataStore((s) => s)
   const [selectedTypes, setSelectedTypes] = useState<string[]>(defaultValues.selectedTypes)
+  const [selectedEdgeTypes, setSelectedEdgeTypes] = useState<string[]>(defaultValues.selectedEdgeTypes)
   const [hops, setHops] = useState(defaultValues.hops)
   const [sourceNodes, setSourceNodes] = useState<number>(defaultValues.sourceNodes)
   const [maxResults, setMaxResults] = useState<number>(defaultValues.maxResults)
@@ -42,17 +50,26 @@ export const FilterSearch = ({ anchorEl, setAnchorEl, onClose }: Props) => {
         const response = await getSchemaAll()
 
         setSchemaAll(response.schemas.filter((schema) => !schema.is_deleted))
+        setSchemaLinks(response.edges)
       } catch (error) {
         console.error('Error fetching schema:', error)
       }
     }
 
     fetchSchemaData()
-  }, [setSchemaAll])
+  }, [setSchemaAll, setSchemaLinks])
 
   const handleSchemaTypeClick = (type: string) => {
     setSelectedTypes((prevSelectedTypes) =>
       prevSelectedTypes.includes(type) ? prevSelectedTypes.filter((t) => t !== type) : [...prevSelectedTypes, type],
+    )
+  }
+
+  const handleEdgeTypeClick = (type: string) => {
+    setSelectedEdgeTypes((prevSelectedEdgeTypes) =>
+      prevSelectedEdgeTypes.includes(type)
+        ? prevSelectedEdgeTypes.filter((t) => t !== type)
+        : [...prevSelectedEdgeTypes, type],
     )
   }
 
@@ -62,6 +79,7 @@ export const FilterSearch = ({ anchorEl, setAnchorEl, onClose }: Props) => {
 
   const resetToDefaultValues = () => {
     setSelectedTypes(defaultValues.selectedTypes)
+    setSelectedEdgeTypes(defaultValues.selectedEdgeTypes)
     setHops(defaultValues.hops)
     setSourceNodes(defaultValues.sourceNodes)
     setMaxResults(defaultValues.maxResults)
@@ -76,6 +94,7 @@ export const FilterSearch = ({ anchorEl, setAnchorEl, onClose }: Props) => {
   const handleFiltersApply = async () => {
     setFilters({
       node_type: selectedTypes,
+      edge_type: selectedEdgeTypes,
       limit: maxResults,
       depth: hops.toString(),
       top_node_count: sourceNodes.toString(),
@@ -110,6 +129,12 @@ export const FilterSearch = ({ anchorEl, setAnchorEl, onClose }: Props) => {
       )}
 
       <NodeTypes handleSchemaTypeClick={handleSchemaTypeClick} schemaAll={schemaAll} selectedTypes={selectedTypes} />
+      <LineBar />
+      <EdgeTypes
+        handleEdgeTypeClick={handleEdgeTypeClick}
+        schemaLinks={schemaLinks}
+        selectedEdgeTypes={selectedEdgeTypes}
+      />
       <LineBar />
       <SourceNodes setSourceNodes={setSourceNodes} sourceNodes={sourceNodes} />
       <LineBar />

--- a/src/stores/useDataStore/index.ts
+++ b/src/stores/useDataStore/index.ts
@@ -28,6 +28,7 @@ export const defaultFilters = {
   top_node_count: '40',
   includeContent: 'true',
   node_type: [],
+  edge_type: [],
   search_method: 'hybrid',
 }
 
@@ -188,7 +189,7 @@ export const useDataStore = create<DataStore>()(
 
       abortController = controller
 
-      const { node_type: filterNodeTypes, ...withoutNodeType } = filters
+      const { node_type: filterNodeTypes, edge_type: filterEdgeTypes, ...withoutNodeType } = filters
       const word = AISearchQuery || currentSearch
 
       const isLatest = isEqual(filters, defaultData.filters) && !word
@@ -200,6 +201,7 @@ export const useDataStore = create<DataStore>()(
         skip: currentPage === 0 ? String(currentPage * itemsPerPage) : String(currentPage * itemsPerPage + 1),
         limit: word ? String(itemsPerPage) : String(itemsPerPage),
         ...(filterNodeTypes.length > 0 ? { node_type: JSON.stringify(filterNodeTypes) } : {}),
+        ...(filterEdgeTypes?.length > 0 ? { edge_type: JSON.stringify(filterEdgeTypes) } : {}),
         ...(word ? { word } : {}),
         ...(aiRefId && AISearchQuery ? { previous_search_ref_id: aiRefId } : {}),
         ...(!word && !AISearchQuery ? { sort_by: 'date_added_to_graph' } : {}),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -80,6 +80,7 @@ export type FilterParams = {
   top_node_count: string
   include_properties: string
   node_type: string[]
+  edge_type: string[]
   search_method: string
   free?: string
   word?: string // Add other optional filter properties as needed


### PR DESCRIPTION
## Summary

Adds Edge Types to the filter panel in the sidebar.

## Changes

1. **New EdgeTypes component** - Similar to NodeTypes, with the same pill styling and view more functionality
2. **Positioned correctly** - Below Node Types and above Source Nodes
3. **Data source** - Uses schema links from /schema/all API response
4. **CHILD_OF filter** - Filters out the CHILD_OF edge type from display
5. **Filter parameter** - Adds edge_type parameter to the graph search request when edges are selected
6. **State management** - Updates schema store to store links, and data store to pass edge_type in API

## Acceptance Criteria

- [x] Render new 'Edges' item in filter panel
- [x] Pill Style exactly like Node Types
- [x] Selected and unselected style like Node Types
- [x] Pass param edge_type in the filters search request /graph/search?edge_type[]=has&edge_type[]=source

Closes issue #2441