### PR TITLE
fix: support youtube live and shorts urls

### DIFF
--- a/src/components/AddContentModal/utils/__tests__/index.ts
+++ b/src/components/AddContentModal/utils/__tests__/index.ts
@@ -12,6 +12,12 @@ describe('youtubeRegex', () => {
     await expect(getInputType('https://youtube.com/live/tkdMgjEFNWs')).resolves.toBe(LINK)
   })
 
+  it('should classify youtube live and shorts URLs as links across subdomains', async () => {
+    await expect(getInputType('https://www.youtube.com/live/abc123')).resolves.toBe(LINK)
+    await expect(getInputType('https://m.youtube.com/live/xyz789?feature=share')).resolves.toBe(LINK)
+    await expect(getInputType('https://www.youtube.com/shorts/short123')).resolves.toBe(LINK)
+  })
+
   it('should assert we can check for twitter spaces regex', async () => {
     await expect(getInputType('https://twitter.com/i/spaces/1zqKVqwrVzlxB?s=20')).resolves.toBe(LINK)
   })
@@ -70,6 +76,12 @@ describe('youtubeRegex', () => {
 
   it('should assert we can check for youtube live clip regex', async () => {
     await expect(getInputType('https://www.youtube.com/@MrBeast')).resolves.toBe(YOUTUBE_CHANNEL)
+  })
+
+  it('should not classify non-channel youtube paths as channels', async () => {
+    await expect(getInputType('https://youtube.com/results?search_query=test')).resolves.not.toBe(YOUTUBE_CHANNEL)
+    await expect(getInputType('https://www.youtube.com/feed/subscriptions')).resolves.not.toBe(YOUTUBE_CHANNEL)
+    await expect(getInputType('https://www.youtube.com/live/tkdMgjEFNWs')).resolves.not.toBe(YOUTUBE_CHANNEL)
   })
 
   it('should assert we can check for document regex', async () => {

--- a/src/components/AddContentModal/utils/index.ts
+++ b/src/components/AddContentModal/utils/index.ts
@@ -2,16 +2,18 @@ import { DOCUMENT, LINK, RSS, TWITTER_HANDLE, TWITTER_SOURCE, WEB_PAGE, YOUTUBE_
 
 export const twitterHandlePattern = /\b(?:twitter\.com|x\.com)\/(?:@)?([\w_]+)(?:$|\?[^/]*$)/
 
-const youtubeRegex = /(https?:\/\/)?(www\.)?youtube\.com\/watch\?v=([A-Za-z0-9_-]+)/
-const youtubeLiveRegex = /(https?:\/\/)?(www\.)?youtube\.com\/live\/([A-Za-z0-9_-]+)/
-const youtubeShortRegex = /(https?:\/\/)?(www\.)?youtu\.be\/([A-Za-z0-9_-]+)/
+const youtubeRegex = /(https?:\/\/)?(www\.|m\.)?youtube\.com\/watch\?v=([A-Za-z0-9_-]+)/
+const youtubeLiveRegex = /(https?:\/\/)?(www\.|m\.)?youtube\.com\/live\/([A-Za-z0-9_-]+)(?:[/?#].*)?$/
+const youtubeShortRegex = /(https?:\/\/)?(www\.)?youtu\.be\/([A-Za-z0-9_-]+)(?:[/?#].*)?$/
+const youtubeShortsRegex = /(https?:\/\/)?(www\.|m\.)?youtube\.com\/shorts\/([A-Za-z0-9_-]+)(?:[/?#].*)?$/
 const twitterSpaceRegex = /https:\/\/twitter\.com\/i\/spaces\/([A-Za-z0-9_-]+)/
 const tweetUrlRegex = /https:\/\/(twitter\.com|x\.com)\/[^/]+\/status\/(\d+)/
 const mp3Regex = /(https?:\/\/)?.*\.mp3/
 const mp4Regex = /(https?:\/\/)?.*\.mp4/
 
 const rssRegex = /(https?:\/\/)?(.*\.)?.+\/(feed|rss|rss\.xml|.*\?(feed|format)=rss)(\/.*)?$/
-const youtubeChannelPattern = /https?:\/\/(www\.)?youtube\.com\/(user\/)?(@)?([\w-]+)/
+const youtubeChannelPattern =
+  /https?:\/\/(www\.|m\.)?youtube\.com\/(?!live\/|watch(?:\?|$)|shorts\/|embed\/|results(?:\?|$)|feed(?:\/|$)|playlist(?:\?|$))(user\/|c\/)?(@)?([\w-]+)(?:[/?#].*)?$/
 
 const genericUrlRegex = /^(https?|ftp):\/\/[^\s/$.?#].[^\s]*$/
 const twitterBroadcastRegex = /https:\/\/twitter\.com\/i\/broadcasts\/([A-Za-z0-9_-]+)/
@@ -33,6 +35,7 @@ export async function getInputType(source: string) {
     twitterBroadcastRegex,
     youtubeRegex,
     youtubeShortRegex,
+    youtubeShortsRegex,
     twitterSpaceRegex,
     mp3Regex,
     mp4Regex,

--- a/src/components/AddItemModal/utils/__tests__/index.ts
+++ b/src/components/AddItemModal/utils/__tests__/index.ts
@@ -18,6 +18,12 @@ describe('youtubeRegex', () => {
     expect(getInputType('https://youtube.com/live/tkdMgjEFNWs')).toBe(LINK)
   })
 
+  it('should classify youtube live and shorts URLs as links across subdomains', async () => {
+    expect(getInputType('https://www.youtube.com/live/abc123')).toBe(LINK)
+    expect(getInputType('https://m.youtube.com/live/xyz789?feature=share')).toBe(LINK)
+    expect(getInputType('https://www.youtube.com/shorts/short123')).toBe(LINK)
+  })
+
   it('should assert we can check for twitter spaces regex', async () => {
     expect(getInputType('https://twitter.com/i/spaces/1zqKVqwrVzlxB?s=20')).toBe(LINK)
   })
@@ -48,6 +54,12 @@ describe('youtubeRegex', () => {
 
   it('should assert we can check for youtube live clip regex', async () => {
     expect(getInputType('https://www.youtube.com/@MrBeast')).toBe(YOUTUBE_CHANNEL)
+  })
+
+  it('should not classify non-channel youtube paths as channels', async () => {
+    expect(getInputType('https://youtube.com/results?search_query=test')).not.toBe(YOUTUBE_CHANNEL)
+    expect(getInputType('https://www.youtube.com/feed/subscriptions')).not.toBe(YOUTUBE_CHANNEL)
+    expect(getInputType('https://www.youtube.com/live/tkdMgjEFNWs')).not.toBe(YOUTUBE_CHANNEL)
   })
 
   it('should assert we can check for document regex', async () => {

--- a/src/components/AddItemModal/utils/index.ts
+++ b/src/components/AddItemModal/utils/index.ts
@@ -2,20 +2,22 @@ import { DOCUMENT, LINK, RSS, TWITTER_HANDLE, TWITTER_SOURCE, WEB_PAGE, YOUTUBE_
 
 export const twitterHandlePattern = /\btwitter\.com\/(?:@)?([\w_]+)(?:$|\?[^/]*$)/
 
-const youtubeRegex = /(https?:\/\/)?(www\.)?youtube\.com\/watch\?v=([A-Za-z0-9_-]+)/
-const youtubeLiveRegex = /(https?:\/\/)?(www\.)?youtube\.com\/live\/([A-Za-z0-9_-]+)/
+const youtubeRegex = /(https?:\/\/)?(www\.|m\.)?youtube\.com\/watch\?v=([A-Za-z0-9_-]+)/
+const youtubeLiveRegex = /(https?:\/\/)?(www\.|m\.)?youtube\.com\/live\/([A-Za-z0-9_-]+)(?:[/?#].*)?$/
+const youtubeShortsRegex = /(https?:\/\/)?(www\.|m\.)?youtube\.com\/shorts\/([A-Za-z0-9_-]+)(?:[/?#].*)?$/
 const twitterSpaceRegex = /https:\/\/twitter\.com\/i\/spaces\/([A-Za-z0-9_-]+)/
 const tweetUrlRegex = /https:\/\/twitter\.com\/[^/]+\/status\/(\d+)/
 const mp3Regex = /(https?:\/\/)?([A-Za-z0-9_-]+)\.mp3/
 
 const rssRegex = /(https?:\/\/)?(.*\.)?.+\/(feed|rss|rss.xml|.*.rss|.*\?(feed|format)=rss)$/
-const youtubeChannelPattern = /https?:\/\/(www\.)?youtube\.com\/(user\/)?(@)?([\w-]+)/
+const youtubeChannelPattern =
+  /https?:\/\/(www\.|m\.)?youtube\.com\/(?!live\/|watch(?:\?|$)|shorts\/|embed\/|results(?:\?|$)|feed(?:\/|$)|playlist(?:\?|$))(user\/|c\/)?(@)?([\w-]+)(?:[/?#].*)?$/
 
 const genericUrlRegex = /^(https?|ftp):\/\/[^\s/$.?#].[^\s]*$/
 const twitterBroadcastRegex = /https:\/\/twitter\.com\/i\/broadcasts\/([A-Za-z0-9_-]+)/
 
 export function getInputType(source: string) {
-  const linkPatterns = [youtubeLiveRegex, twitterBroadcastRegex, youtubeRegex, twitterSpaceRegex, mp3Regex]
+  const linkPatterns = [youtubeLiveRegex, youtubeShortsRegex, twitterBroadcastRegex, youtubeRegex, twitterSpaceRegex, mp3Regex]
 
   if (linkPatterns.some((pattern) => pattern.test(source))) {
     return LINK

--- a/src/components/mindset/components/LandingPage/utils/index.tsx
+++ b/src/components/mindset/components/LandingPage/utils/index.tsx
@@ -5,9 +5,10 @@ const topLevelDomains = /(?:\.[a-zA-Z0-9][a-zA-Z0-9-]{0,61})[a-zA-Z0-9](?:\.[a-z
 const path = /(\/[^\s?]*)?/
 const query = /(\?[^\s]*)?/
 
-const youtubeRegex = /(https?:\/\/)?(www\.)?youtube\.com\/watch\?v=([A-Za-z0-9_-]+)/
-const youtubeLiveRegex = /(https?:\/\/)?(www\.)?youtube\.com\/live\/([A-Za-z0-9_-]+)/
-const youtubeShortRegex = /(https?:\/\/)?(www\.)?youtu\.be\/([A-Za-z0-9_-]+)/
+const youtubeRegex = /(https?:\/\/)?(www\.|m\.)?youtube\.com\/watch\?v=([A-Za-z0-9_-]+)/
+const youtubeLiveRegex = /(https?:\/\/)?(www\.|m\.)?youtube\.com\/live\/([A-Za-z0-9_-]+)(?:[/?#].*)?$/
+const youtubeShortRegex = /(https?:\/\/)?(www\.)?youtu\.be\/([A-Za-z0-9_-]+)(?:[/?#].*)?$/
+const youtubeShortsRegex = /(https?:\/\/)?(www\.|m\.)?youtube\.com\/shorts\/([A-Za-z0-9_-]+)(?:[/?#].*)?$/
 const mp3Regex = /(https?:\/\/)?([A-Za-z0-9_-]+)\.mp3/
 
 const urlRegex = new RegExp(
@@ -41,7 +42,7 @@ export const isValidMediaUrl = (url: string): boolean => {
     return false
   }
 
-  const mediaPatterns = [youtubeRegex, youtubeLiveRegex, youtubeShortRegex, mp3Regex]
+  const mediaPatterns = [youtubeRegex, youtubeLiveRegex, youtubeShortRegex, youtubeShortsRegex, mp3Regex]
 
   return mediaPatterns.some((pattern) => pattern.test(url))
 }

--- a/src/components/mindset/tweet/components/LandingPage/utils/index.tsx
+++ b/src/components/mindset/tweet/components/LandingPage/utils/index.tsx
@@ -5,9 +5,10 @@ const topLevelDomains = /(?:\.[a-zA-Z0-9][a-zA-Z0-9-]{0,61})[a-zA-Z0-9](?:\.[a-z
 const path = /(\/[^\s?]*)?/
 const query = /(\?[^\s]*)?/
 
-const youtubeRegex = /(https?:\/\/)?(www\.)?youtube\.com\/watch\?v=([A-Za-z0-9_-]+)/
-const youtubeLiveRegex = /(https?:\/\/)?(www\.)?youtube\.com\/live\/([A-Za-z0-9_-]+)/
-const youtubeShortRegex = /(https?:\/\/)?(www\.)?youtu\.be\/([A-Za-z0-9_-]+)/
+const youtubeRegex = /(https?:\/\/)?(www\.|m\.)?youtube\.com\/watch\?v=([A-Za-z0-9_-]+)/
+const youtubeLiveRegex = /(https?:\/\/)?(www\.|m\.)?youtube\.com\/live\/([A-Za-z0-9_-]+)(?:[/?#].*)?$/
+const youtubeShortRegex = /(https?:\/\/)?(www\.)?youtu\.be\/([A-Za-z0-9_-]+)(?:[/?#].*)?$/
+const youtubeShortsRegex = /(https?:\/\/)?(www\.|m\.)?youtube\.com\/shorts\/([A-Za-z0-9_-]+)(?:[/?#].*)?$/
 const mp3Regex = /(https?:\/\/)?([A-Za-z0-9_-]+)\.mp3/
 
 const urlRegex = new RegExp(
@@ -41,7 +42,7 @@ export const isValidMediaUrl = (url: string): boolean => {
     return false
   }
 
-  const mediaPatterns = [youtubeRegex, youtubeLiveRegex, youtubeShortRegex, mp3Regex]
+  const mediaPatterns = [youtubeRegex, youtubeLiveRegex, youtubeShortRegex, youtubeShortsRegex, mp3Regex]
 
   return mediaPatterns.some((pattern) => pattern.test(url))
 }


### PR DESCRIPTION
## Summary
- expand YouTube URL handling to support `m.youtube.com/live/...`, `youtube.com/shorts/...`, and `youtu.be` URLs with trailing query/hash segments
- avoid misclassifying reserved YouTube paths like `/live/`, `/watch`, `/shorts/`, `/results`, `/feed`, and `/playlist` as channels
- add regression coverage in both AddContentModal and AddItemModal utility test suites

## Testing
- not run locally; repository dependency installation in the imported snapshot was unstable, so this PR was prepared from a clean upstream clone and validated by code-level diff review