### PR TITLE
Fix: close chat splash on logo navigation

### DIFF
--- a/src/components/App/AppBar/index.tsx
+++ b/src/components/App/AppBar/index.tsx
@@ -11,6 +11,7 @@ import { media } from '~/utils/media'
 
 export const AppBar = () => {
   const appMetaData = useAppStore((s) => s.appMetaData)
+  const setUniverseQuestionIsOpen = useAppStore((s) => s.setUniverseQuestionIsOpen)
   const { resetAiSummaryAnswer, setNewLoading } = useAiSummaryStore()
   const { abortFetchData, resetGraph } = useDataStore((s) => s)
   const navigate = useNavigate()
@@ -24,6 +25,7 @@ export const AppBar = () => {
     abortFetchData()
     resetGraph()
     resetAiSummaryAnswer()
+    setUniverseQuestionIsOpen(false)
     navigate('/')
   }
 

--- a/src/components/App/MainToolbar/__tests__/index.tsx
+++ b/src/components/App/MainToolbar/__tests__/index.tsx
@@ -2,6 +2,7 @@
 import '@testing-library/jest-dom'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { useFeatureFlagStore } from '~/stores/useFeatureFlagStore'
+import { useAppStore } from '~/stores/useAppStore'
 import { useModal } from '~/stores/useModalStore'
 import { useUserStore } from '~/stores/useUserStore'
 import { MainToolbar } from '..'
@@ -80,6 +81,10 @@ describe('MainToolbar Component Tests', () => {
       customSchemaFeatureFlag: true,
       userFeedbackFeatureFlag: true,
     })
+    useAppStore.setState({ universeQuestionIsOpen: false })
+    Object.assign(useUserStore, {
+      getState: jest.fn(() => ({ setBudget: jest.fn() })),
+    })
     ;(useUserStore as unknown as jest.Mock).mockImplementation((selector: (s: unknown) => unknown) =>
       selector({
         isAdmin: false,
@@ -114,6 +119,16 @@ describe('MainToolbar Component Tests', () => {
       fireEvent.click(screen.getByTestId('cy-open-soure-table'))
       expect(openMock).toHaveBeenCalled()
     })
+  })
+
+  it('closes the chat splash when the logo is clicked', () => {
+    useAppStore.setState({ universeQuestionIsOpen: true })
+
+    renderWithProviders(<MainToolbar />)
+
+    fireEvent.click(screen.getByAltText('Second brain'))
+
+    expect(useAppStore.getState().universeQuestionIsOpen).toBe(false)
   })
 
   it('renders MainToolbar component with correct elements', () => {

--- a/src/components/App/MainToolbar/index.tsx
+++ b/src/components/App/MainToolbar/index.tsx
@@ -40,6 +40,7 @@ export const MainToolbar = () => {
     setNewLoading(null)
     abortFetchData()
     resetAiSummaryAnswer()
+    setUniverseQuestionIsOpen(false)
     resetGraph()
     navigate('/')
   }

--- a/src/components/App/UniverseQuestion/__tests__/index.tsx
+++ b/src/components/App/UniverseQuestion/__tests__/index.tsx
@@ -1,0 +1,34 @@
+import '@testing-library/jest-dom'
+import { ThemeProvider } from '@mui/material'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { ThemeProvider as StyleThemeProvider } from 'styled-components'
+import { useAppStore } from '~/stores/useAppStore'
+import { appTheme } from '../../Providers'
+import { UniverseQuestion } from '..'
+
+const renderWithProviders = (ui: React.ReactElement) =>
+  render(
+    <ThemeProvider theme={appTheme}>
+      <StyleThemeProvider theme={appTheme}>{ui}</StyleThemeProvider>
+    </ThemeProvider>,
+  )
+
+describe('UniverseQuestion', () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      showCollapseButton: true,
+      sidebarIsOpen: false,
+      universeQuestionIsOpen: true,
+    })
+  })
+
+  it('closes the chat splash when the title is clicked', () => {
+    renderWithProviders(<UniverseQuestion />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Ideas have shapes' }))
+
+    expect(useAppStore.getState().universeQuestionIsOpen).toBe(false)
+    expect(useAppStore.getState().sidebarIsOpen).toBe(true)
+    expect(useAppStore.getState().showCollapseButton).toBe(true)
+  })
+})

