### PR TITLE
Fix: extend mindset timeline across bottom

### DIFF
--- a/src/components/mindset/components/PlayerContols/index.tsx
+++ b/src/components/mindset/components/PlayerContols/index.tsx
@@ -45,27 +45,45 @@ export const PlayerControl = ({ markers, chapters }: Props) => {
 
   return showPlayer ? (
     <Wrapper>
-      <Controls />
-      <ProgressBar
-        chapters={chapters}
-        duration={duration}
-        handleProgressChange={handleProgressChange}
-        markers={markers}
-        playingTime={currentTime}
-      />
+      <ControlsRow>
+        <Controls />
+      </ControlsRow>
+      <TimelineRow>
+        <ProgressBar
+          chapters={chapters}
+          duration={duration}
+          handleProgressChange={handleProgressChange}
+          markers={markers}
+          playingTime={currentTime}
+        />
+      </TimelineRow>
     </Wrapper>
   ) : null
 }
 
 const Wrapper = styled(Flex).attrs({
-  direction: 'row',
-  align: 'center',
-  justify: 'space-between',
+  direction: 'column',
+  align: 'stretch',
+  justify: 'center',
 })`
   padding: 20px;
   background: ${colors.BG2};
-  height: 96px;
+  min-height: 120px;
   border-radius: 8px;
   box-sizing: border-box;
   margin-right: 4px;
+  gap: 14px;
+`
+
+const ControlsRow = styled(Flex).attrs({
+  direction: 'row',
+  align: 'center',
+  justify: 'flex-start',
+})`
+  width: 100%;
+`
+
+const TimelineRow = styled(Flex)`
+  width: 100%;
+  min-height: 24px;
 `

--- a/src/components/mindset/index.tsx
+++ b/src/components/mindset/index.tsx
@@ -306,6 +306,5 @@ const ContentContainer = styled(Flex)`
 `
 
 const PlayerControlWrapper = styled(Flex)`
-  padding: 16px 16px 16px 0;
-  margin-left: 18px;
+  padding: 16px 16px 16px 20px;
 `


### PR DESCRIPTION
## Summary
- move the mindset player timeline into its own full-width row beneath the controls
- let the bottom player wrapper start from the left-side padding so the timeline extends below the transcript/sidebar area
- keep the existing ProgressBar component, seek handler, markers, and chapter behavior intact

## Validation
- `corepack yarn prettier:check`
- `corepack yarn typecheck`
- `git diff --check`
- `corepack yarn build`