### PR TITLE
Limit hover card shadow to the bottom edge

### DIFF
--- a/src/components/Universe/CursorTooltip/index.tsx
+++ b/src/components/Universe/CursorTooltip/index.tsx
@@ -71,5 +71,5 @@ const TooltipContainer = styled(Flex)`
   overflow: hidden;
   text-overflow: ellipsis;
   display: none;
-  box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 8px 0 rgba(0, 0, 0, 0.3);
 `


### PR DESCRIPTION
Fixes #2546.

## Summary
- change the cursor hover-card wrapper from an all-around blurred shadow to a bottom-only shadow
- preserve the existing hover-card surface and bottom accent while removing the visible top/side frame around the card

## Verification
- `corepack yarn prettier:check`
- `corepack yarn typecheck`
- `git diff --check`
- `corepack yarn build` (passes with existing repo warnings)
