### PR TITLE
Add dynamic general node hover tooltip

### DIFF
--- a/src/components/Universe/CursorTooltip/HoverCard/General/index.tsx
+++ b/src/components/Universe/CursorTooltip/HoverCard/General/index.tsx
@@ -15,6 +15,7 @@ export const General = ({ node }: Props) => {
   const { getNodeKeysByType } = useSchemaStore((s) => s)
 
   const keyProperty = getNodeKeysByType(node.node_type) || ''
+  const imageUrl = node?.properties?.image_url
 
   let title = ''
   let description = node?.properties?.description || node.properties?.text || ''
@@ -25,28 +26,28 @@ export const General = ({ node }: Props) => {
     title = ''
     description = node?.properties?.name || ''
   } else if (node?.properties) {
-    title = node.properties[keyProperty] || ''
+    title = node.properties[keyProperty] || node.name || ''
   }
 
   return (
-    <TooltipContainer>
+    <TooltipContainer $hasImage={!!imageUrl}>
       <ContentWrapper>
         <Heading>
-          {node?.properties?.image_url && <Avatar src={node.properties.image_url} />}
+          {imageUrl && <Avatar alt={title || node.node_type} loading="lazy" src={imageUrl} />}
           <TitleWrapper>
             <TypeBadge type={node.node_type} />
 
             {title && <Title>{truncateText(title, 70)}</Title>}
           </TitleWrapper>
         </Heading>
-        {description && <Description>{description}</Description>}
+        {description && <Description>{truncateText(description, 200)}</Description>}
       </ContentWrapper>
     </TooltipContainer>
   )
 }
 
-const TooltipContainer = styled(Flex)`
-  width: fit-content;
+const TooltipContainer = styled(Flex)<{ $hasImage: boolean }>`
+  width: ${({ $hasImage }) => ($hasImage ? '390px' : 'fit-content')};
   background: ${colors.HOVER_CARD_BG};
   flex-direction: column;
   pointer-events: auto;
@@ -54,6 +55,7 @@ const TooltipContainer = styled(Flex)`
   border-radius: 8px;
   overflow: hidden;
   max-width: 390px;
+  min-width: ${({ $hasImage }) => ($hasImage ? '320px' : '220px')};
   border-bottom: 5px solid rgba(0, 0, 0, 0.3);
   padding: 16px 14px;
 `
@@ -66,15 +68,19 @@ const ContentWrapper = styled(Flex)`
 `
 
 export const Avatar = styled.img`
-  width: 32px;
-  height: 32px;
-  border-radius: 50%;
+  width: 72px;
+  height: 72px;
+  border-radius: 6px;
   object-fit: cover;
-  margin-right: 8px;
+  margin-right: 12px;
+  flex-shrink: 0;
+  background: ${colors.BG1};
 `
 
 const Heading = styled(Flex)`
   flex-direction: row;
+  align-items: flex-start;
+  width: 100%;
 `
 
 const TitleWrapper = styled(Flex)`
@@ -106,6 +112,7 @@ const Description = styled(Text)`
   font-weight: 400;
   line-height: 20px;
   margin-top: 16px;
+  max-width: 100%;
   color: ${colors.white};
   opacity: 0.8;
   white-space: normal;

--- a/src/components/Universe/CursorTooltip/index.tsx
+++ b/src/components/Universe/CursorTooltip/index.tsx
@@ -6,11 +6,14 @@ import { HoverCard } from './HoverCard/index'
 
 export const CursorTooltip = () => {
   const tooltipRef = useRef<HTMLDivElement | null>(null)
+  const nodeRef = useRef<ReturnType<typeof useHoveredNode>>(null)
   const node = useHoveredNode()
 
   useEffect(() => {
+    nodeRef.current = node
+
     if (tooltipRef.current) {
-      tooltipRef.current.style.display = node ? 'block' : 'none'
+      tooltipRef.current.dataset.visible = node ? 'true' : 'false'
     }
   }, [node])
 
@@ -25,13 +28,13 @@ export const CursorTooltip = () => {
 
       const target = e.target as Element
 
-      if (target.tagName !== 'CANVAS') {
-        tooltip.style.display = 'none'
+      if (target.tagName !== 'CANVAS' || !nodeRef.current) {
+        tooltip.dataset.visible = 'false'
 
         return
       }
 
-      tooltip.style.display = 'block'
+      tooltip.dataset.visible = 'true'
 
       const tooltipWidth = tooltip.offsetWidth
       const tooltipHeight = tooltip.offsetHeight
@@ -54,7 +57,11 @@ export const CursorTooltip = () => {
     }
   }, [])
 
-  return <TooltipContainer ref={tooltipRef}>{node && <HoverCard node={node} />}</TooltipContainer>
+  return (
+    <TooltipContainer ref={tooltipRef} data-visible={!!node}>
+      {node && <HoverCard node={node} />}
+    </TooltipContainer>
+  )
 }
 
 const TooltipContainer = styled(Flex)`
@@ -70,6 +77,13 @@ const TooltipContainer = styled(Flex)`
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  display: none;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.16s ease, visibility 0.16s ease;
   box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.2);
+
+  &[data-visible='true'] {
+    opacity: 1;
+    visibility: visible;
+  }
 `


### PR DESCRIPTION
## Summary
- update the general node hover card to adapt when `image_url` is present or absent
- show larger lazy-loaded images on the upper left while keeping no-image nodes full-width
- cap descriptions at 200 characters and preserve graceful title/type fallbacks
- replace direct display toggles with opacity/visibility transitions for smooth tooltip appearance/disappearance

Fixes #2735.

## Validation
- `corepack yarn prettier:check`
- `corepack yarn typecheck`
- `git diff --check`
- `corepack yarn build`

Build completed with existing repo warnings for console/constant-condition lint warnings, unresolved Barlow font at runtime, lottie eval warnings, and chunk-size warnings.