--- a/src/components/App/UniverseQuestion/index.tsx
+++ b/src/components/App/UniverseQuestion/index.tsx
@@ -44,7 +44,7 @@ export const UniverseQuestion = () => {
   const handleSubmitQuestion = async (questionToSubmit: string) => {
     if (questionToSubmit) {
       resetAiSummaryAnswer()
-      setUniverseQuestionIsOpen()
+      setUniverseQuestionIsOpen(false)
       resetData()
       setSidebarOpen(true)
       setShowCollapseButton(true)
@@ -67,7 +67,7 @@ export const UniverseQuestion = () => {
   }
 
   const handleUniverseQuestionIsOpen = () => {
-    setUniverseQuestionIsOpen()
+    setUniverseQuestionIsOpen(false)
     setSidebarOpen(true)
     setShowCollapseButton(true)
   }
@@ -90,7 +90,9 @@ export const UniverseQuestion = () => {
 
   return (
     <Wrapper>
-      Ideas have shapes
+      <SplashTitle onClick={handleUniverseQuestionIsOpen} type="button">
+        Ideas have shapes
+      </SplashTitle>
       <TextAreaWrapper onKeyDown={onEnterPress} py={12} tabIndex={-1}>
         <StyledTextarea
           ref={textAreaRef}
@@ -199,6 +201,15 @@ const Wrapper = styled(Flex)`
   font-weight: 700;
   line-height: 16px;
   font-family: 'Barlow';
+`
+
+const SplashTitle = styled.button`
+  background: transparent;
+  border: 0;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  padding: 0;
 `
 
 const StyledButton = styled(Button)`

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -88,7 +88,7 @@ export const App = () => {
 
   useEffect(() => {
     if (chatSplashScreenAsDefault && chatInterfaceFeatureFlag) {
-      setUniverseQuestionIsOpen()
+      setUniverseQuestionIsOpen(true)
     }
   }, [chatInterfaceFeatureFlag, chatSplashScreenAsDefault, setUniverseQuestionIsOpen])
 

--- a/src/stores/useAppStore/__tests__/index.ts
+++ b/src/stores/useAppStore/__tests__/index.ts
@@ -1,0 +1,23 @@
+import { useAppStore } from '..'
+
+describe('useAppStore', () => {
+  beforeEach(() => {
+    useAppStore.setState({ universeQuestionIsOpen: false })
+  })
+
+  it('can explicitly open and close the universe question splash', () => {
+    useAppStore.getState().setUniverseQuestionIsOpen(true)
+
+    expect(useAppStore.getState().universeQuestionIsOpen).toBe(true)
+
+    useAppStore.getState().setUniverseQuestionIsOpen(false)
+
+    expect(useAppStore.getState().universeQuestionIsOpen).toBe(false)
+  })
+
+  it('preserves toggle behavior when no explicit state is provided', () => {
+    useAppStore.getState().setUniverseQuestionIsOpen()
+
+    expect(useAppStore.getState().universeQuestionIsOpen).toBe(true)
+  })
+})

--- a/src/stores/useAppStore/index.ts
+++ b/src/stores/useAppStore/index.ts
@@ -26,7 +26,7 @@ export type AppStore = {
   setTranscriptOpen: (_: boolean) => void
   setFlagErrorOpen: (_: boolean) => void
   setAppMetaData: (val: TAboutParams) => void
-  setUniverseQuestionIsOpen: () => void
+  setUniverseQuestionIsOpen: (_?: boolean) => void
   setCurrentPlayingAudio: (_: React.MutableRefObject<HTMLAudioElement | null> | null) => void
   setShowCollapseButton: (_: boolean) => void
   selectedColor: string
@@ -81,7 +81,11 @@ export const useAppStore = create<AppStore>((set, get) => ({
       transcriptIsOpen: !sidebarIsOpen ? false : get().transcriptIsOpen,
     }),
   setTranscriptOpen: (transcriptIsOpen) => set({ transcriptIsOpen }),
-  setUniverseQuestionIsOpen: () => set({ universeQuestionIsOpen: !get().universeQuestionIsOpen }),
+  setUniverseQuestionIsOpen: (universeQuestionIsOpen) =>
+    set({
+      universeQuestionIsOpen:
+        typeof universeQuestionIsOpen === 'boolean' ? universeQuestionIsOpen : !get().universeQuestionIsOpen,
+    }),
   setAppMetaData: (appMetaData) => set({ appMetaData }),
   setShowCollapseButton: (showCollapseButton) => set({ showCollapseButton }),
   setSelectedColor: (selectedColor) => set({ selectedColor }),


### PR DESCRIPTION
## Summary
- close the chat splash explicitly when the left logo or app title navigates back to the graph
- make the splash title `Ideas have shapes` behave like the Explore Graph action
- keep existing toggle behavior while allowing explicit open/close state updates

## Tests
- `corepack yarn jest src/components/App/MainToolbar/__tests__/index.tsx src/components/App/UniverseQuestion/__tests__/index.tsx src/stores/useAppStore/__tests__/index.ts --coverage=false --runInBand --forceExit`
- `corepack yarn prettier:check`
- `corepack yarn typecheck`
- `git diff --check`
- `corepack yarn build`

Fixes #2074