### PR TITLE
fix: exclude YouTube /live/ URLs from channel regex

### DIFF
--- a/src/components/AddContentModal/utils/__tests__/index.ts
+++ b/src/components/AddContentModal/utils/__tests__/index.ts
@@ -12,6 +12,10 @@ describe('youtubeRegex', () => {
     await expect(getInputType('https://youtube.com/live/tkdMgjEFNWs')).resolves.toBe(LINK)
   })
 
+  it('should assert youtube live URL is not detected as channel', async () => {
+    await expect(getInputType('https://www.youtube.com/live/tkdMgjEFNWs')).resolves.toBe(LINK)
+  })
+
   it('should assert we can check for twitter spaces regex', async () => {
     await expect(getInputType('https://twitter.com/i/spaces/1zqKVqwrVzlxB?s=20')).resolves.toBe(LINK)
   })

--- a/src/components/AddContentModal/utils/index.ts
+++ b/src/components/AddContentModal/utils/index.ts
@@ -11,7 +11,7 @@ const mp3Regex = /(https?:\/\/)?.*\.mp3/
 const mp4Regex = /(https?:\/\/)?.*\.mp4/
 
 const rssRegex = /(https?:\/\/)?(.*\.)?.+\/(feed|rss|rss\.xml|.*\?(feed|format)=rss)(\/.*)?$/
-const youtubeChannelPattern = /https?:\/\/(www\.)?youtube\.com\/(user\/)?(@)?([\w-]+)/
+const youtubeChannelPattern = /https?:\/\/(www\.)?youtube\.com\/(?!live\/)(user\/)?(@)?([\w-]+)/
 
 const genericUrlRegex = /^(https?|ftp):\/\/[^\s/$.?#].[^\s]*$/
 const twitterBroadcastRegex = /https:\/\/twitter\.com\/i\/broadcasts\/([A-Za-z0-9_-]+)/


### PR DESCRIPTION
## Summary
- Fixes YouTube `/live/` URLs being classified as YouTube channels
- Excludes the `/live/` path from `youtubeChannelPattern`
- Adds a regression test for `https://www.youtube.com/live/tkdMgjEFNWs`

## Why
Issue #643 reports that YouTube live URLs should be treated as single video/link content, not as a YouTube channel. The channel regex was broad enough to match `/live/`, so this PR explicitly excludes that path.

## Test
- Added regression test in `src/components/AddContentModal/utils/__tests__/index.ts`
- Could not run local Jest in this environment because `yarn`/dependencies are not installed, but the change is narrowly scoped and covered by the added test.

Fixes #643
