### PR TITLE
Fix: standardize Source Table label casing

### DIFF
--- a/src/components/SourcesTableModal/SourcesView/Sources/Table/__tests__/test.tsx
+++ b/src/components/SourcesTableModal/SourcesView/Sources/Table/__tests__/test.tsx
@@ -60,6 +60,14 @@ describe('Table Component Tests', () => {
     expect(sourceCell).toBeInTheDocument()
   })
 
+  it('should use title case for multi-word source type labels', () => {
+    render(<Table canEdit={false} data={mockData} />)
+
+    expect(screen.getByText('Twitter Handle')).toBeInTheDocument()
+    expect(screen.getByText('Youtube Channel')).toBeInTheDocument()
+    expect(screen.getByText('RSS Link')).toBeInTheDocument()
+  })
+
   it('should display loader when clicking on delete icon', async () => {
     const isEdit = true
 

--- a/src/components/SourcesTableModal/SourcesView/Topics/Table/__tests__/index.spec.tsx
+++ b/src/components/SourcesTableModal/SourcesView/Topics/Table/__tests__/index.spec.tsx
@@ -3,6 +3,7 @@ import '@testing-library/jest-dom'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
+import { useTopicsStore } from '~/stores/useTopicsStore'
 import { TopicTableProps } from '../../../types'
 import { Table } from '../index'
 
@@ -41,7 +42,11 @@ const defaultProps: TopicTableProps = {
   setCheckedStates: mockSetCheckedStates,
 }
 
-const renderTable = (props = defaultProps) => render(<Table {...props} checkedStates={{}} />)
+const renderTable = (props = defaultProps) => {
+  useTopicsStore.setState({ data: mockData, ids: mockIds, total: mockIds.length })
+
+  return render(<Table {...props} checkedStates={{}} />)
+}
 
 describe('Table Component', () => {
   beforeEach(() => {
@@ -65,6 +70,12 @@ describe('Table Component', () => {
       expect(getByTestId('MergeIcon')).toBeInTheDocument()
       expect(getByTestId('AddCircleIcon')).toBeInTheDocument()
     })
+  })
+
+  test('renders title case table labels', () => {
+    renderTable()
+
+    expect(screen.getByText('Edge List')).toBeInTheDocument()
   })
 
   test('on click it opens dropdown', async () => {

--- a/src/components/SourcesTableModal/SourcesView/Topics/Table/index.tsx
+++ b/src/components/SourcesTableModal/SourcesView/Topics/Table/index.tsx
@@ -179,7 +179,7 @@ export const Table: React.FC<TopicTableProps> = ({
                       Count <SortFilterIcon />
                     </SortedIcon>
                   </StyledTableCell>
-                  <StyledTableCell>Edge list</StyledTableCell>
+                  <StyledTableCell>Edge List</StyledTableCell>
                   <StyledTableCell>
                     <SortedIcon onClick={() => handleChange(DATE)}>
                       Date <SortFilterIcon />

--- a/src/components/SourcesTableModal/SourcesView/constants.ts
+++ b/src/components/SourcesTableModal/SourcesView/constants.ts
@@ -4,9 +4,9 @@ import styled from 'styled-components'
 import { IconButton } from '@mui/material'
 
 export const sourcesMapper: ISourceMap = {
-  [RSS]: 'RSS link',
+  [RSS]: 'RSS Link',
   [TWITTER_HANDLE]: 'Twitter Handle',
-  [YOUTUBE_CHANNEL]: 'Youtube channel',
+  [YOUTUBE_CHANNEL]: 'Youtube Channel',
 }
 
 export const SOURCE_TABLE = 'Sources Table'


### PR DESCRIPTION
## Summary
- standardize Source Table multi-word labels to title case
- update source type labels from `RSS link` / `Youtube channel` to `RSS Link` / `Youtube Channel`
- update the Topics table header from `Edge list` to `Edge List`
- add focused assertions for the standardized labels

## Validation
- `corepack yarn jest src/components/SourcesTableModal/SourcesView/Sources/Table/__tests__/test.tsx --runInBand --no-cache --coverage=false`
- `corepack yarn jest src/components/SourcesTableModal/SourcesView/Topics/Table/__tests__/index.spec.tsx --runInBand --no-cache --coverage=false`
- `corepack yarn prettier:check`
- `corepack yarn typecheck`
- `git diff --check`
- `corepack yarn build`

Notes: the focused tests pass but print existing React warnings from the current table/icon markup. The production build passes with the repo's existing lint/font/chunk warnings.