### PR TITLE
fix: unstack source selection nodes

### DIFF
--- a/src/components/Universe/Graph/Cubes/SelectionDataNodes/__tests__/index.ts
+++ b/src/components/Universe/Graph/Cubes/SelectionDataNodes/__tests__/index.ts
@@ -1,0 +1,42 @@
+import { NodeExtended } from '~/types'
+import { getSelectionNodeRadius, layoutSelectionNodes } from '../utils'
+
+const makeNode = (refId: string): NodeExtended =>
+  ({
+    ref_id: refId,
+    node_type: 'Topic',
+    name: refId,
+    label: refId,
+    edge_count: 1,
+    x: 0,
+    y: 0,
+    z: 0,
+  } as NodeExtended)
+
+describe('SelectionDataNodes utils', () => {
+  it('keeps a readable minimum radius for small graphs', () => {
+    expect(getSelectionNodeRadius(2)).toBe(240)
+    expect(getSelectionNodeRadius(4)).toBe(240)
+  })
+
+  it('expands the radius as more sibling nodes are shown', () => {
+    expect(getSelectionNodeRadius(30)).toBeGreaterThan(240)
+  })
+
+  it('places the selected node at the center and distributes siblings around it', () => {
+    const nodes = [makeNode('selected'), makeNode('a'), makeNode('b'), makeNode('c')]
+    const laidOutNodes = layoutSelectionNodes(nodes, 'selected')
+    const selectedNode = laidOutNodes.find((node) => node.ref_id === 'selected')
+    const siblingNodes = laidOutNodes.filter((node) => node.ref_id !== 'selected')
+
+    expect(selectedNode).toMatchObject({ x: 0, y: 0, z: 0 })
+
+    siblingNodes.forEach((node) => {
+      const distanceFromCenter = Math.hypot(node.x || 0, node.y || 0)
+
+      expect(distanceFromCenter).toBeCloseTo(240, 5)
+    })
+
+    expect(new Set(siblingNodes.map((node) => `${node.x}:${node.y}`)).size).toBe(siblingNodes.length)
+  })
+})

--- a/src/components/Universe/Graph/Cubes/SelectionDataNodes/index.tsx
+++ b/src/components/Universe/Graph/Cubes/SelectionDataNodes/index.tsx
@@ -9,8 +9,8 @@ import { Link, Node, NodeExtended } from '~/types'
 import { LinkPosition } from '../..'
 import { Connections } from './Connections'
 import { Node as GraphNode } from './Node'
+import { getSelectionNodeRadius, layoutSelectionNodes } from './utils'
 
-const RADIUS = 50
 const MAX_LENGTH = 7
 
 export type PathNode = NodeExtended & {
@@ -64,9 +64,10 @@ export const SelectionDataNodes = memo(() => {
       ...oldNodes,
       ...newNodes.map((node, index) => {
         // Calculate angular position for the new node
+        const radius = getSelectionNodeRadius(totalNodes + 1)
         const theta = startTheta + thetaSpan * (index + 1) // Start adding from startTheta
-        const x = node.ref_id === selectedNode?.ref_id ? 0 : Math.cos(theta) * RADIUS
-        const y = node.ref_id === selectedNode?.ref_id ? 0 : Math.sin(theta) * RADIUS
+        const x = node.ref_id === selectedNode?.ref_id ? 0 : Math.cos(theta) * radius
+        const y = node.ref_id === selectedNode?.ref_id ? 0 : Math.sin(theta) * radius
         const z = node.ref_id === selectedNode?.ref_id ? 0 : 0
 
         return { ...node, x, y, z }
@@ -158,7 +159,10 @@ export const SelectionDataNodes = memo(() => {
           ),
         )
 
-        setSelectionData({ nodes: siblings, links: links as unknown as GraphData['links'] })
+        setSelectionData({
+          nodes: layoutSelectionNodes(siblings, selectedNode.ref_id),
+          links: links as unknown as GraphData['links'],
+        })
       } else {
         init()
       }
@@ -183,8 +187,9 @@ export const SelectionDataNodes = memo(() => {
         ].slice(0, 3)
 
         const angle = Math.atan2(-newSelectedNode.y, -newSelectedNode.x)
-        const x = RADIUS * Math.cos(angle)
-        const y = RADIUS * Math.sin(angle)
+        const radius = getSelectionNodeRadius(graphData.nodes.length)
+        const x = radius * Math.cos(angle)
+        const y = radius * Math.sin(angle)
 
         const updatedPathNodes = newPathNodes.map((node, index) => {
           if (index === 0) {

--- a/src/components/Universe/Graph/Cubes/SelectionDataNodes/utils.ts
+++ b/src/components/Universe/Graph/Cubes/SelectionDataNodes/utils.ts
@@ -1,0 +1,45 @@
+import { NodeExtended } from '~/types'
+
+const MIN_SELECTION_RADIUS = 240
+const MAX_SELECTION_RADIUS = 480
+const NODE_SPACING = 110
+
+export const getSelectionNodeRadius = (nodeCount: number) => {
+  const orbitNodeCount = Math.max(nodeCount - 1, 0)
+
+  if (orbitNodeCount <= 1) {
+    return MIN_SELECTION_RADIUS
+  }
+
+  const radiusForSpacing = Math.ceil((orbitNodeCount * NODE_SPACING) / (2 * Math.PI))
+
+  return Math.min(MAX_SELECTION_RADIUS, Math.max(MIN_SELECTION_RADIUS, radiusForSpacing))
+}
+
+export const layoutSelectionNodes = (nodes: NodeExtended[], selectedNodeId?: string | null) => {
+  if (!nodes.length) {
+    return []
+  }
+
+  const radius = getSelectionNodeRadius(nodes.length)
+  const orbitNodes = nodes.filter((node) => node.ref_id !== selectedNodeId)
+  const angleStep = orbitNodes.length > 0 ? (Math.PI * 2) / orbitNodes.length : 0
+
+  let orbitIndex = 0
+
+  return nodes.map((node) => {
+    if (node.ref_id === selectedNodeId) {
+      return { ...node, x: 0, y: 0, z: 0 }
+    }
+
+    const theta = angleStep * orbitIndex
+    orbitIndex += 1
+
+    return {
+      ...node,
+      x: Math.cos(theta) * radius,
+      y: Math.sin(theta) * radius,
+      z: 0,
+    }
+  })
+}

--- a/src/components/Universe/SelectionContent/Controls/index.tsx
+++ b/src/components/Universe/SelectionContent/Controls/index.tsx
@@ -11,7 +11,7 @@ export const Controls = () => {
 
   useEffect(() => {
     if (cameraControlsRef.current) {
-      const distance = cameraControlsRef.current.getDistanceToFitSphere(50 + 5)
+      const distance = cameraControlsRef.current.getDistanceToFitSphere(selectionGraphRadius + 40)
 
       cameraControlsRef.current.setLookAt(
         selectionGraphCameraPosition.x,


### PR DESCRIPTION
Fixes #2398

This fixes the stacked related-topic nodes in the selection graph by moving selected-node siblings from the old tight 50px circle to a deterministic orbit layout with enough spacing between nodes.

Changes:
- Add selection-node layout helpers with min/max radius and spacing-based radius growth
- Use the layout helper when rendering selected-node sibling graphs
- Keep path navigation spacing consistent with the same radius helper
- Fit the selection camera to the actual selection graph radius
- Add unit coverage for selected-node centering and sibling distribution

Validation:
- `yarn typecheck`
- `yarn jest src/components/Universe/Graph/Cubes/SelectionDataNodes/__tests__/index.ts --runInBand --no-cache --coverage=false`
