### PR TITLE
Fix: show Edge List tooltip on hover

### DIFF
--- a/src/components/SourcesTableModal/SourcesView/Topics/Table/TableRow.tsx
+++ b/src/components/SourcesTableModal/SourcesView/Topics/Table/TableRow.tsx
@@ -1,4 +1,4 @@
-import { IconButton, Popover, Typography } from '@mui/material'
+import { IconButton, Tooltip, Typography } from '@mui/material'
 import React, { FC, memo, useState } from 'react'
 import { ClipLoader } from 'react-spinners'
 import styled from 'styled-components'
@@ -37,7 +37,6 @@ const TableRowComponent: FC<TTableRaw> = ({
 }) => {
   const [ids, total] = useTopicsStore((s) => [s.ids, s.total])
   const [loading, setLoading] = useState(false)
-  const [isPopoverOpen, setIsPopoverOpen] = useState(false)
 
   const date = formatDate(topic.date_added_to_graph)
 
@@ -73,19 +72,7 @@ const TableRowComponent: FC<TTableRaw> = ({
 
   const lettersToShow = topic.edgeList.slice(0, 1)
   const hiddenLettersCount = topic.edgeList.length - lettersToShow.length
-
-  const [anchorEl, setAnchorEl] = React.useState<HTMLElement | null>(null)
-
-  const handlePopoverOpen = (event: React.MouseEvent<HTMLElement>) => {
-    setAnchorEl(event.currentTarget)
-    setIsPopoverOpen(true)
-  }
-
-  const handlePopoverClose = () => {
-    setIsPopoverOpen(false)
-  }
-
-  const open = Boolean(anchorEl) && isPopoverOpen
+  const edgeListTooltip = topic.edgeList.join(', ')
 
   const checkboxVisibleClass = checkedStates[topic.ref_id] ? 'visible' : ''
 
@@ -110,49 +97,31 @@ const TableRowComponent: FC<TTableRaw> = ({
         <CountEdgeWrapper>{topic.edgeCount}</CountEdgeWrapper>
       </StyledTableCell>
       <StyledTableCell>
-        <Popover
-          anchorEl={anchorEl}
-          anchorOrigin={{
-            vertical: 'top',
-            horizontal: 'center',
-          }}
-          disableRestoreFocus
-          id="mouse-over-popover"
-          onClose={handlePopoverClose}
-          onMouseEnter={() => setIsPopoverOpen(true)}
-          onMouseLeave={handlePopoverClose}
-          open={open}
-          sx={{
-            pointerEvents: 'auto',
-            '& .MuiPaper-root': {
-              backgroundColor: 'rgba(0, 0, 0, 0.9)',
-              borderRadius: '4px',
-              width: '160px',
-              maxHeight: '200px',
-              overflowY: 'scroll',
-            },
-          }}
-          transformOrigin={{
-            vertical: 'bottom',
-            horizontal: 'center',
-          }}
-        >
-          <Typography sx={{ p: 1.5, fontSize: '13px', fontWeight: 400, lineHeight: '1.8', wordWrap: 'break-word' }}>
-            {topic.edgeList.join(', ')}
-          </Typography>
-        </Popover>
         {lettersToShow.join(', ')}
         {hiddenLettersCount > 0 && (
-          <Typography
-            aria-haspopup="true"
-            aria-owns={open ? 'mouse-over-popover' : undefined}
-            component="span"
-            onMouseEnter={handlePopoverOpen}
-            onMouseLeave={handlePopoverClose}
-            sx={{ cursor: 'pointer' }}
+          <Tooltip
+            componentsProps={{
+              tooltip: {
+                sx: {
+                  backgroundColor: 'rgba(0, 0, 0, 0.9)',
+                  borderRadius: '4px',
+                  fontSize: '13px',
+                  fontWeight: 400,
+                  lineHeight: 1.8,
+                  maxHeight: '200px',
+                  overflowY: 'auto',
+                  width: '160px',
+                  wordWrap: 'break-word',
+                },
+              },
+            }}
+            enterDelay={0}
+            title={edgeListTooltip}
           >
-            ,...
-          </Typography>
+            <Typography component="span" sx={{ cursor: 'pointer' }}>
+              ,...
+            </Typography>
+          </Tooltip>
         )}
       </StyledTableCell>
       <StyledTableCell>

--- a/src/components/SourcesTableModal/SourcesView/Topics/Table/__tests__/index.tsx
+++ b/src/components/SourcesTableModal/SourcesView/Topics/Table/__tests__/index.tsx
@@ -45,7 +45,7 @@ describe('TableRowComponent', () => {
     })
   })
 
-  it('Shows hover state for topics with more than one edge', () => {
+  it('Shows hover state for topics with more than one edge', async () => {
     render(
       <TopicRow
         checkedStates={mockCheckedStates}
@@ -56,12 +56,9 @@ describe('TableRowComponent', () => {
       />,
     )
 
-    waitFor(() => {
-      const cell = screen.getByText(multipleEdgesTopic.topic)
+    fireEvent.mouseOver(screen.getByText(',...'))
 
-      fireEvent.mouseEnter(cell)
-      expect(screen.getByText(multipleEdgesTopic.edgeList.join(', '))).toBeInTheDocument()
-    })
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(multipleEdgesTopic.edgeList.join(', '))
   })
 
   it('Ensures each row is the same size', () => {


### PR DESCRIPTION
## Summary
- replace the custom Edge List hover popover with a MUI Tooltip on the overflow indicator
- keep the existing edge-list preview while making the full list reliably appear on hover
- update focused coverage to hover the `,...` indicator and assert the tooltip content

## Validation
- `corepack yarn jest src/components/SourcesTableModal/SourcesView/Topics/Table/__tests__/index.tsx --runInBand --no-cache --coverage=false`
- `corepack yarn prettier:check`
- `corepack yarn typecheck`
- `git diff --check`
- `corepack yarn build`

Notes: the focused test passes but still prints existing DOM nesting warnings from the current topic row test setup. Production build passes with the repo's existing lint/font/chunk warnings.