### PR TITLE
Fix: fetch Engagement Report data by selected sort

### DIFF
--- a/src/components/ModalsContainer/TweetAnalyze/Body/Engagement/__tests__/utils.ts
+++ b/src/components/ModalsContainer/TweetAnalyze/Body/Engagement/__tests__/utils.ts
@@ -1,0 +1,13 @@
+import { getEngagement, getFollowers } from '~/network/tweetAnalyze'
+import { SORT_OPTIONS } from '../..'
+import { getTweetAnalyzeRequest } from '../utils'
+
+describe('getTweetAnalyzeRequest', () => {
+  it('uses the engagement endpoint for engagement sorting', () => {
+    expect(getTweetAnalyzeRequest(SORT_OPTIONS.ENGAGEMENT.value)).toBe(getEngagement)
+  })
+
+  it('uses the followers endpoint for follower sorting', () => {
+    expect(getTweetAnalyzeRequest(SORT_OPTIONS.FOLLOWERS.value)).toBe(getFollowers)
+  })
+})

--- a/src/components/ModalsContainer/TweetAnalyze/Body/Engagement/index.tsx
+++ b/src/components/ModalsContainer/TweetAnalyze/Body/Engagement/index.tsx
@@ -6,10 +6,10 @@ import { ClipLoader } from 'react-spinners'
 import { CsvDownloadButton } from '~/components/common/CsvDownloader'
 import { Flex } from '~/components/common/Flex'
 import LinkIcon from '~/components/Icons/LinkIcon'
-import { getEngagement, getFollowers } from '~/network/tweetAnalyze'
 import { Node } from '~/types'
 import { colors } from '~/utils'
 import { Avatar, Engagement, EngagementBar, SORT_OPTIONS, SortBy, TweetLink, TweetTime, UserInfo, Username } from '..'
+import { getTweetAnalyzeRequest } from './utils'
 
 type Props = {
   sortBy: SortBy
@@ -25,15 +25,17 @@ export const EngagementTable = ({ sortBy, idsToAnalyze }: Props) => {
   useEffect(() => {
     const fetchTweets = async () => {
       if (idsToAnalyze.length === 0) {
+        setLoading(false)
+
         return
       }
 
       setLoading(true)
 
       try {
-        const responses = await Promise.all(
-          idsToAnalyze.map((id) => (sortBy === 'followers' ? getEngagement(id) : getFollowers(id))),
-        )
+        const request = getTweetAnalyzeRequest(sortBy)
+
+        const responses = await Promise.all(idsToAnalyze.map((id) => request(id)))
 
         const mainTweetsArray = []
         const mergedTweetsByImpressionCount: Node[] = []

--- a/src/components/ModalsContainer/TweetAnalyze/Body/Engagement/utils.ts
+++ b/src/components/ModalsContainer/TweetAnalyze/Body/Engagement/utils.ts
@@ -1,0 +1,5 @@
+import { getEngagement, getFollowers } from '~/network/tweetAnalyze'
+import { SORT_OPTIONS, SortBy } from '..'
+
+export const getTweetAnalyzeRequest = (sortBy: SortBy) =>
+  sortBy === SORT_OPTIONS.FOLLOWERS.value ? getFollowers : getEngagement


### PR DESCRIPTION
## Summary
- route Engagement Report requests to the endpoint that matches the selected sort mode
- use the engagement endpoint for engagement sorting and the followers endpoint for follower sorting
- stop the report from staying in loading state when there are no tweet ids to analyze

## Tests
- `corepack yarn jest src/components/ModalsContainer/TweetAnalyze/Body/Engagement/__tests__/utils.ts --coverage=false --runInBand --forceExit`
- `corepack yarn prettier:check`
- `corepack yarn typecheck`
- `git diff --check`
- `corepack yarn build`

Related to #2787