### PR TITLE
test: cover latest button selector regression

### DIFF
--- a/src/components/App/SideBar/Latest/__test__/index.tsx
+++ b/src/components/App/SideBar/Latest/__test__/index.tsx
@@ -24,13 +24,18 @@ Object.defineProperty(window, 'matchMedia', {
 })
 
 describe('LatestView Component', () => {
+  const fetchDataMock = jest.fn()
+  const setAbortRequestsMock = jest.fn()
+  const setNodeCountMock = jest.fn()
+  const setBudgetMock = jest.fn()
+
   beforeEach(() => {
     jest.clearAllMocks()
-    mockedUseDataStore.mockReturnValue({ fetchData: jest.fn() })
-    mockedUseUserStore.mockReturnValue({ nodeCount: 0, setNodeCount: jest.fn(), setBudget: jest.fn() })
+    mockedUseDataStore.mockReturnValue({ fetchData: fetchDataMock, setAbortRequests: setAbortRequestsMock })
+    mockedUseUserStore.mockReturnValue({ nodeCount: 0, setNodeCount: setNodeCountMock, setBudget: setBudgetMock })
   })
 
-  test('renders button correctly when new data added', () => {
+  test('renders latest heading and icon', () => {
     const { getByText } = render(<LatestView />)
     const galleryIcon = document.querySelector('.heading__icon') as Node
 
@@ -39,30 +44,28 @@ describe('LatestView Component', () => {
   })
 
   test('does not show the latest button when there are no nodes', () => {
-    mockedUseUserStore.mockReturnValue({ nodeCount: 0, setNodeCount: jest.fn(), setBudget: jest.fn() })
+    const { queryByTestId } = render(<LatestView />)
 
-    const { queryByText } = render(<LatestView />)
+    expect(queryByTestId('see_latest_button')).toBeNull()
+  })
 
-    expect(queryByText('See Latest (0)')).toBeNull()
+  test('shows the latest button when new nodes are available', () => {
+    mockedUseUserStore.mockReturnValue({ nodeCount: 5, setNodeCount: setNodeCountMock, setBudget: setBudgetMock })
+
+    const { getByTestId } = render(<LatestView />)
+
+    expect(getByTestId('see_latest_button')).toHaveTextContent('See Latest (5)')
   })
 
   test('calls latest endpoint with param on button click', async () => {
-    const fetchDataMock = jest.fn()
-
-    mockedUseDataStore.mockReturnValue({ fetchData: fetchDataMock })
-
-    const setNodeCountMock = jest.fn()
-
-    const setBudgetMock = jest.fn()
-
     mockedUseUserStore.mockReturnValue({ nodeCount: 5, setNodeCount: setNodeCountMock, setBudget: setBudgetMock })
 
-    const { getByText } = render(<LatestView />)
+    const { getByTestId } = render(<LatestView />)
 
-    fireEvent.click(getByText('See Latest (5)'))
+    fireEvent.click(getByTestId('see_latest_button'))
 
     await waitFor(() => {
-      expect(fetchDataMock).toHaveBeenCalledWith(setBudgetMock, { skip_cache: 'true' })
+      expect(fetchDataMock).toHaveBeenCalledWith(setBudgetMock, setAbortRequestsMock, '', { skip_cache: 'true' })
       expect(setNodeCountMock).toHaveBeenCalledWith('CLEAR')
     })
   })


### PR DESCRIPTION
Fixes #2527

## Summary
- updates the `LatestView` regression test to assert the stable `data-testid=see_latest_button` selector used by the flaky latest-button flow
- adds explicit coverage that the button renders when `nodeCount > 0`
- updates the click assertion to match the current `fetchData(setBudget, setAbortRequests, '', { skip_cache: 'true' })` call shape

## Verification
- Not run locally: this Codex environment reports 0 bytes free on `C:`, so dependencies/build artifacts cannot be installed or written.
- Remote diff was checked via GitHub compare: 1 commit, 1 test file changed.

## Notes
This is scoped to the stale/flaky latest-button coverage path. The Cypress spec referenced in #2527 no longer exists on `master`, so this preserves the intended selector behavior in the current test suite.