### PR TITLE
Fix latest count for realtime node updates

### DIFF
--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -112,6 +112,10 @@ export const App = () => {
         return
       }
 
+      if (data.nodes?.length) {
+        setNodeCount('INCREMENT')
+      }
+
       if (!queueRef.current) {
         queueRef.current = { nodes: [], edges: [] }
       }
@@ -140,7 +144,7 @@ export const App = () => {
         }
       }, 3000) // Adjust delay as necessary
     },
-    [addNewNode, isFetching],
+    [addNewNode, isFetching, setNodeCount],
   )
 
   const handleNodeUpdated = useCallback((data: FetchDataResponse) => {
@@ -204,7 +208,9 @@ export const App = () => {
         console.error('Socket connection error:', error)
       })
 
-      socket.on('newnode', handleNewNode)
+      if (!realtimeGraphFeatureFlag) {
+        socket.on('newnode', handleNewNode)
+      }
 
       if (chatInterfaceFeatureFlag) {
         socket.on('extractedentitieshook', handleExtractedEntities)


### PR DESCRIPTION
Fixes #2527.

## Summary
- increment the latest-node count when realtime `new_node_created` payloads include nodes
- keep the legacy `newnode` latest-count listener for non-realtime mode only, avoiding double-counts when realtime graph updates are enabled
- preserve existing realtime graph queuing behavior

## Verification
- `corepack yarn prettier:check`
- `corepack yarn typecheck`
- `git diff --check`
- `corepack yarn build` (passes with existing repo warnings)

Note: the failing `cypress/e2e/seeLatest/latest.cy.ts` from the issue is not present in current `master`, so I could not rerun that exact Cypress spec locally.
