### PR TITLE
test: add youtube live URL edge cases to prevent channel regression

### DIFF
--- a/src/components/AddContentModal/utils/__tests__/index.ts
+++ b/src/components/AddContentModal/utils/__tests__/index.ts
@@ -12,6 +12,14 @@ describe('youtubeRegex', () => {
     await expect(getInputType('https://youtube.com/live/tkdMgjEFNWs')).resolves.toBe(LINK)
   })
 
+  it('should assert youtube live with www prefix is not treated as channel', async () => {
+    await expect(getInputType('https://www.youtube.com/live/tkdMgjEFNWs')).resolves.toBe(LINK)
+  })
+
+  it('should assert youtube live with query params is treated as link', async () => {
+    await expect(getInputType('https://youtube.com/live/tkdMgjEFNWs?t=120')).resolves.toBe(LINK)
+  })
+
   it('should assert we can check for twitter spaces regex', async () => {
     await expect(getInputType('https://twitter.com/i/spaces/1zqKVqwrVzlxB?s=20')).resolves.toBe(LINK)
   })


### PR DESCRIPTION
## Summary
Closes #643

The `youtubeLiveRegex` was already added to the codebase but was missing test coverage for edge cases that could cause regressions.

### Changes
- Added test for `youtube.com/live/xxx` with `www.` prefix
- Added test for `youtube.com/live/xxx` with query parameters
- These prevent future regressions where `/live/` URLs get misclassified as YouTube channels

### Verified
The regex correctly matches:
- `https://youtube.com/live/tkdMgjEFNWs` ? LINK ?
- `https://www.youtube.com/live/tkdMgjEFNWs` ? LINK ?
- `https://youtube.com/live/tkdMgjEFNWs?t=120` ? LINK ?