### PR TITLE
Add edge type filters to graph search

### DIFF
--- a/src/components/App/SideBar/FilterSearch/EdgeTypes/index.tsx
+++ b/src/components/App/SideBar/FilterSearch/EdgeTypes/index.tsx
@@ -1,0 +1,160 @@
+import { useState } from 'react'
+import styled from 'styled-components'
+import { Flex } from '~/components/common/Flex'
+import PlusIcon from '~/components/Icons/PlusIcon'
+import { SchemaLink } from '~/network/fetchSourcesData'
+import { colors } from '~/utils'
+import { PopoverBody } from '..'
+
+type Props = {
+  edgeTypes: SchemaLink[]
+  handleEdgeTypeClick: (type: string) => void
+  selectedEdgeTypes: string[]
+}
+
+export const EdgeTypes = ({ edgeTypes, handleEdgeTypeClick, selectedEdgeTypes }: Props) => {
+  const [showAllEdges, setShowAllEdges] = useState(false)
+
+  const edgesPerRow = 3
+  const MAX_ROWS = 4
+  const maxVisibleEdges = edgesPerRow * MAX_ROWS
+
+  const uniqueEdgeTypes = edgeTypes
+    .map((edge) => edge.edge_type)
+    .filter((type) => type && type !== 'CHILD_OF')
+    .filter((type, index, self) => index === self.findIndex((item) => item === type))
+
+  const visibleEdgeTypes = showAllEdges ? uniqueEdgeTypes : uniqueEdgeTypes.slice(0, maxVisibleEdges)
+
+  return (
+    <>
+      <PopoverHeader>
+        <div>Edges</div>
+        <CountSelectedWrapper>
+          <Count>{selectedEdgeTypes.length}</Count>
+          <SelectedText>Selected</SelectedText>
+        </CountSelectedWrapper>
+      </PopoverHeader>
+      <PopoverBody>
+        <SchemaTypeWrapper>
+          {visibleEdgeTypes.map((type) => (
+            <SchemaType
+              key={type}
+              isSelected={selectedEdgeTypes.includes(type)}
+              onClick={() => handleEdgeTypeClick(type)}
+            >
+              {type}
+            </SchemaType>
+          ))}
+        </SchemaTypeWrapper>
+        {!showAllEdges && uniqueEdgeTypes.length > maxVisibleEdges && (
+          <ViewMoreButton onClick={() => setShowAllEdges(true)}>
+            <PlusIconWrapper>
+              <PlusIcon /> View More
+            </PlusIconWrapper>
+          </ViewMoreButton>
+        )}
+      </PopoverBody>
+    </>
+  )
+}
+
+const PopoverHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-bottom: 8px;
+  font-family: Barlow;
+  font-size: 18px;
+  font-weight: 500;
+`
+
+const CountSelectedWrapper = styled.div`
+  font-size: 13px;
+  display: flex;
+  align-items: center;
+`
+
+const Count = styled.span`
+  color: ${colors.white};
+`
+
+const SelectedText = styled.span`
+  color: ${colors.GRAY3};
+  margin-left: 4px;
+`
+
+const PlusIconWrapper = styled.span`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 6px;
+
+  svg {
+    width: 23px;
+    height: 23px;
+    fill: none;
+    margin-top: 2px;
+  }
+`
+
+const SchemaTypeWrapper = styled(Flex).attrs({
+  align: 'center',
+  direction: 'row',
+  grow: 1,
+  justify: 'flex-start',
+})`
+  flex-wrap: wrap;
+  gap: 10px;
+  padding-right: 10px;
+  margin-right: calc(0px - 16px);
+`
+
+const SchemaType = styled(Flex).attrs({
+  align: 'center',
+  direction: 'row',
+  justify: 'flex-start',
+})<{ isSelected: boolean }>`
+  color: ${({ isSelected }) => (isSelected ? colors.black : colors.white)};
+  background: ${({ isSelected }) => (isSelected ? colors.white : colors.BUTTON1_PRESS)};
+  padding: 6px 10px 6px 8px;
+  font-family: Barlow;
+  font-size: 13px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 15px;
+  letter-spacing: 0.78px;
+  margin: 0 3px;
+  border-radius: 200px;
+  cursor: pointer;
+
+  &:hover {
+    background: ${({ isSelected }) => (isSelected ? colors.white : colors.BUTTON1_PRESS)};
+  }
+
+  &:active {
+    background: ${colors.white};
+    color: ${colors.black};
+  }
+`
+
+const ViewMoreButton = styled.button`
+  background: transparent;
+  color: ${colors.white};
+  border: none;
+  padding: 6px 12px 6px 3px;
+  margin-top: 20px;
+  cursor: pointer;
+  border-radius: 4px;
+  font-family: Barlow;
+  font-size: 13px;
+  font-weight: 500;
+
+  &:hover {
+    background: ${colors.BUTTON1_HOVER};
+  }
+
+  &:active {
+    background: ${colors.BUTTON1_PRESS};
+  }
+`

--- a/src/components/App/SideBar/FilterSearch/__tests__/index.tsx
+++ b/src/components/App/SideBar/FilterSearch/__tests__/index.tsx
@@ -39,7 +39,12 @@ jest.mock('~/stores/useSchemaStore', () => ({
 
 describe('FilterSearch Component', () => {
   const mockSetSchemas = jest.fn()
+  const mockSetSchemaLinks = jest.fn()
   const mockSchemaAll = [{ type: 'Type1' }, { type: 'Type2' }, { type: 'Type3' }]
+  const mockSchemaLinks = [
+    { edge_type: 'HAS', ref_id: 'edge-1', source: 'Type1', target: 'Type2' },
+    { edge_type: 'SOURCE', ref_id: 'edge-2', source: 'Type2', target: 'Type3' },
+  ]
 
   beforeEach(() => {
     jest.clearAllMocks()
@@ -53,13 +58,13 @@ describe('FilterSearch Component', () => {
     })
 
     //
-    ;(useSchemaStore as jest.Mock).mockReturnValue([mockSchemaAll, mockSetSchemas]) // Return an array
+    ;(useSchemaStore as jest.Mock).mockReturnValue([mockSchemaAll, mockSchemaLinks, mockSetSchemas, mockSetSchemaLinks]) // Return an array
 
     //
     ;(useFeatureFlagStore as jest.Mock).mockReturnValue({ fastFiltersFeatureFlag: true })
 
     //
-    ;(getSchemaAll as jest.Mock).mockResolvedValue({ schemas: mockSchemaAll })
+    ;(getSchemaAll as jest.Mock).mockResolvedValue({ edges: mockSchemaLinks, schemas: mockSchemaAll })
   })
 
   const renderComponent = () =>
@@ -106,6 +111,26 @@ describe('FilterSearch Component', () => {
     await waitFor(() => {
       expect(mockSetFilters).toHaveBeenCalledWith({
         node_type: ['Type1'],
+        edge_type: [],
+        limit: 1000,
+        depth: '3',
+        top_node_count: '10',
+      })
+    })
+  })
+
+  it('should apply selected edge filters', async () => {
+    renderComponent()
+
+    const edgePill = await screen.findByText('HAS')
+
+    fireEvent.click(edgePill)
+    fireEvent.click(screen.getByText('Apply'))
+
+    await waitFor(() => {
+      expect(mockSetFilters).toHaveBeenCalledWith({
+        node_type: [],
+        edge_type: ['HAS'],
         limit: 1000,
         depth: '3',
         top_node_count: '10',

--- a/src/components/App/SideBar/FilterSearch/index.tsx
+++ b/src/components/App/SideBar/FilterSearch/index.tsx
@@ -9,6 +9,7 @@ import { useFeatureFlagStore } from '~/stores/useFeatureFlagStore'
 import { useSchemaStore } from '~/stores/useSchemaStore'
 import { colors } from '~/utils/colors'
 import { FastFilters } from './FastFilters'
+import { EdgeTypes } from './EdgeTypes'
 import { Hops } from './Hops'
 import { MaxResults } from './MaxResults'
 import { NodeTypes } from './NodeTypes'
@@ -25,12 +26,20 @@ const defaultValues = {
   hops: 3,
   sourceNodes: 10,
   maxResults: 1000,
+  selectedEdgeTypes: [] as string[],
 }
 
 export const FilterSearch = ({ anchorEl, setAnchorEl, onClose }: Props) => {
-  const [schemaAll, setSchemaAll] = useSchemaStore((s) => [s.schemas, s.setSchemas])
+  const [schemaAll, schemaLinks, setSchemaAll, setSchemaLinks] = useSchemaStore((s) => [
+    s.schemas,
+    s.links,
+    s.setSchemas,
+    s.setSchemaLinks,
+  ])
+
   const { abortFetchData, resetGraph, setFilters, resetData } = useDataStore((s) => s)
   const [selectedTypes, setSelectedTypes] = useState<string[]>(defaultValues.selectedTypes)
+  const [selectedEdgeTypes, setSelectedEdgeTypes] = useState<string[]>(defaultValues.selectedEdgeTypes)
   const [hops, setHops] = useState(defaultValues.hops)
   const [sourceNodes, setSourceNodes] = useState<number>(defaultValues.sourceNodes)
   const [maxResults, setMaxResults] = useState<number>(defaultValues.maxResults)
@@ -42,13 +51,14 @@ export const FilterSearch = ({ anchorEl, setAnchorEl, onClose }: Props) => {
         const response = await getSchemaAll()
 
         setSchemaAll(response.schemas.filter((schema) => !schema.is_deleted))
+        setSchemaLinks(response.edges)
       } catch (error) {
         console.error('Error fetching schema:', error)
       }
     }
 
     fetchSchemaData()
-  }, [setSchemaAll])
+  }, [setSchemaAll, setSchemaLinks])
 
   const handleSchemaTypeClick = (type: string) => {
     setSelectedTypes((prevSelectedTypes) =>
@@ -60,8 +70,15 @@ export const FilterSearch = ({ anchorEl, setAnchorEl, onClose }: Props) => {
     setSelectedTypes(types)
   }
 
+  const handleEdgeTypeClick = (type: string) => {
+    setSelectedEdgeTypes((prevSelectedTypes) =>
+      prevSelectedTypes.includes(type) ? prevSelectedTypes.filter((t) => t !== type) : [...prevSelectedTypes, type],
+    )
+  }
+
   const resetToDefaultValues = () => {
     setSelectedTypes(defaultValues.selectedTypes)
+    setSelectedEdgeTypes(defaultValues.selectedEdgeTypes)
     setHops(defaultValues.hops)
     setSourceNodes(defaultValues.sourceNodes)
     setMaxResults(defaultValues.maxResults)
@@ -76,6 +93,7 @@ export const FilterSearch = ({ anchorEl, setAnchorEl, onClose }: Props) => {
   const handleFiltersApply = async () => {
     setFilters({
       node_type: selectedTypes,
+      edge_type: selectedEdgeTypes,
       limit: maxResults,
       depth: hops.toString(),
       top_node_count: sourceNodes.toString(),
@@ -110,6 +128,12 @@ export const FilterSearch = ({ anchorEl, setAnchorEl, onClose }: Props) => {
       )}
 
       <NodeTypes handleSchemaTypeClick={handleSchemaTypeClick} schemaAll={schemaAll} selectedTypes={selectedTypes} />
+      <LineBar />
+      <EdgeTypes
+        edgeTypes={schemaLinks}
+        handleEdgeTypeClick={handleEdgeTypeClick}
+        selectedEdgeTypes={selectedEdgeTypes}
+      />
       <LineBar />
       <SourceNodes setSourceNodes={setSourceNodes} sourceNodes={sourceNodes} />
       <LineBar />

--- a/src/stores/useAiSummaryStore/index.ts
+++ b/src/stores/useAiSummaryStore/index.ts
@@ -102,17 +102,18 @@ export const useAiSummaryStore = create<AiSummaryStore>()(
 
       abortController = controller
 
-      const { node_type: filterNodeTypes, ...withoutNodeType } = filters
+      const { edge_type: filterEdgeTypes, node_type: filterNodeTypes, ...withoutTypeFilters } = filters
       const word = fullAiSearchQuery || currentSearch
 
       const isLatest = isEqual(filters, defaultFilters) && !word
 
       const updatedParams = {
-        ...withoutNodeType,
+        ...withoutTypeFilters,
         ...ai,
         skip: currentPage === 0 ? String(currentPage * itemsPerPage) : String(currentPage * itemsPerPage + 1),
         limit: word ? '25' : String(itemsPerPage),
         ...(filterNodeTypes.length > 0 ? { node_type: JSON.stringify(filterNodeTypes) } : {}),
+        ...(filterEdgeTypes.length > 0 ? { edge_type: JSON.stringify(filterEdgeTypes) } : {}),
         ...(word ? { word } : {}),
         ...(aiRefId && AISearchQuery ? { previous_search_ref_id: aiRefId } : {}),
         ...(!word && !AISearchQuery ? { sort_by: 'date_added_to_graph' } : {}),

--- a/src/stores/useDataStore/index.ts
+++ b/src/stores/useDataStore/index.ts
@@ -28,6 +28,7 @@ export const defaultFilters = {
   top_node_count: '40',
   includeContent: 'true',
   node_type: [],
+  edge_type: [],
   search_method: 'hybrid',
 }
 
@@ -188,18 +189,19 @@ export const useDataStore = create<DataStore>()(
 
       abortController = controller
 
-      const { node_type: filterNodeTypes, ...withoutNodeType } = filters
+      const { edge_type: filterEdgeTypes, node_type: filterNodeTypes, ...withoutTypeFilters } = filters
       const word = AISearchQuery || currentSearch
 
       const isLatest = isEqual(filters, defaultData.filters) && !word
 
       const updatedParams = {
-        ...withoutNodeType,
+        ...withoutTypeFilters,
         depth: filters.depth || '0',
         ...ai,
         skip: currentPage === 0 ? String(currentPage * itemsPerPage) : String(currentPage * itemsPerPage + 1),
         limit: word ? String(itemsPerPage) : String(itemsPerPage),
         ...(filterNodeTypes.length > 0 ? { node_type: JSON.stringify(filterNodeTypes) } : {}),
+        ...(filterEdgeTypes.length > 0 ? { edge_type: JSON.stringify(filterEdgeTypes) } : {}),
         ...(word ? { word } : {}),
         ...(aiRefId && AISearchQuery ? { previous_search_ref_id: aiRefId } : {}),
         ...(!word && !AISearchQuery ? { sort_by: 'date_added_to_graph' } : {}),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -80,6 +80,7 @@ export type FilterParams = {
   top_node_count: string
   include_properties: string
   node_type: string[]
+  edge_type: string[]
   search_method: string
   free?: string
   word?: string // Add other optional filter properties as needed


### PR DESCRIPTION
Fixes #2444.

## Summary
- add an `Edges` section to the filter popover below `Type`
- load edge schema data from `/schema/all`, de-duplicate edge types, and filter out `CHILD_OF`
- render edge filters with the same pill selection styling and view-more behavior as node types
- serialize selected edges as `edge_type` in graph search requests, including AI summary search path compatibility
- add focused test coverage for applying selected edge filters

## Verification
- `corepack yarn prettier:check`
- `corepack yarn typecheck`
- `git diff --check`
- `corepack yarn jest src/components/App/SideBar/FilterSearch/__tests__/index.tsx --runInBand --no-cache --coverage=false`
- `corepack yarn build` (passes with existing repo warnings)
