### PR TITLE
fix: hide youtube media player labels

### DIFF
--- a/src/components/App/SideBar/SidebarSubView/MediaPlayer/index.tsx
+++ b/src/components/App/SideBar/SidebarSubView/MediaPlayer/index.tsx
@@ -17,6 +17,8 @@ type FullScreenProps = {
   isFullScreen: boolean
 }
 
+const isYouTubeUrl = (url?: string) => !!url && /(?:youtube\.com|youtu\.be)/i.test(url)
+
 const MediaPlayerComponent: FC<Props> = ({ hidden }) => {
   const playerRef = useRef<ReactPlayer | null>(null)
   const wrapperRef = useRef<HTMLDivElement | null>(null)
@@ -59,7 +61,7 @@ const MediaPlayerComponent: FC<Props> = ({ hidden }) => {
   const mediaUrl =
     playingNode?.media_url || playingNode?.link || playingNode?.properties?.link || playingNode?.properties?.media_url
 
-  const isYouTubeVideo = mediaUrl?.includes('youtube') || mediaUrl?.includes('youtu.be')
+  const isYouTubeVideo = isYouTubeUrl(mediaUrl)
 
   useEffect(() => () => resetPlayer(), [resetPlayer])
 
@@ -241,6 +243,7 @@ const MediaPlayerComponent: FC<Props> = ({ hidden }) => {
           volume={volume}
           width="100%"
         />
+        {isYouTubeVideo && <YouTubeChromeMask isFullScreen={isFullScreen} />}
       </PlayerWrapper>
       {status === 'error' ? (
         <ErrorWrapper className="error-wrapper">Error happened, please try later</ErrorWrapper>
@@ -306,6 +309,34 @@ const PlayerWrapper = styled.div<{ isFullScreen: boolean }>`
   margin: ${(props) => (props.isFullScreen ? '80px auto' : '0')};
   width: 100%;
   cursor: pointer;
+  position: relative;
+  overflow: hidden;
+`
+
+const YouTubeChromeMask = styled.div<FullScreenProps>`
+  pointer-events: none;
+
+  &::before,
+  &::after {
+    content: '';
+    position: absolute;
+    z-index: 2;
+    background: ${colors.black};
+  }
+
+  &::before {
+    top: 0;
+    left: 0;
+    right: 0;
+    height: ${(props) => (props.isFullScreen ? '72px' : '52px')};
+  }
+
+  &::after {
+    right: 0;
+    bottom: 0;
+    width: ${(props) => (props.isFullScreen ? '190px' : '148px')};
+    height: ${(props) => (props.isFullScreen ? '68px' : '52px')};
+  }
 `
 
 export const MediaPlayer = memo(MediaPlayerComponent)

--- a/src/components/mindset/components/MediaPlayer/index.tsx
+++ b/src/components/mindset/components/MediaPlayer/index.tsx
@@ -14,6 +14,7 @@ import { colors } from '~/utils'
 import { secondsToMediaTime } from '~/utils/secondsToMediaTime'
 
 const isVideoFile = (url: string) => /\.(mp4|webm|mov|mkv|avi)(\?.*)?$/i.test(url)
+const isYouTubeUrl = (url?: string) => !!url && /(?:youtube\.com|youtu\.be)/i.test(url)
 
 const findCurrentEdge = (sortedEdges: Link[], playerProgress: number): Link | null => {
   let low = 0
@@ -75,6 +76,7 @@ const MediaPlayerComponent = ({ mediaUrl }: Props) => {
   } = usePlayerStore((s) => s)
 
   const duration = playerRef?.getDuration() || 0
+  const isYouTubeVideo = isYouTubeUrl(mediaUrl)
 
   useEffect(() => () => resetPlayer(), [resetPlayer])
 
@@ -210,6 +212,7 @@ const MediaPlayerComponent = ({ mediaUrl }: Props) => {
           volume={volume}
           width="100%"
         />
+        {isYouTubeVideo && <YouTubeChromeMask isFullScreen={isFullScreen} />}
         <Overlay className="time-overlay" isFullScreen={isFullScreen}>
           <TimeDisplay>
             {secondsToMediaTime(playingTime)} / {secondsToMediaTime(duration)}
@@ -263,6 +266,7 @@ const PlayerWrapper = styled.div<{ isFullScreen: boolean }>`
   justify-content: center;
   z-index: 10;
   position: relative;
+  overflow: hidden;
 
   ${(props) =>
     props.isFullScreen &&
@@ -281,6 +285,32 @@ const PlayerWrapper = styled.div<{ isFullScreen: boolean }>`
 
   &:hover .time-overlay {
     opacity: 1;
+  }
+`
+
+const YouTubeChromeMask = styled.div<FullScreenProps>`
+  pointer-events: none;
+
+  &::before,
+  &::after {
+    content: '';
+    position: absolute;
+    z-index: 20;
+    background: ${colors.black};
+  }
+
+  &::before {
+    top: 0;
+    left: 0;
+    right: 0;
+    height: ${(props) => (props.isFullScreen ? '72px' : '52px')};
+  }
+
+  &::after {
+    right: 0;
+    bottom: 0;
+    width: ${(props) => (props.isFullScreen ? '190px' : '148px')};
+    height: ${(props) => (props.isFullScreen ? '68px' : '52px')};
   }
 `
 


### PR DESCRIPTION
## Summary
- hide YouTube iframe title/branding chrome in the sidebar media player
- apply the same YouTube-only chrome mask to the Graph Mindset media player
- keep the mask non-interactive so app-level play/pause and toolbar controls remain usable

Fixes #2517.

## Testing
- `corepack yarn prettier:check`
- `corepack yarn typecheck`
- `git diff --check`
- `corepack yarn build` (passes; existing lint/chunk-size warnings only)
