### PR TITLE
fix: prevent youtube channel regex from matching /live/ URLs

### DIFF
--- a/src/components/AddContentModal/utils/index.ts
+++ b/src/components/AddContentModal/utils/index.ts
@@ -11,7 +11,7 @@ const mp3Regex = /(https?:\/\/)?.*\.mp3/
 const mp4Regex = /(https?:\/\/)?.*\.mp4/
 
 const rssRegex = /(https?:\/\/)?(.*\.)?.+\/(feed|rss|rss\.xml|.*\?(feed|format)=rss)(\/.*)?$/
-const youtubeChannelPattern = /https?:\/\/(www\.)?youtube\.com\/(user\/)?(@)?([\w-]+)/
+const youtubeChannelPattern = /https?:\/\/(www\.)?youtube\.com\/(?!live\/)(user\/)?(@)?([\w-]+)/
 
 const genericUrlRegex = /^(https?|ftp):\/\/[^\s/$.?#].[^\s]*$/
 const twitterBroadcastRegex = /https:\/\/twitter\.com\/i\/broadcasts\/([A-Za-z0-9_-]+)/

--- a/src/components/AddItemModal/utils/index.ts
+++ b/src/components/AddItemModal/utils/index.ts
@@ -9,7 +9,7 @@ const tweetUrlRegex = /https:\/\/twitter\.com\/[^/]+\/status\/(\d+)/
 const mp3Regex = /(https?:\/\/)?([A-Za-z0-9_-]+)\.mp3/
 
 const rssRegex = /(https?:\/\/)?(.*\.)?.+\/(feed|rss|rss.xml|.*.rss|.*\?(feed|format)=rss)$/
-const youtubeChannelPattern = /https?:\/\/(www\.)?youtube\.com\/(user\/)?(@)?([\w-]+)/
+const youtubeChannelPattern = /https?:\/\/(www\.)?youtube\.com\/(?!live\/)(user\/)?(@)?([\w-]+)/
 
 const genericUrlRegex = /^(https?|ftp):\/\/[^\s/$.?#].[^\s]*$/
 const twitterBroadcastRegex = /https:\/\/twitter\.com\/i\/broadcasts\/([A-Za-z0-9_-]+)/


### PR DESCRIPTION
## Summary

Fixes #643 - YouTube `/live/` URLs (e.g., `https://youtube.com/live/tkdMgjEFNWs`) are being incorrectly identified as YouTube channels instead of individual video links.

## Root Cause

The `youtubeChannelPattern` regex:
```
/https?:\/\/(www\.)?youtube\.com\/(user\/)?(@)?([\w-]+)/
```

matched `/live/` URLs because the `([\w-]+)` group captured `live` as a channel name. While the `youtubeLiveRegex` in `linkPatterns` is checked first and returns `LINK` correctly, the channel regex would still match `/live/` if evaluated, which is semantically incorrect.

## Fix

Added a negative lookahead `(?!live\/)` to the `youtubeChannelPattern` regex to explicitly exclude `/live/` paths:

```
/https?:\/\/(www\.)?youtube\.com\/(?!live\/)(user\/)?(@)?([\w-]+)/
```

This change was applied to both:
- `src/components/AddContentModal/utils/index.ts`
- `src/components/AddItemModal/utils/index.ts`

## Test Plan

- [x] `https://youtube.com/live/tkdMgjEFNWs` correctly returns `LINK`
- [x] `https://www.youtube.com/live/tkdMgjEFNWs` correctly returns `LINK`
- [x] `https://www.youtube.com/@MrBeast` correctly returns `YOUTUBE_CHANNEL`
- [x] `https://www.youtube.com/user/SomeChannel` correctly returns `YOUTUBE_CHANNEL`
- [x] `https://youtube.com/user/SomeChannel` correctly returns `YOUTUBE_CHANNEL`