### PR TITLE
Fix Chrome scrubber seek indicator before playback

### DIFF
--- a/src/components/mindset/components/PlayerContols/index.tsx
+++ b/src/components/mindset/components/PlayerContols/index.tsx
@@ -22,6 +22,8 @@ export const PlayerControl = ({ markers, chapters }: Props) => {
     (_: Event, value: number | number[]) => {
       const newValue = Array.isArray(value) ? value[0] : value
 
+      setCurrentTime(newValue)
+
       if (playerRef) {
         playerRef.seekTo(newValue, 'seconds')
       }


### PR DESCRIPTION
Fixes #2612.

## Summary
- update the local scrubber time immediately when the progress slider changes
- keep the existing `seekTo` call so playback starts from the selected timestamp

## Verification
- `corepack yarn prettier:check`
- `corepack yarn typecheck`
- `git diff --check`
- `corepack yarn build` (passes with existing repo warnings)
