### PR TITLE
Fix: show full YouTube source URL

### DIFF
--- a/src/components/AddContentModal/SourceTypeStep/__tests__/index.tsx
+++ b/src/components/AddContentModal/SourceTypeStep/__tests__/index.tsx
@@ -1,0 +1,15 @@
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import { YOUTUBE_CHANNEL } from '~/constants'
+import { SourceTypeStep } from '..'
+
+describe('SourceTypeStep', () => {
+  it('shows the full YouTube channel URL', () => {
+    const url = 'https://www.youtube.com/@MrBeast'
+
+    render(<SourceTypeStep onNextStep={jest.fn()} onPrevStep={jest.fn()} type={YOUTUBE_CHANNEL} value={url} />)
+
+    expect(screen.getByText(url)).toBeInTheDocument()
+  })
+})

--- a/src/components/AddContentModal/SourceTypeStep/index.tsx
+++ b/src/components/AddContentModal/SourceTypeStep/index.tsx
@@ -29,6 +29,14 @@ const CONTENT_TYPE_MAPPING: Record<string, { [k: string]: string }> = {
   },
 }
 
+const getDisplayValue = (value: string, type: string) => {
+  if (type === YOUTUBE_CHANNEL) {
+    return value
+  }
+
+  return extractNameFromLink(value, type) ?? value
+}
+
 export const SourceTypeStep: FC<Props> = ({ onNextStep, onPrevStep, type, value }) => (
   <Flex>
     <Flex align="center" direction="row" justify="space-between" mb={20}>
@@ -41,7 +49,7 @@ export const SourceTypeStep: FC<Props> = ({ onNextStep, onPrevStep, type, value 
         <img alt={CONTENT_TYPE_MAPPING[type].label} className="badge__img" src={CONTENT_TYPE_MAPPING[type].img} />
         <StyledText>{CONTENT_TYPE_MAPPING[type].label}</StyledText>
       </TextWrapper>
-      <StyledLink>{extractNameFromLink(value, type) ?? value}</StyledLink>
+      <StyledLink>{getDisplayValue(value, type)}</StyledLink>
     </Flex>
     <Flex direction="row">
       <Flex grow={1}>
@@ -74,9 +82,8 @@ const StyledLink = styled(Flex)`
   margin-top: 15px;
   color: ${colors.GRAY3};
   max-width: 300px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  word-wrap: break-word;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 `
 
 const StyledHeaderText = styled(Text)`


### PR DESCRIPTION
## Summary
- keep YouTube channel values displayed as the full submitted URL on the Source Type step
- allow the source value to wrap instead of being hidden with ellipsis
- add focused coverage to verify the full YouTube URL is rendered

## Validation
- `corepack yarn jest src/components/AddContentModal/SourceTypeStep/__tests__/index.tsx --runInBand --no-cache --coverage=false`
- `corepack yarn prettier:check`
- `corepack yarn typecheck`
- `git diff --check`
- `corepack yarn build`

Note: production build passes with the repo's existing lint/font/chunk warnings.