### PR TITLE
Fix: add View Content Date and Status sorting

### DIFF
--- a/src/components/SourcesTableModal/SourcesView/Content/Table/__tests__/index.tsx
+++ b/src/components/SourcesTableModal/SourcesView/Content/Table/__tests__/index.tsx
@@ -1,0 +1,62 @@
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen, within } from '@testing-library/react'
+import React from 'react'
+import { Node } from '~/network/fetchSourcesData'
+import { Table } from '..'
+
+jest.mock('~/stores/useModalStore', () => ({
+  useModal: () => ({
+    open: jest.fn(),
+  }),
+}))
+
+jest.mock('~/components/Stats/Animation', () => ({
+  Animation: () => <div data-testid="status-animation" />,
+}))
+
+const nodes = [
+  {
+    node_type: 'Article',
+    properties: {
+      date: '1617638400',
+      source_link: 'https://example.com/newer',
+      status: 'pending',
+    },
+    ref_id: 'newer',
+  },
+  {
+    node_type: 'Article',
+    properties: {
+      date: '1617552000',
+      source_link: 'https://example.com/older',
+      status: 'complete',
+    },
+    ref_id: 'older',
+  },
+] as unknown as Node[]
+
+const getBodySources = () => {
+  const rows = screen.getAllByRole('row').slice(1)
+
+  return rows.map((row) => within(row).getAllByRole('cell')[3].textContent)
+}
+
+describe('View Content Table sorting', () => {
+  it('sorts by date when the Date header is clicked', () => {
+    render(<Table nodes={nodes} />)
+
+    expect(getBodySources()).toEqual(['https://example.com/newer', 'https://example.com/older'])
+
+    fireEvent.click(screen.getByRole('button', { name: /date/i }))
+
+    expect(getBodySources()).toEqual(['https://example.com/older', 'https://example.com/newer'])
+  })
+
+  it('sorts by status when the Status header is clicked', () => {
+    render(<Table nodes={nodes} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /status/i }))
+
+    expect(getBodySources()).toEqual(['https://example.com/older', 'https://example.com/newer'])
+  })
+})

--- a/src/components/SourcesTableModal/SourcesView/Content/Table/index.tsx
+++ b/src/components/SourcesTableModal/SourcesView/Content/Table/index.tsx
@@ -1,9 +1,10 @@
 import { Button, Table as MaterialTable, styled, TableRow } from '@mui/material'
-import React from 'react'
+import React, { useMemo, useState } from 'react'
 import { Flex } from '~/components/common/Flex'
 import { Text } from '~/components/common/Text'
 import ContentIcon from '~/components/Icons/ContentIcon'
 import PlusIcon from '~/components/Icons/PlusIcon'
+import SortFilterIcon from '~/components/Icons/SortFilterIcon'
 import { Node } from '~/network/fetchSourcesData'
 import { useModal } from '~/stores/useModalStore'
 import { colors } from '~/utils'
@@ -14,12 +15,55 @@ interface TableProps {
   nodes: Node[]
 }
 
+type SortField = 'date' | 'status'
+type SortDirection = 'asc' | 'desc'
+
+const getNodeDate = (node: Node) => {
+  const rawDate = node.properties?.date_added_to_graph || node.properties?.date
+  const numericDate = Number(rawDate)
+
+  if (!Number.isNaN(numericDate)) {
+    return numericDate
+  }
+
+  const parsedDate = Date.parse(String(rawDate))
+
+  return Number.isNaN(parsedDate) ? 0 : parsedDate
+}
+
+const getNodeStatus = (node: Node) => String(node.properties?.status || 'processing').toLowerCase()
+
 export const Table: React.FC<TableProps> = ({ nodes }) => {
   const { open: openContentAddModal } = useModal('addContent')
+  const [sortField, setSortField] = useState<SortField>('date')
+  const [sortDirection, setSortDirection] = useState<SortDirection>('desc')
 
   const handleAddContent = async () => {
     openContentAddModal()
   }
+
+  const handleSort = (field: SortField) => {
+    if (sortField === field) {
+      setSortDirection(sortDirection === 'asc' ? 'desc' : 'asc')
+
+      return
+    }
+
+    setSortField(field)
+    setSortDirection(field === 'date' ? 'desc' : 'asc')
+  }
+
+  const sortedNodes = useMemo(() => {
+    const direction = sortDirection === 'asc' ? 1 : -1
+
+    return [...nodes].sort((a, b) => {
+      if (sortField === 'status') {
+        return getNodeStatus(a).localeCompare(getNodeStatus(b)) * direction
+      }
+
+      return (getNodeDate(a) - getNodeDate(b)) * direction
+    })
+  }, [nodes, sortDirection, sortField])
 
   return !nodes || nodes?.length === 0 ? (
     <>
@@ -49,14 +93,22 @@ export const Table: React.FC<TableProps> = ({ nodes }) => {
       <StyledTableHead>
         <TableRow component="tr">
           <StyledTableCell className="empty" />
-          <StyledTableCell>Date</StyledTableCell>
+          <StyledTableCell>
+            <SortedHeaderButton onClick={() => handleSort('date')} type="button">
+              Date <SortFilterIcon />
+            </SortedHeaderButton>
+          </StyledTableCell>
           <StyledTableCell>Type</StyledTableCell>
           <StyledTableCell>Source</StyledTableCell>
-          <StyledTableCell>Status</StyledTableCell>
+          <StyledTableCell>
+            <SortedHeaderButton onClick={() => handleSort('status')} type="button">
+              Status <SortFilterIcon />
+            </SortedHeaderButton>
+          </StyledTableCell>
         </TableRow>
       </StyledTableHead>
       <tbody>
-        {nodes?.map((node) => (
+        {sortedNodes?.map((node) => (
           <TopicRow key={node?.ref_id} node={node} />
         ))}
       </tbody>
@@ -99,5 +151,22 @@ const IconWrapper = styled(Flex)`
     fill: none;
     height: 60px;
     width: 60px;
+  }
+`
+
+const SortedHeaderButton = styled('button')`
+  align-items: center;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  cursor: pointer;
+  display: inline-flex;
+  font: inherit;
+  gap: 4px;
+  padding: 0;
+
+  svg {
+    height: 16px;
+    width: 16px;
   }
 `


### PR DESCRIPTION
## Summary
- add sortable Date and Status headers in the Source Table View Content tab
- default View Content rows to newest Date first and allow toggling Date order
- sort Status alphabetically when the Status header is clicked
- add focused table tests for Date and Status sorting behavior

## Validation
- `corepack yarn jest src/components/SourcesTableModal/SourcesView/Content/Table/__tests__/index.tsx --runInBand --no-cache --coverage=false`
- `corepack yarn prettier:check`
- `corepack yarn typecheck`
- `git diff --check`
- `corepack yarn build`

Note: production build passes with the repo's existing lint/font/chunk warnings.