### PR TITLE
fix: prevent blueprint sidebar horizontal overflow

### DIFF
--- a/src/components/App/SideBar/RegularView/index.tsx
+++ b/src/components/App/SideBar/RegularView/index.tsx
@@ -33,11 +33,12 @@ export const RegularView = () => {
   )
 }
 
-const ScrollWrapper = styled(Flex)(() => ({
-  overflow: 'auto',
-  flex: 1,
-  width: '100%',
-}))
+const ScrollWrapper = styled(Flex)`
+  overflow-y: auto;
+  overflow-x: hidden;
+  flex: 1;
+  width: 100%;
+`
 
 const TrendingWrapper = styled(Flex)`
   padding: 0;

--- a/src/components/ModalsContainer/BlueprintModal/Body/AddEdgeNode/Body/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/AddEdgeNode/Body/index.tsx
@@ -158,7 +158,10 @@ export const Body = ({ onCancel, edgeLinkData, setGraphLoading }: Props) => {
 }
 
 const CustomButton = styled(Button)`
-  width: 400px !important;
+  flex: 1 1 auto;
+  min-width: 0 !important;
+  width: auto !important;
+  max-width: 400px !important;
   margin: 0 0 10px auto !important;
 `
 

--- a/src/components/ModalsContainer/BlueprintModal/Body/Editor/ColorPickerPopover/ColorPickerPopoverView/ColorPicker/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Editor/ColorPickerPopover/ColorPickerPopoverView/ColorPicker/index.tsx
@@ -124,14 +124,16 @@ const Wrapper = styled(Flex)`
 
 const TableWrapper = styled(Flex)`
   min-height: 0;
-  overflow: auto;
+  overflow-y: auto;
+  overflow-x: hidden;
   flex: 1;
   width: 100%;
 `
 
 const PickerContainer = styled.div`
   padding: 0 20px;
-  width: 315px;
+  width: 100%;
+  box-sizing: border-box;
 `
 
 const ColorPalette = styled.div`

--- a/src/components/ModalsContainer/BlueprintModal/Body/Editor/ColorPickerPopover/ColorPickerPopoverView/IconPicker/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Editor/ColorPickerPopover/ColorPickerPopoverView/IconPicker/index.tsx
@@ -73,20 +73,22 @@ const Wrapper = styled(Flex)`
 
 const TableWrapper = styled(Flex)`
   min-height: 0;
-  overflow: auto;
+  overflow-y: auto;
+  overflow-x: hidden;
   flex: 1;
   width: 100%;
 `
 
 const PickerContainer = styled.div`
   padding: 0 20px;
-  width: 300px;
+  width: 100%;
+  box-sizing: border-box;
   height: 350px;
-  overflow: auto;
+  overflow-y: auto;
+  overflow-x: hidden;
 `
 
 const IconPaletteWrapper = styled.div`
-  margin-left: 18px;
   margin-bottom: 6px;
 `
 

--- a/src/components/ModalsContainer/BlueprintModal/Body/Editor/ColorPickerPopover/ColorPickerPopoverView/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Editor/ColorPickerPopover/ColorPickerPopoverView/index.tsx
@@ -101,7 +101,10 @@ const TabPanelWrapper = styled(Flex)`
   min-height: 572px;
   padding: 20px 0;
   max-height: 572px;
-  overflow: auto;
+  overflow-y: auto;
+  overflow-x: hidden;
+  width: 100%;
+  box-sizing: border-box;
 
   @media (max-width: 1024px) {
     width: 100%;
@@ -125,6 +128,7 @@ const TabPanelWrapper = styled(Flex)`
 const Wrapper = styled(Flex)`
   min-height: 0;
   flex: 1;
+  width: 100%;
   overflow: hidden;
 
   @media (max-width: 768px) {

--- a/src/components/ModalsContainer/BlueprintModal/Body/Editor/ColorPickerPopover/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Editor/ColorPickerPopover/index.tsx
@@ -31,6 +31,8 @@ const ModalContent = styled.div`
   background: ${colors.BG1};
   width: 300px;
   height: 460px;
+  box-sizing: border-box;
+  overflow: hidden;
   z-index: 1001;
   border-radius: 8px;
   box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3);

--- a/src/components/ModalsContainer/BlueprintModal/Body/Editor/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Editor/index.tsx
@@ -755,7 +755,10 @@ export const Editor = ({
 }
 
 const CustomButton = styled(Button)`
-  width: 400px !important;
+  flex: 1 1 auto;
+  min-width: 0 !important;
+  width: auto !important;
+  max-width: 400px !important;
   margin: 0 auto !important;
 `
 
@@ -868,8 +871,11 @@ const InputIconWrapper = styled(Flex)`
   flex-direction: row;
   position: relative;
   display: flex;
+  width: 100%;
+  min-width: 0;
 `
 
 const InputWrapper = styled(Flex)`
-  width: 320px;
+  flex: 1 1 auto;
+  min-width: 0;
 `

--- a/src/components/ModalsContainer/BlueprintModal/Body/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/index.tsx
@@ -271,7 +271,10 @@ const EditorWrapper = styled(Flex)<EditorWrapperProps>`
 
 const InnerEditorWrapper = styled.div`
   height: 100%;
+  width: 100%;
+  box-sizing: border-box;
   overflow-y: auto;
+  overflow-x: hidden;
   padding: 16px;
   max-height: calc(90vh - 20px);
 


### PR DESCRIPTION
## Summary
- prevent horizontal scrolling in the blueprint create/edit type sidebar by constraining editor content, inputs, and action buttons to the available width
- keep the blueprint color/icon popover content inside its 300px panel by removing fixed inner widths and hiding accidental x-overflow
- change the main create/edit sidebar scroll container to vertical-only scrolling

Fixes #2315.

## Testing
- `corepack yarn install --immutable` (first attempt hit `EADDRNOTAVAIL`; retry with `YARN_NETWORK_CONCURRENCY=4` completed with existing peer dependency warnings)
- `corepack yarn prettier:check`
- `corepack yarn typecheck`
- `git diff --check`
- `corepack yarn build` (passes; existing lint/chunk-size warnings only)
