### PR TITLE
fix: handle YouTube /live/ and /shorts/ URLs correctly

### DIFF
--- a/src/components/AddContentModal/utils/__tests__/index.ts
+++ b/src/components/AddContentModal/utils/__tests__/index.ts
@@ -72,6 +72,14 @@ describe('youtubeRegex', () => {
     await expect(getInputType('https://www.youtube.com/@MrBeast')).resolves.toBe(YOUTUBE_CHANNEL)
   })
 
+  it('should not match youtube live URL as channel', async () => {
+    await expect(getInputType('https://youtube.com/live/tkdMgjEFNWs')).resolves.toBe(LINK)
+  })
+
+  it('should not match youtube shorts URL as channel', async () => {
+    await expect(getInputType('https://www.youtube.com/shorts/abc123')).resolves.toBe(LINK)
+  })
+
   it('should assert we can check for document regex', async () => {
     await expect(getInputType('some plain text')).resolves.toBe(DOCUMENT)
   })

--- a/src/components/AddContentModal/utils/index.ts
+++ b/src/components/AddContentModal/utils/index.ts
@@ -4,6 +4,7 @@ export const twitterHandlePattern = /\b(?:twitter\.com|x\.com)\/(?:@)?([\w_]+)(?
 
 const youtubeRegex = /(https?:\/\/)?(www\.)?youtube\.com\/watch\?v=([A-Za-z0-9_-]+)/
 const youtubeLiveRegex = /(https?:\/\/)?(www\.)?youtube\.com\/live\/([A-Za-z0-9_-]+)/
+const youtubeShortsRegex = /(https?:\/\/)?(www\.)?youtube\.com\/shorts\/([A-Za-z0-9_-]+)/
 const youtubeShortRegex = /(https?:\/\/)?(www\.)?youtu\.be\/([A-Za-z0-9_-]+)/
 const twitterSpaceRegex = /https:\/\/twitter\.com\/i\/spaces\/([A-Za-z0-9_-]+)/
 const tweetUrlRegex = /https:\/\/(twitter\.com|x\.com)\/[^/]+\/status\/(\d+)/
@@ -11,7 +12,7 @@ const mp3Regex = /(https?:\/\/)?.*\.mp3/
 const mp4Regex = /(https?:\/\/)?.*\.mp4/
 
 const rssRegex = /(https?:\/\/)?(.*\.)?.+\/(feed|rss|rss\.xml|.*\?(feed|format)=rss)(\/.*)?$/
-const youtubeChannelPattern = /https?:\/\/(www\.)?youtube\.com\/(user\/)?(@)?([\w-]+)/
+const youtubeChannelPattern = /https?:\/\/(www\.)?youtube\.com\/(user\/)?(@)?(?!live\/|watch|shorts\/)([\w-]+)/
 
 const genericUrlRegex = /^(https?|ftp):\/\/[^\s/$.?#].[^\s]*$/
 const twitterBroadcastRegex = /https:\/\/twitter\.com\/i\/broadcasts\/([A-Za-z0-9_-]+)/
@@ -30,6 +31,7 @@ export async function checkIfRSS(url: string): Promise<boolean> {
 export async function getInputType(source: string) {
   const linkPatterns = [
     youtubeLiveRegex,
+    youtubeShortsRegex,
     twitterBroadcastRegex,
     youtubeRegex,
     youtubeShortRegex,


### PR DESCRIPTION
## Problem

YouTube Live URLs like `https://youtube.com/live/tkdMgjEFNWs` were potentially misclassified as YouTube channels because the `youtubeChannelPattern` regex was too greedy — it matched any path segment after `youtube.com/`, including `live`, `shorts`, etc.

Fixes #643

## Changes

1. **Added negative lookahead to `youtubeChannelPattern`** to exclude `/live/`, `/watch`, and `/shorts/` paths from being matched as channels:
   ``regex
   /https?:\/\/(www\.)?youtube\.com\/(user\/)?(@)?(?!live\/|watch|shorts\/)([\w-]+)/
   ``

2. **Added `youtubeShortsRegex`** to properly classify `youtube.com/shorts/<id>` URLs as individual video links:
   ``regex
   /(https?:\/\/)?(www\.)?youtube\.com\/shorts\/([A-Za-z0-9_-]+)/
   ``

3. **Added test cases** for live and shorts URL edge cases.

## Testing

- `https://youtube.com/live/tkdMgjEFNWs` → `LINK` ✅
- `https://www.youtube.com/shorts/abc123` → `LINK` ✅
- `https://www.youtube.com/@MrBeast` → `YOUTUBE_CHANNEL` ✅ (still works correctly)