### PR TITLE
Show no results state for empty filter results

### DIFF
--- a/src/components/App/SideBar/RegularView/index.tsx
+++ b/src/components/App/SideBar/RegularView/index.tsx
@@ -1,8 +1,9 @@
 import { useRef } from 'react'
+import { isEqual } from 'lodash'
 import styled from 'styled-components'
 import { Flex } from '~/components/common/Flex'
 import { useAppStore } from '~/stores/useAppStore'
-import { useDataStore } from '~/stores/useDataStore'
+import { defaultFilters, useDataStore } from '~/stores/useDataStore'
 import { useFeatureFlagStore } from '~/stores/useFeatureFlagStore'
 import { LatestView } from '../Latest'
 import { Relevance } from '../Relevance'
@@ -12,22 +13,23 @@ import { Trending } from '../Trending'
 export const MENU_WIDTH = 390
 
 export const RegularView = () => {
-  const { isFetching: isLoading } = useDataStore((s) => s)
+  const { filters, isFetching: isLoading } = useDataStore((s) => s)
 
   const { currentSearch: searchTerm } = useAppStore((s) => s)
 
   const [trendingTopicsFeatureFlag] = useFeatureFlagStore((s) => [s.trendingTopicsFeatureFlag])
 
   const componentRef = useRef<HTMLDivElement | null>(null)
+  const hasActiveFilters = !isEqual(filters, defaultFilters)
 
   return (
     <ScrollWrapper ref={componentRef}>
-      {!searchTerm && trendingTopicsFeatureFlag && (
+      {!searchTerm && !hasActiveFilters && trendingTopicsFeatureFlag && (
         <TrendingWrapper>
           <Trending />
         </TrendingWrapper>
       )}
-      {!searchTerm && <LatestView />}
+      {!searchTerm && !hasActiveFilters && <LatestView />}
       {isLoading ? <EpisodeSkeleton /> : <Relevance isSearchResult={!!searchTerm} />}
     </ScrollWrapper>
   )

--- a/src/components/App/SideBar/Relevance/__tests__/index.tsx
+++ b/src/components/App/SideBar/Relevance/__tests__/index.tsx
@@ -44,6 +44,17 @@ jest.mock('@mui/material', () => ({
 }))
 
 jest.mock('~/stores/useDataStore', () => ({
+  defaultFilters: {
+    skip: 0,
+    limit: 100,
+    depth: '3',
+    sort_by: 'score',
+    include_properties: 'true',
+    top_node_count: '40',
+    includeContent: 'true',
+    node_type: [],
+    search_method: 'hybrid',
+  },
   useDataStore: jest.fn(),
   useFilteredNodes: jest.fn(),
 }))
@@ -62,6 +73,22 @@ const mockedUseDataStore = useDataStore as jest.MockedFunction<typeof useDataSto
 const mockedUseAppStore = useAppStore as jest.MockedFunction<typeof useAppStore>
 
 const mockedUseFilterNodes = useFilteredNodes as jest.MockedFunction<typeof useFilteredNodes>
+const createStoreState = () => ({
+  dataInitial: { nodes: mockedFilterNodes, links: [] },
+  filters: {
+    skip: 0,
+    limit: 100,
+    depth: '3',
+    sort_by: 'score',
+    include_properties: 'true',
+    top_node_count: '40',
+    includeContent: 'true',
+    node_type: [],
+    search_method: 'hybrid',
+  },
+  nextPage: jest.fn(),
+  setSelectedTimestamp: jest.fn(),
+})
 // const mockedSaveConsumedContent = jest.spyOn(relayHelper, 'saveConsumedContent')
 // const mockedUseIsMatchBreakpoint = jest.spyOn(utils, 'useIsMatchBreakpoint')
 
@@ -75,7 +102,7 @@ describe('test Relevance Component', () => {
       setRelevanceSelected: jest.fn(),
     }))
 
-    mockedUseDataStore.mockImplementation(() => [false, jest.fn().mockImplementation((relevance) => relevance)])
+    mockedUseDataStore.mockImplementation((selector) => selector(createStoreState()))
   })
 
   const renderWithRouter = (component: React.ReactElement) => {
@@ -109,6 +136,22 @@ describe('test Relevance Component', () => {
     const { getByText } = renderWithRouter(<Relevance isSearchResult={false} />)
 
     expect(getByText('Load More')).toBeInTheDocument()
+  })
+
+  it('renders no results state for empty filter results', () => {
+    mockedUseFilterNodes.mockReturnValue([])
+    mockedUseDataStore.mockImplementation((selector) =>
+      selector({
+        ...createStoreState(),
+        dataInitial: { nodes: [], links: [] },
+        filters: { ...createStoreState().filters, node_type: ['Bounty'] },
+      }),
+    )
+
+    const { getByTestId, getByText } = renderWithRouter(<Relevance isSearchResult={false} />)
+
+    expect(getByTestId('no-filter-results')).toBeInTheDocument()
+    expect(getByText('No Results')).toBeInTheDocument()
   })
 
   it.skip('asserts that 10 nodes are initial rendered', () => {

--- a/src/components/App/SideBar/Relevance/index.tsx
+++ b/src/components/App/SideBar/Relevance/index.tsx
@@ -1,11 +1,14 @@
 import { Button } from '@mui/material'
+import { isEqual } from 'lodash'
 import { memo, useCallback, useMemo, useState } from 'react'
 import styled from 'styled-components'
+import NoFilterResultIcon from '~/components/Icons/NoFilterResultIcon'
 import { Flex } from '~/components/common/Flex'
 import { useNodeNavigation } from '~/components/Universe/useNodeNavigation'
 import { useAppStore } from '~/stores/useAppStore'
-import { useDataStore, useFilteredNodes } from '~/stores/useDataStore'
+import { defaultFilters, useDataStore, useFilteredNodes } from '~/stores/useDataStore'
 import { NodeExtended } from '~/types'
+import { colors } from '~/utils/colors'
 import { formatDescription } from '~/utils/formatDescription'
 import { saveConsumedContent } from '~/utils/relayHelper'
 import { adaptTweetNode } from '~/utils/twitterAdapter'
@@ -20,7 +23,7 @@ type Props = {
 const _Relevance = ({ isSearchResult }: Props) => {
   const pageSize = !isSearchResult ? 10 : 80
 
-  const { setSelectedTimestamp, nextPage } = useDataStore((s) => s)
+  const { dataInitial, filters, setSelectedTimestamp, nextPage } = useDataStore((s) => s)
   const { navigateToNode } = useNodeNavigation()
 
   const { currentSearch, setSidebarOpen, setRelevanceSelected } = useAppStore((s) => s)
@@ -76,8 +79,21 @@ const _Relevance = ({ isSearchResult }: Props) => {
     return []
   }, [filteredNodes, currentSearch, endSlice])
 
+  const hasActiveFilters = !isEqual(filters, defaultFilters)
+  const shouldShowNoResults = (isSearchResult || hasActiveFilters) && dataInitial?.nodes.length === 0
+
   return (
     <>
+      {shouldShowNoResults && (
+        <NoResultsWrapper data-testid="no-filter-results">
+          <NoResultsIconWrapper>
+            <NoFilterResultIcon />
+          </NoResultsIconWrapper>
+          <NoResultsTitle>No Results</NoResultsTitle>
+          <NoResultsDescription>Try changing your search or filter criteria.</NoResultsDescription>
+        </NoResultsWrapper>
+      )}
+
       {(currentNodes ?? []).map((n) => {
         const adaptedNode = adaptTweetNode(n)
 
@@ -130,4 +146,50 @@ export const Relevance = memo(_Relevance)
 
 const LoadMoreWrapper = styled(Flex)`
   flex: 0 0 86px;
+`
+
+const NoResultsWrapper = styled(Flex).attrs({
+  align: 'center',
+  direction: 'column',
+  justify: 'center',
+})`
+  flex: 1 0 auto;
+  min-height: 220px;
+  padding: 42px 32px;
+  text-align: center;
+`
+
+const NoResultsIconWrapper = styled(Flex).attrs({
+  align: 'center',
+  justify: 'center',
+})`
+  width: 48px;
+  height: 48px;
+  margin-bottom: 16px;
+  border-radius: 50%;
+  background: ${colors.BUTTON1};
+  color: ${colors.GRAY6};
+
+  svg {
+    width: 24px;
+    height: 24px;
+  }
+`
+
+const NoResultsTitle = styled.div`
+  color: ${colors.white};
+  font-family: Barlow;
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 20px;
+`
+
+const NoResultsDescription = styled.div`
+  max-width: 240px;
+  margin-top: 8px;
+  color: ${colors.GRAY6};
+  font-family: Barlow;
+  font-size: 13px;
+  font-weight: 400;
+  line-height: 18px;
 `

--- a/src/stores/useDataStore/index.ts
+++ b/src/stores/useDataStore/index.ts
@@ -245,6 +245,19 @@ export const useDataStore = create<DataStore>()(
       const nodesFilteredByFilters = data.nodes
       const newNodes: Node[] = []
 
+      if (!existingData && nodesFilteredByFilters.length === 0) {
+        set({
+          dataInitial: { nodes: [], links: [] },
+          dataNew: { nodes: [], links: [] },
+          nodeTypes: [],
+          linkTypes: [],
+          sidebarFilters: ['all'],
+          sidebarFilterCounts: [{ name: 'all', count: 0 }],
+        })
+
+        return
+      }
+
       nodesFilteredByFilters.forEach((node) => {
         if (!normalizedNodesMap.has(node.ref_id)) {
           normalizedNodesMap.set(node.ref_id, { ...node, sources: [], targets: [] })


### PR DESCRIPTION
Fixes #2402.

## Summary
- preserve an explicit empty graph result when `/graph/search` returns no nodes
- hide the latest/trending feed while filters are active so empty filter results are not masked
- render a clear sidebar "No Results" state for empty search/filter results
- add focused coverage for the empty filter result state

## Verification
- `corepack yarn prettier:check`
- `corepack yarn typecheck`
- `git diff --check`
- `corepack yarn jest src/components/App/SideBar/Relevance/__tests__/index.tsx --runInBand --no-cache --coverage=false`
- `corepack yarn build` (passes with existing repo warnings)
