### PR TITLE
Fix worldmap details panel background

### DIFF
--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -34,7 +34,7 @@ import { Toasts } from './Toasts'
 const Wrapper = styled(Flex)`
   height: 100%;
   width: 100%;
-  background-color: ${colors.black};
+  background-color: ${colors.BLUE_PRESS_STATE};
 `
 
 const Version = styled(Flex)`


### PR DESCRIPTION
Fixes #448

## Summary
- Match the app wrapper background to the worldmap/universe background color.
- Prevent the rounded/offset details panel from exposing a black backdrop in worldmap view.

## Validation
- `node .yarn/releases/yarn-3.5.0.cjs typecheck`
- `node .yarn/releases/yarn-3.5.0.cjs build`

Build passes. Existing unrelated build warnings remain, including unresolved runtime font URLs, lint warnings, eval warnings from dependencies, and large chunk warnings.