### PR TITLE
Fix: pluralize stats tooltip labels

### DIFF
--- a/src/components/Stats/__tests__/index.tsx
+++ b/src/components/Stats/__tests__/index.tsx
@@ -4,7 +4,7 @@ import { render, screen, waitFor } from '@testing-library/react'
 import React from 'react'
 import { MemoryRouter } from 'react-router-dom'
 import { ProcessingResponse, getTotalProcessing } from '~/network/fetchSourcesData'
-import { Stats } from '..'
+import { Stats, getStatTooltip } from '..'
 import * as network from '../../../network/fetchSourcesData'
 import { useDataStore } from '../../../stores/useDataStore'
 import { useUserStore } from '../../../stores/useUserStore'
@@ -141,5 +141,12 @@ describe('Component Test Stats', () => {
     // The button should be visible since totalProcessing is present and greater than 0
     const button = screen.getByText('100')
     expect(button).toBeInTheDocument()
+  })
+
+  it('pluralizes stat tooltips when the stat count is plural', () => {
+    expect(getStatTooltip('Node', 1)).toBe('Node')
+    expect(getStatTooltip('Node', 5000)).toBe('Nodes')
+    expect(getStatTooltip('Video', '800')).toBe('Videos')
+    expect(getStatTooltip('Document', '1,483')).toBe('Documents')
   })
 })

--- a/src/components/Stats/index.tsx
+++ b/src/components/Stats/index.tsx
@@ -17,6 +17,29 @@ import { colors } from '~/utils/colors'
 import { Flex } from '../common/Flex'
 import { Animation } from './Animation'
 
+const pluralStatLabels: Record<string, string> = {
+  Audio: 'Audio Files',
+  Contributor: 'Contributors',
+  Daily: 'Dailies',
+  Document: 'Documents',
+  Episode: 'Episodes',
+  Node: 'Nodes',
+  Twitter: 'Twitter Spaces',
+  Video: 'Videos',
+}
+
+const normalizeStatValue = (value: number | string) => Number(String(value).replace(/,/g, ''))
+
+export const getStatTooltip = (name: string, value: number | string) => {
+  const count = normalizeStatValue(value)
+
+  if (count === 1) {
+    return name
+  }
+
+  return pluralStatLabels[name] || `${name}s`
+}
+
 export const Stats = () => {
   const [isTotalProcessing, setIsTotalProcessing] = useState(false)
   const [totalProcessing, setTotalProcessing] = useState(0)
@@ -93,7 +116,7 @@ export const Stats = () => {
 
   const generateStatConfigItem = (key: string) => {
     const name = convertToTitleCase(key.split('_')[0])
-    const tooltip = name
+    const tooltip = getStatTooltip(name, stats[key as keyof TStats])
     const primaryIcon = normalizedSchemasByType[name]?.icon
     const Icon = Icons[primaryIcon as string] || NodesIcon
 


### PR DESCRIPTION
## Summary
- add count-aware stats tooltip formatting so singular counts keep singular labels and plural counts use plural labels
- cover explicit plural wording for common stats such as nodes, videos, documents, audio files, and Twitter spaces
- add focused unit coverage for singular and plural tooltip labels, including formatted comma values

## Validation
- `corepack yarn jest src/components/Stats/__tests__/index.tsx --runInBand --no-cache --coverage=false`
- `corepack yarn prettier:check`
- `corepack yarn typecheck`
- `git diff --check`
- `corepack yarn build`

Note: running the focused Jest target without `--coverage=false` executes all assertions successfully but exits nonzero because repo-wide coverage thresholds are enforced against untouched files.