### PR TITLE
Fix: prevent stacked selection graph nodes

### DIFF
--- a/src/components/Universe/Graph/Cubes/SelectionDataNodes/__tests__/utils.ts
+++ b/src/components/Universe/Graph/Cubes/SelectionDataNodes/__tests__/utils.ts
@@ -1,0 +1,30 @@
+import { Link, NodeExtended } from '~/types'
+import { getLinksForNodes, uniqueNodesByRefId } from '../utils'
+
+const node = (refId: string): NodeExtended => ({ ref_id: refId } as NodeExtended)
+
+const link = (source: string, target: string): Link => ({
+  source,
+  target,
+  ref_id: `${source}-${target}`,
+  edge_type: '',
+})
+
+describe('SelectionDataNodes utils', () => {
+  it('removes duplicate related nodes by ref_id while preserving order', () => {
+    expect(uniqueNodesByRefId([node('source'), node('topic-1'), node('topic-1'), node('topic-2')])).toEqual([
+      node('source'),
+      node('topic-1'),
+      node('topic-2'),
+    ])
+  })
+
+  it('keeps only links whose source and target are visible selection nodes', () => {
+    expect(
+      getLinksForNodes(
+        [link('source', 'topic-1'), link('source', 'missing-topic'), link('topic-1', 'topic-2')],
+        [node('source'), node('topic-1'), node('topic-2')],
+      ),
+    ).toEqual([link('source', 'topic-1'), link('topic-1', 'topic-2')])
+  })
+})

--- a/src/components/Universe/Graph/Cubes/SelectionDataNodes/index.tsx
+++ b/src/components/Universe/Graph/Cubes/SelectionDataNodes/index.tsx
@@ -9,9 +9,10 @@ import { Link, Node, NodeExtended } from '~/types'
 import { LinkPosition } from '../..'
 import { Connections } from './Connections'
 import { Node as GraphNode } from './Node'
+import { getLinksForNodes, MAX_RELATED_SELECTION_NODES, uniqueNodesByRefId } from './utils'
 
 const RADIUS = 50
-const MAX_LENGTH = 7
+const MAX_LENGTH = MAX_RELATED_SELECTION_NODES
 
 export type PathNode = NodeExtended & {
   isPathNode?: boolean
@@ -100,22 +101,18 @@ export const SelectionDataNodes = memo(() => {
     const init = async () => {
       if (selectedNode?.ref_id && selectedNode.ref_id !== prevSelectedNodeId) {
         try {
-          const data = await fetchNodeEdges(selectedNode.ref_id, 0, 5, { useSubGraph: false })
+          const data = await fetchNodeEdges(selectedNode.ref_id, 0, MAX_RELATED_SELECTION_NODES, { useSubGraph: false })
 
           if (data) {
-            const filteredNodes: Node[] = data.nodes.filter(
-              (node, index) => node.ref_id !== selectedNode.ref_id && index < MAX_LENGTH,
-            )
+            const filteredNodes: Node[] = uniqueNodesByRefId(
+              data.nodes.filter((node) => node.ref_id !== selectedNode.ref_id),
+            ).slice(0, MAX_LENGTH)
 
             const graphNodes = filteredNodes.map((node: Node) => ({ ...node, x: 0, y: 0, z: 0 }))
 
             const nodes: PathNode[] = [...graphNodes, { ...selectedNode, x: 0, y: 0, z: 0, fx: 0, fy: 0, fz: 0 }]
 
-            const links = data.edges.filter(
-              (link: Link) =>
-                nodes.some((node: NodeExtended) => node.ref_id === link.target) &&
-                nodes.some((node: NodeExtended) => node.ref_id === link.source),
-            )
+            const links = getLinksForNodes(data.edges, nodes)
 
             setSelectionData({ nodes, links: links as unknown as GraphData['links'] })
             linksPositionRef.current = new Map()
@@ -144,19 +141,13 @@ export const SelectionDataNodes = memo(() => {
           .map((i) => nodesNormalized.get(i))
           .filter((i) => !!i) as NodeExtended[]
 
-        const siblings: NodeExtended[] = [
-          ...sourceNodes,
-          ...targetNodes,
-          { ...selectedNode, x: 0, y: 0, z: 0, fx: 0, fy: 0, fz: 0 },
-        ]
+        const relatedNodes = uniqueNodesByRefId([...sourceNodes, ...targetNodes])
+          .filter((node) => node.ref_id !== selectedNode.ref_id)
+          .slice(0, MAX_RELATED_SELECTION_NODES)
 
-        const links = (dataInitial?.links || []).filter((l: Link) =>
-          siblings.some(
-            (i: NodeExtended) =>
-              (i.ref_id === l.source && l.target === selectedNode.ref_id) ||
-              (i.ref_id === l.target && l.source === selectedNode.ref_id),
-          ),
-        )
+        const siblings: NodeExtended[] = [...relatedNodes, { ...selectedNode, x: 0, y: 0, z: 0, fx: 0, fy: 0, fz: 0 }]
+
+        const links = getLinksForNodes(dataInitial?.links || [], siblings)
 
         setSelectionData({ nodes: siblings, links: links as unknown as GraphData['links'] })
       } else {

--- a/src/components/Universe/Graph/Cubes/SelectionDataNodes/utils.ts
+++ b/src/components/Universe/Graph/Cubes/SelectionDataNodes/utils.ts
@@ -1,0 +1,23 @@
+import { Link, NodeExtended } from '~/types'
+
+export const MAX_RELATED_SELECTION_NODES = 20
+
+export const uniqueNodesByRefId = <T extends Pick<NodeExtended, 'ref_id'>>(nodes: T[]): T[] => {
+  const seen = new Set<string>()
+
+  return nodes.filter((node) => {
+    if (seen.has(node.ref_id)) {
+      return false
+    }
+
+    seen.add(node.ref_id)
+
+    return true
+  })
+}
+
+export const getLinksForNodes = <T extends Pick<NodeExtended, 'ref_id'>>(links: Link[], nodes: T[]): Link[] => {
+  const nodeIds = new Set(nodes.map((node) => node.ref_id))
+
+  return links.filter((link) => nodeIds.has(link.source) && nodeIds.has(link.target))
+}


### PR DESCRIPTION
## Summary
- dedupe related selection-graph nodes by `ref_id` before rendering them
- keep the selected source/topic node centered while showing more related nodes around it
- filter selection links through a shared visible-node helper so links only reference rendered nodes

## Tests
- `corepack yarn jest src/components/Universe/Graph/Cubes/SelectionDataNodes/__tests__/utils.ts --coverage=false --runInBand --forceExit`
- `corepack yarn prettier:check`
- `corepack yarn typecheck`
- `git diff --check`
- `corepack yarn build`

Fixes #2398