### PR TITLE
Fix: keep Blueprint toolbar click state visible

### DIFF
--- a/src/components/ModalsContainer/BlueprintModal/Body/Toolbar/__tests__/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Toolbar/__tests__/index.tsx
@@ -1,0 +1,33 @@
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import { ThemeProvider } from 'styled-components'
+import { colors } from '~/utils/colors'
+import { Toolbar } from '..'
+
+const theme = {
+  transitions: {
+    create: () => 'none',
+  },
+}
+
+const renderToolbar = (activeAction?: 'createType' | 'addEdge') =>
+  render(
+    <ThemeProvider theme={theme}>
+      <Toolbar activeAction={activeAction} onAddEdgeNode={jest.fn()} onCreateNew={jest.fn()} />
+    </ThemeProvider>,
+  )
+
+describe('Blueprint Toolbar', () => {
+  it('keeps the selected create type button visible', () => {
+    renderToolbar('createType')
+
+    expect(screen.getByTestId('add-schema-type')).not.toHaveStyle(`background: ${colors.black}`)
+  })
+
+  it('keeps the selected add edge button visible', () => {
+    renderToolbar('addEdge')
+
+    expect(screen.getByTestId('add-edge')).not.toHaveStyle(`background: ${colors.black}`)
+  })
+})

--- a/src/components/ModalsContainer/BlueprintModal/Body/Toolbar/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/Toolbar/index.tsx
@@ -7,16 +7,17 @@ import { colors } from '~/utils/colors'
 type Props = {
   onCreateNew: () => void
   onAddEdgeNode: () => void
+  activeAction?: 'createType' | 'addEdge'
 }
 
-export const Toolbar = ({ onCreateNew, onAddEdgeNode }: Props) => (
+export const Toolbar = ({ onCreateNew, onAddEdgeNode, activeAction }: Props) => (
   <Wrapper>
-    <ActionButton data-testid="add-schema-type" onClick={onCreateNew}>
+    <ActionButton active={activeAction === 'createType'} data-testid="add-schema-type" onClick={onCreateNew}>
       <IconWrapper>
         <PlusIcon />
       </IconWrapper>
     </ActionButton>
-    <ActionButton data-testid="add-edge" onClick={onAddEdgeNode}>
+    <ActionButton active={activeAction === 'addEdge'} data-testid="add-edge" onClick={onAddEdgeNode}>
       <IconWrapper>
         <CreateEdgeIcon />
       </IconWrapper>
@@ -39,14 +40,21 @@ const ActionButton = styled(Flex).attrs({
   justify: 'center',
   p: 0,
 })<{
+  active?: boolean
   disabled?: boolean
 }>`
   position: relative;
   width: 40px;
   height: 40px;
   flex-direction: row;
-  color: ${colors.GRAY6};
-  background: ${({ disabled }) => (disabled ? colors.disableBtn : colors.BG1)};
+  color: ${({ active }) => (active ? colors.white : colors.GRAY6)};
+  background: ${({ active, disabled }) => {
+    if (disabled) {
+      return colors.disableBtn
+    }
+
+    return active ? colors.BUTTON1 : colors.BG1
+  }};
   cursor: pointer;
   border-radius: 6px;
   transition: ${({ theme }) => theme.transitions.create(['opacity', 'box-shadow', 'background-color'])};
@@ -57,7 +65,7 @@ const ActionButton = styled(Flex).attrs({
 
   &:active {
     color: ${colors.white};
-    background: ${({ disabled }) => (disabled ? colors.BG1 : colors.black)};
+    background: ${({ disabled }) => (disabled ? colors.BG1 : colors.BUTTON1_PRESS)};
   }
 
   &.root {

--- a/src/components/ModalsContainer/BlueprintModal/Body/index.tsx
+++ b/src/components/ModalsContainer/BlueprintModal/Body/index.tsx
@@ -135,6 +135,9 @@ export const Body = ({ Close }: BodyProps) => {
   const filteredLinks =
     activeTab === 'all' ? linksFiltered : linksFiltered.filter((link) => link.edge_type === 'CHILD_OF')
 
+  const activeToolbarAction = isAddEdgeNode ? 'addEdge' : undefined
+  const activeAction = isCreateNew ? 'createType' : activeToolbarAction
+
   return (
     <>
       <Flex ml={-20} mr={-20} mt={-20}>
@@ -183,6 +186,7 @@ export const Body = ({ Close }: BodyProps) => {
         </Flex>
         <Flex>
           <Toolbar
+            activeAction={activeAction}
             onAddEdgeNode={() => {
               setIsAddEdgeNode(true)
               setIsCreateNew(false)


### PR DESCRIPTION
## Summary
- track the active Blueprint toolbar action for Create Type and Add Edge
- keep the selected toolbar button visibly highlighted while its side panel is open
- replace the black pressed background with the existing button press color so click feedback remains visible
- add focused toolbar tests for visible selected states

## Validation
- `corepack yarn jest src/components/ModalsContainer/BlueprintModal/Body/Toolbar/__tests__/index.tsx --runInBand --no-cache --coverage=false`
- `corepack yarn prettier:check`
- `corepack yarn typecheck`
- `git diff --check`
- `corepack yarn build`

Note: production build passes with the repo's existing lint/font/chunk warnings.