### PR TITLE
[codex] Support runtime API host config

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,13 @@ See the section about [deployment](https://facebook.github.io/create-react-app/d
 For run the docker build locally use the commands bellow
 
 build docker image
-`docker build --build-arg REACT_APP_API_URL={{custom_api_irl}}  -t sphinx_nav_fiber .`
+`docker build -t sphinx_nav_fiber .`
 
-run the image on localhost
+run the image on localhost with a runtime API host
 
-`docker run -p 3004:80 sphinx_nav_fiber`
+`docker run -p 3004:80 -e VITE_APP_API_URL=https://custom-api.example.com/api sphinx_nav_fiber`
+
+`API_URL` and `BOLTWALL_URL` are also accepted as runtime API host aliases for older deployments.
 
 ### Generate icons for latest layout
 

--- a/deploy/docker-entrypoint.sh
+++ b/deploy/docker-entrypoint.sh
@@ -1,30 +1,42 @@
 #!/bin/sh
 
-# Replace the placeholder in index.html with actual environment variable
-ENV_VARS=""
+set -eu
 
-if [ ! -z "$BOLTWALL_URL" ]; then
-    echo "Injecting BOLTWALL_URL: $BOLTWALL_URL"
-    ENV_VARS="BOLTWALL_URL: '$BOLTWALL_URL'"
-fi
+ENV_CONFIG_FILE=${ENV_CONFIG_FILE:-/usr/share/nginx/html/env-config.js}
 
-if [ ! -z "$STAKWORK_WEBSOCKET_URL" ]; then
-    echo "Injecting STAKWORK_WEBSOCKET_URL: $STAKWORK_WEBSOCKET_URL"
-    if [ ! -z "$ENV_VARS" ]; then
-        ENV_VARS="$ENV_VARS, "
+js_escape() {
+    printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+append_env_value() {
+    key=$1
+    value=$2
+
+    if [ -z "$value" ]; then
+        return
     fi
-    ENV_VARS="${ENV_VARS}STAKWORK_WEBSOCKET_URL: '$STAKWORK_WEBSOCKET_URL'"
-fi
 
-if [ ! -z "$ENV_VARS" ]; then
-    # Create the environment configuration
-    ENV_CONFIG="window.ENV = { $ENV_VARS };"
+    if [ "$wrote_env" = "1" ]; then
+        printf ',\n'
+    fi
 
-    # Find index.html and inject the environment config
-    find /usr/share/nginx/html -name "index.html" -exec sed -i "s|<head>|<head><script>$ENV_CONFIG</script>|g" {} \;
-else
-    echo "No environment variables set, using build-time configuration"
-fi
+    escaped_value=$(js_escape "$value")
+    printf '  "%s": "%s"' "$key" "$escaped_value"
+    wrote_env=1
+}
+
+runtime_api_url="${VITE_APP_API_URL:-${API_URL:-${BOLTWALL_URL:-}}}"
+wrote_env=0
+
+{
+    printf 'window.ENV = {\n'
+    append_env_value "VITE_APP_API_URL" "$runtime_api_url"
+    append_env_value "BOLTWALL_URL" "${BOLTWALL_URL:-}"
+    append_env_value "STAKWORK_WEBSOCKET_URL" "${STAKWORK_WEBSOCKET_URL:-}"
+    printf '\n};\n'
+} > "$ENV_CONFIG_FILE"
+
+echo "Runtime configuration written to $ENV_CONFIG_FILE"
 
 # Start nginx
 exec "$@"

--- a/index.html
+++ b/index.html
@@ -21,6 +21,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
+    <script src="/env-config.js"></script>
     <title>Second Brain</title>
   </head>
   <body style="background: #000">

--- a/public/env-config.js
+++ b/public/env-config.js
@@ -1,0 +1,1 @@
+window.ENV = window.ENV || {};

--- a/src/utils/apiUrlFromSwarmHost/__tests__/index.ts
+++ b/src/utils/apiUrlFromSwarmHost/__tests__/index.ts
@@ -1,21 +1,24 @@
-import { apiUrlFromSwarmHost } from '../index.ts'
+import { apiUrlFromSwarmHost, getUrlFromEnv, normalizeApiUrl, removeApi } from '../index.ts'
+
+const originalLocation = window.location
+const originalEnv = window.ENV
 
 function mockWindowLocation(url) {
   delete global.window.location
-  global.window = Object.create(window)
   global.window.location = new URL(url)
-  global.window.host = global.window.location.host
-  global.window.origin = global.window.location.origin
 }
 
 describe('apiUrlFromSwarmHost', () => {
   afterEach(() => {
+    delete global.window.location
+    global.window.location = originalLocation
+    global.window.ENV = originalEnv
     jest.restoreAllMocks()
   })
 
-  it('returns "https://bitcoin.sphinx.chat/api" for the URL "https://second-brain.sphinx.chat"', () => {
+  it('returns the current origin API path for the URL "https://second-brain.sphinx.chat"', () => {
     mockWindowLocation('https://second-brain.sphinx.chat')
-    expect(apiUrlFromSwarmHost()).toBe('https://bitcoin.sphinx.chat/api')
+    expect(apiUrlFromSwarmHost()).toBe('https://second-brain.sphinx.chat/api')
   })
 
   it('returns "https://bitcoin.sphinx.chat/api" for a URL containing "localhost"', () => {
@@ -28,5 +31,46 @@ describe('apiUrlFromSwarmHost', () => {
 
     mockWindowLocation(nonSwarmUrl)
     expect(apiUrlFromSwarmHost()).toBe(`${nonSwarmUrl}/api`)
+  })
+})
+
+describe('runtime API URL helpers', () => {
+  afterEach(() => {
+    global.window.ENV = originalEnv
+  })
+
+  it('normalizes configured API hosts', () => {
+    expect(normalizeApiUrl('https://example.com')).toBe('https://example.com/api')
+    expect(normalizeApiUrl('https://example.com/api/')).toBe('https://example.com/api')
+    expect(normalizeApiUrl('  https://example.com/api  ')).toBe('https://example.com/api')
+  })
+
+  it('reads VITE_APP_API_URL from runtime window env before legacy values', () => {
+    global.window.ENV = {
+      BOLTWALL_URL: 'https://legacy.example.com',
+      VITE_APP_API_URL: 'https://runtime.example.com',
+    }
+
+    expect(getUrlFromEnv()).toBe('https://runtime.example.com/api')
+  })
+
+  it('supports legacy runtime API_URL and BOLTWALL_URL values', () => {
+    global.window.ENV = {
+      API_URL: 'https://api-url.example.com/api',
+      BOLTWALL_URL: 'https://boltwall.example.com',
+    }
+
+    expect(getUrlFromEnv()).toBe('https://api-url.example.com/api')
+
+    global.window.ENV = {
+      BOLTWALL_URL: 'https://boltwall.example.com',
+    }
+
+    expect(getUrlFromEnv()).toBe('https://boltwall.example.com/api')
+  })
+
+  it('removes a trailing api path for websocket origins', () => {
+    expect(removeApi('https://example.com/api')).toBe('https://example.com')
+    expect(removeApi('https://example.com/api/')).toBe('https://example.com')
   })
 })

--- a/src/utils/apiUrlFromSwarmHost/index.ts
+++ b/src/utils/apiUrlFromSwarmHost/index.ts
@@ -1,28 +1,38 @@
-const { origin, host } = window.location
+const DEFAULT_API_URL = 'https://bitcoin.sphinx.chat/api'
 
-const getUrlFormEnv = () => {
-  // Check for runtime environment variable (injected by container)
-  const windowWithEnv = window as Window & { ENV?: { BOLTWALL_URL?: string } }
+export function normalizeApiUrl(apiUrl?: string): string | undefined {
+  const trimmedUrl = apiUrl?.trim()
 
-  if (windowWithEnv.ENV?.BOLTWALL_URL) {
-    return windowWithEnv.ENV.BOLTWALL_URL
+  if (!trimmedUrl) {
+    return undefined
   }
 
-  // Fallback to build-time variable
-  return import.meta.env.VITE_APP_API_URL
+  const urlWithoutTrailingSlash = trimmedUrl.replace(/\/+$/, '')
+
+  if (urlWithoutTrailingSlash.endsWith('/api')) {
+    return urlWithoutTrailingSlash
+  }
+
+  return `${urlWithoutTrailingSlash}/api`
 }
 
-export const API_URL = getUrlFormEnv() || apiUrlFromSwarmHost() || 'https://bitcoin.sphinx.chat'
+export const getUrlFromEnv = () => {
+  const runtimeEnv = window.ENV
+
+  return normalizeApiUrl(
+    runtimeEnv?.VITE_APP_API_URL || runtimeEnv?.API_URL || runtimeEnv?.BOLTWALL_URL || import.meta.env.VITE_APP_API_URL,
+  )
+}
+
+export const API_URL = getUrlFromEnv() || apiUrlFromSwarmHost() || DEFAULT_API_URL
 
 export function apiUrlFromSwarmHost(): string | undefined {
-  // for swarm deployments, always point to "boltwall"
-  // for now, only if the URL contains "swarm"
-  const originUrl = window.location.origin
+  const { origin, host, hostname, protocol } = window.location
 
-  let url = originUrl
+  let url = origin
 
-  if (window.location.protocol === 'https:' && window.location.host.endsWith('.sphinx.chat:8000')) {
-    url = `https://${window.location.hostname}:8444`
+  if (protocol === 'https:' && host.endsWith('.sphinx.chat:8000')) {
+    url = `https://${hostname}:8444`
   } else if (host.includes('swarm')) {
     if (host.startsWith('nav')) {
       const hostArray = host.split('.')
@@ -47,11 +57,11 @@ export function apiUrlFromSwarmHost(): string | undefined {
     url = 'https://bitcoin.sphinx.chat'
   }
 
-  return `${url}/api`
+  return normalizeApiUrl(url)
 }
 
 export function removeApi(url: string) {
-  const regex = /\/api$/
+  const regex = /\/api\/?$/
 
   return url.replace(regex, '')
 }

--- a/vite-env.d.ts
+++ b/vite-env.d.ts
@@ -10,3 +10,12 @@ interface ImportMetaEnv {
 interface ImportMeta {
   readonly env: ImportMetaEnv
 }
+
+interface Window {
+  ENV?: {
+    API_URL?: string
+    BOLTWALL_URL?: string
+    STAKWORK_WEBSOCKET_URL?: string
+    VITE_APP_API_URL?: string
+  }
+}


### PR DESCRIPTION
Closes #262.

Addresses Sphinx bounty #266: Runtime env var for API host.

## Summary
- Load `/env-config.js` before the app bundle so Docker can provide the API host at container startup.
- Support runtime `VITE_APP_API_URL`, `API_URL`, and `BOLTWALL_URL` values, normalized to the `/api` base path.
- Generate `env-config.js` from the Docker entrypoint instead of mutating `index.html` inline, while preserving websocket runtime config.
- Update Docker docs and add coverage for runtime API URL helpers.

## Validation
- `yarn jest src/utils/apiUrlFromSwarmHost/__tests__/index.ts --runInBand --coverage=false`
- `yarn typecheck`
- `yarn eslint src/utils/apiUrlFromSwarmHost/index.ts src/utils/apiUrlFromSwarmHost/__tests__/index.ts --max-warnings 0`
- `sh -n deploy/docker-entrypoint.sh`
- entrypoint smoke checks for `VITE_APP_API_URL` and `API_URL` runtime output
- `yarn build` (passes; existing unrelated warnings remain from console/constant-condition lint, unresolved font runtime paths, dependency eval usage, and chunk size)

BTC payout address: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`